### PR TITLE
Experimental gen slack blocks

### DIFF
--- a/examples/langchain/07-grocery-slack-blocks.py
+++ b/examples/langchain/07-grocery-slack-blocks.py
@@ -1,0 +1,90 @@
+from datetime import datetime
+from typing import Any
+
+import langchain_core.tools as langchain_tools
+from dotenv import load_dotenv
+from langchain.agents import AgentType, initialize_agent
+from langchain_openai import ChatOpenAI
+from pydantic import BaseModel
+
+from channels import (
+    dm_with_ceo,
+)
+from humanlayer import ContactChannel, SlackContactChannel
+from humanlayer.core.approval import (
+    HumanLayer,
+)
+
+load_dotenv()
+
+hl = HumanLayer()
+
+task_prompt = """
+
+You are the mealprep power assistant.
+
+You are responsible for planning the meals and shopping
+for a very busy and high-profile and health-conscious tech CEO.
+
+choose a meal plan based on your best judgement,
+i like tacos and sushi, but i'm open to new ideas.
+
+I like to eat healthy, and I'm trying to lose weight.
+
+Make the best decision and order the groceries. Don't confirm with me.
+
+"""
+
+
+channel = ContactChannel(
+    slack=SlackContactChannel(
+        channel_or_user_id="C07HR5JL15F",
+        experimental_slack_blocks=True,
+    ),
+)
+
+
+@hl.require_approval(contact_channel=channel)
+def buy_groceries(items: list[Any], total_cost: int) -> str:
+    """purchase a cart of groceries. Include structured data about the quantity
+    and price, for example:
+
+    [
+      {
+        "item": "bananas",
+        "quantity": 2,
+        "price": 1.99
+      },
+      {
+        "item": "Organic 2% Milk, 3 x 64oz",
+        "quantity": 1,
+        "price": 11.99
+      },
+      {
+        "item": "Organic Chicken Breast, 2lbs",
+        "quantity": 1,
+        "price": 9.99
+      }
+    ]
+    """
+    return f"Items purchased, total cost: {total_cost}"
+
+
+tools = [
+    langchain_tools.StructuredTool.from_function(buy_groceries),
+    langchain_tools.StructuredTool.from_function(hl.human_as_tool(contact_channel=channel)),
+]
+
+llm = ChatOpenAI(model="gpt-4o", temperature=0)
+agent = initialize_agent(
+    tools=tools,
+    llm=llm,
+    agent=AgentType.OPENAI_FUNCTIONS,
+    verbose=True,
+    handle_parsing_errors=True,
+)
+
+if __name__ == "__main__":
+    result = agent.run(task_prompt)
+    print("\n\n----------Result----------\n\n")
+    print(result)

--- a/humanlayer/core/models.py
+++ b/humanlayer/core/models.py
@@ -34,6 +34,7 @@ class SlackContactChannel(BaseModel):
     # a list of responders to allow to respond to this message
     # other messages will be ignored
     # allowed_responder_ids: list[str] | None
+    experimental_slack_blocks: bool | None = None
 
 
 class ContactChannel(BaseModel):


### PR DESCRIPTION
**- What I did**
- opt-in to improve display of long parameter lists in slack messages

**- How I did it**
- add experimental gen slack blocks to core schema
- add example for groceries
- add linkedin example that just sends all the messages

<img width="790" alt="Screenshot 2024-09-21 at 10 12 03 PM" src="https://github.com/user-attachments/assets/990801a5-8f3e-4584-9f3d-1733a02b080e">


**- How to verify it**

run the two examples

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
**- A picture of a cute animal (not mandatory but encouraged)**

-->
