### PR TITLE
add sms/whatsapp + verbose + response options

### DIFF
--- a/examples/langchain/01-math_example.py
+++ b/examples/langchain/01-math_example.py
@@ -12,7 +12,7 @@ from langchain.tools import tool
 
 load_dotenv()
 
-hl = HumanLayer()
+hl = HumanLayer(verbose=True)
 
 
 @tool

--- a/examples/langchain/02-customer_email.py
+++ b/examples/langchain/02-customer_email.py
@@ -9,7 +9,7 @@ from humanlayer.core.approval import HumanLayer
 
 load_dotenv()
 
-hl = HumanLayer()
+hl = HumanLayer(verbose=True)
 
 task_prompt = """
 

--- a/examples/langchain/04-human_as_tool_linkedin.py
+++ b/examples/langchain/04-human_as_tool_linkedin.py
@@ -15,7 +15,7 @@ from humanlayer.core.approval import (
 
 load_dotenv()
 
-hl = HumanLayer()
+hl = HumanLayer(verbose=True)
 
 task_prompt = """
 

--- a/examples/langchain/04-human_as_tool_linkedin_frustration.py
+++ b/examples/langchain/04-human_as_tool_linkedin_frustration.py
@@ -8,15 +8,15 @@ from pydantic import BaseModel
 
 from channels import (
     dm_with_ceo,
-    dm_with_head_of_marketing,
 )
+from humanlayer import ResponseOption
 from humanlayer.core.approval import (
     HumanLayer,
 )
 
 load_dotenv()
 
-hl = HumanLayer()
+hl = HumanLayer(verbose=True)
 
 task_prompt = """
 
@@ -103,7 +103,23 @@ def get_linkedin_threads() -> list[LinkedInThread]:
     ]
 
 
-@hl.require_approval(contact_channel=dm_with_ceo)
+@hl.require_approval(
+    contact_channel=dm_with_ceo,
+    # reject options lets you show custom pre-filled rejection prompts to the human
+    reject_options=[
+        ResponseOption(
+            name="reject",
+            description="Reject the message",
+            prompt_fill="try again but this time ",
+        ),
+        ResponseOption(
+            name="skip",
+            title="Skip it",  # optional - add a title
+            description="Skip this operation",
+            prompt_fill="skip this and move on to the next task ",
+        ),
+    ],
+)
 def send_linkedin_message(thread_id: str, to_name: str, msg: str) -> str:
     """send a message in a thread in LinkedIn"""
     return f"message successfully sent to {to_name}"
@@ -116,6 +132,7 @@ tools = [
         # allow the agent to contact the CEO
         hl.human_as_tool(
             contact_channel=dm_with_ceo,
+            response_options=None,
         ),
     ),
 ]

--- a/examples/langchain/04-human_as_tool_onboarding.py
+++ b/examples/langchain/04-human_as_tool_onboarding.py
@@ -14,7 +14,7 @@ from langchain.agents import AgentType, initialize_agent
 
 load_dotenv()
 
-hl = HumanLayer()
+hl = HumanLayer(verbose=True)
 
 task_prompt = """
 

--- a/examples/langchain/04-linkedin-experimental-slack-blocks.py
+++ b/examples/langchain/04-linkedin-experimental-slack-blocks.py
@@ -17,7 +17,7 @@ from humanlayer.core.approval import (
 
 load_dotenv()
 
-hl = HumanLayer()
+hl = HumanLayer(verbose=True)
 
 task_prompt = """
 

--- a/examples/langchain/05-approvals_and_humans_composite.py
+++ b/examples/langchain/05-approvals_and_humans_composite.py
@@ -31,7 +31,7 @@ from channels import (
 
 load_dotenv()
 
-hl = HumanLayer()
+hl = HumanLayer(verbose=True)
 
 task_prompt = """
 

--- a/examples/langchain/06-custom_bot_token.py
+++ b/examples/langchain/06-custom_bot_token.py
@@ -16,7 +16,7 @@ load_dotenv()
 
 override_bot_token = os.getenv("SLACK_BOT_TOKEN")
 
-hl = HumanLayer()
+hl = HumanLayer(verbose=True)
 
 
 task_prompt = """

--- a/examples/langchain/07-grocery-slack-blocks.py
+++ b/examples/langchain/07-grocery-slack-blocks.py
@@ -17,7 +17,7 @@ from humanlayer.core.approval import (
 
 load_dotenv()
 
-hl = HumanLayer()
+hl = HumanLayer(verbose=True)
 
 task_prompt = """
 

--- a/examples/langchain/channels.py
+++ b/examples/langchain/channels.py
@@ -4,23 +4,27 @@ dm_with_ceo = ContactChannel(
     slack=SlackContactChannel(
         channel_or_user_id="C07HR5JL15F",
         context_about_channel_or_user="a DM with the ceo",
+        experimental_slack_blocks=True,
     )
 )
 dm_with_head_of_marketing = ContactChannel(
     slack=SlackContactChannel(
         channel_or_user_id="C07H5RZMBK8",
         context_about_channel_or_user="a DM with the head of marketing",
+        experimental_slack_blocks=True,
     ),
 )
 dm_with_summer_intern = ContactChannel(
     slack=SlackContactChannel(
         channel_or_user_id="C07H5S4E6EA",
         context_about_channel_or_user="a DM with the summer intern",
+        experimental_slack_blocks=True,
     ),
 )
 channel_with_sre_team = ContactChannel(
     slack=SlackContactChannel(
         channel_or_user_id="C07HR5LJ0KT",
         context_about_channel_or_user="a channel with the SRE team",
+        experimental_slack_blocks=True,
     ),
 )

--- a/examples/ts_langchain/index.ts
+++ b/examples/ts_langchain/index.ts
@@ -11,7 +11,7 @@ import { CallbackManagerForToolRun } from "@langchain/core/dist/callbacks/manage
 import { RunnableConfig } from "@langchain/core/runnables";
 import { HumanLayer } from "humanlayer";
 
-const hl = new HumanLayer();
+const hl = new HumanLayer({ verbose: true });
 
 class AddTool extends StructuredTool {
   name: string = "add";

--- a/examples/ts_openai_client/human-as-tool.ts
+++ b/examples/ts_openai_client/human-as-tool.ts
@@ -2,7 +2,7 @@ import { ContactChannel, HumanLayer } from "humanlayer";
 import OpenAI from "openai";
 import { ChatCompletionTool } from "openai/src/resources/index.js";
 
-const hl = new HumanLayer();
+const hl = new HumanLayer({ verbose: true });
 
 const PROMPT = `
 

--- a/examples/ts_openai_client/index.ts
+++ b/examples/ts_openai_client/index.ts
@@ -2,7 +2,7 @@ import { HumanLayer } from "humanlayer";
 import OpenAI from "openai";
 import { ChatCompletionTool } from "openai/src/resources/index.js";
 
-const hl = new HumanLayer();
+const hl = new HumanLayer({ verbose: true });
 
 const PROMPT = `multiply 2 and 5, then add 32 to the result.
 

--- a/humanlayer/core/approval_human_as_tool_test.py
+++ b/humanlayer/core/approval_human_as_tool_test.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock
 
+import pytest
+
 from humanlayer import (
     AgentBackend,
     ContactChannel,
@@ -9,7 +11,8 @@ from humanlayer import (
     HumanLayer,
     SlackContactChannel,
 )
-from humanlayer.core.protocol import AgentStore
+from humanlayer.core.models import ResponseOption
+from humanlayer.core.protocol import AgentStore, HumanLayerException
 
 
 def test_human_as_tool_generic() -> None:
@@ -185,3 +188,29 @@ def test_human_as_tool_fn_contact_channel() -> None:
     contacts.get.assert_called_once_with("generated-id")
 
     pass
+
+
+def test_human_as_tool_response_names_must_be_unique() -> None:
+    """
+    test that the response names in the response_options must be unique
+    """
+    hl = HumanLayer()
+    with pytest.raises(HumanLayerException) as e:
+        hl.human_as_tool(
+            response_options=[
+                ResponseOption(
+                    name="foo",
+                    title="foo",
+                    description="foo",
+                    prompt_fill="foo",
+                ),
+                ResponseOption(
+                    name="foo",
+                    title="bar",
+                    description="bar",
+                    prompt_fill="bar",
+                ),
+            ]
+        )
+
+    assert "response_options must have unique names" in str(e.value)

--- a/humanlayer/core/approval_require_approval_test.py
+++ b/humanlayer/core/approval_require_approval_test.py
@@ -1,14 +1,17 @@
 from unittest.mock import Mock
 
+import pytest
+
 from humanlayer import (
     AgentBackend,
     ContactChannel,
     FunctionCall,
     FunctionCallSpec,
     HumanLayer,
+    ResponseOption,
     SlackContactChannel,
 )
-from humanlayer.core.protocol import AgentStore
+from humanlayer.core.protocol import AgentStore, HumanLayerException
 
 
 def test_require_approval() -> None:
@@ -131,3 +134,26 @@ def test_require_approval_wrapper_contact_channel() -> None:
     )
     functions.get.assert_called_once_with("generated-id")
     mock_function.assert_called_with(bar="baz")
+
+
+def test_require_approval_unique_reject_option_names() -> None:
+    hl = HumanLayer()
+    with pytest.raises(HumanLayerException) as e:
+        hl.require_approval(
+            reject_options=[
+                ResponseOption(
+                    name="foo",
+                    title="foo",
+                    description="foo",
+                    prompt_fill="foo",
+                ),
+                ResponseOption(
+                    name="foo",
+                    title="bar",
+                    description="bar",
+                    prompt_fill="bar",
+                ),
+            ]
+        )
+
+    assert "reject_options must have unique names" in str(e.value)


### PR DESCRIPTION
**- What I did**
* add types for sending sms/whatsapp channels
* enable custom response options from client side

**- How to verify it**
- Check / run the changed examples

**- Description for the changelog**
- Add client-side types for SMS and WhatsApp messaging
- Add `verbose=True` to `HumanLayer` constructor in TS and Py clients
- Add ability to specify custom `reject_options` in `FunctionCall.spec` and custom `response_options` in `HumanContact.spec`

**- Picture of a cute animal**

![image](https://github.com/user-attachments/assets/92d7c249-885d-4896-b4ff-abcfe1e2d37a)
