### PR TITLE
update cf example

### DIFF
--- a/examples/controlflow/Dockerfile
+++ b/examples/controlflow/Dockerfile
@@ -1,13 +1,15 @@
-# syntax=docker/dockerfile:1
-FROM python:3.11-slim-bookworm as prod
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 WORKDIR /app
 
-COPY requirements.txt /app
-RUN  --mount=type=cache,target=/root/.cache/pip \
-    pip install -r requirements.txt
+ENV UV_SYSTEM_PYTHON=1
+ENV PATH="/root/.local/bin:$PATH"
 
-COPY . /app
+COPY requirements.txt .
 
-ENTRYPOINT ["python3"]
-CMD ["controlflow_math.py"]
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install -r requirements.txt
+
+COPY controlflow_math.py .
+
+ENTRYPOINT ["uv", "run", "controlflow_math.py"]

--- a/examples/controlflow/README.md
+++ b/examples/controlflow/README.md
@@ -23,7 +23,9 @@ python controlflow_math.py
 ```
 
 ## If you prefer docker
+
 Be sure to set the environment variables in the `.env` file or pass them explicitly via the `-e` flag.
+
 ```
 # docker compose
 docker compose run examples controlflow_math.py

--- a/examples/controlflow/README.md
+++ b/examples/controlflow/README.md
@@ -25,5 +25,6 @@ python controlflow_math.py
 ## If you prefer docker
 Be sure to set the environment variables in the `.env` file or pass them explicitly via the `-e` flag.
 ```
+# docker compose
 docker compose run examples controlflow_math.py
 ```

--- a/examples/controlflow/README.md
+++ b/examples/controlflow/README.md
@@ -23,7 +23,7 @@ python controlflow_math.py
 ```
 
 ## If you prefer docker
-
+Be sure to set the environment variables in the `.env` file or pass them explicitly via the `-e` flag.
 ```
 docker compose run examples controlflow_math.py
 ```

--- a/examples/controlflow/controlflow_math.py
+++ b/examples/controlflow/controlflow_math.py
@@ -1,10 +1,11 @@
-from dotenv import load_dotenv
+# /// script
+# dependencies = ["controlflow", "humanlayer"]
+# ///
+
+# https://controlflow.ai/welcome
+import controlflow as cf
 
 from humanlayer import HumanLayer
-
-load_dotenv()
-
-import controlflow as cf
 
 hl = HumanLayer(
     # run_id is optional -it can be used to identify the agent in approval history
@@ -23,12 +24,11 @@ def multiply(x: int, y: int) -> int:
     return x * y
 
 
-@cf.task(tools=[add, multiply])
-def do_math() -> int:
-    """multiply 2 and 5, then add 32 to the result"""
-
-
 if __name__ == "__main__":
-    result = do_math()
+    result = cf.run(
+        "multiply 2 and 5, then add 32 to the result",
+        tools=[add, multiply],
+    )
+
     print("\n\n---------- RESULT ----------\n\n")
     print(result)

--- a/examples/controlflow/docker-compose.yaml
+++ b/examples/controlflow/docker-compose.yaml
@@ -5,3 +5,5 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./:/app
+    env_file:
+      - .env

--- a/examples/controlflow/docker-compose.yaml
+++ b/examples/controlflow/docker-compose.yaml
@@ -1,3 +1,4 @@
+version: "3.7"
 services:
   examples:
     build:

--- a/examples/controlflow/docker-compose.yaml
+++ b/examples/controlflow/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   examples:
     build:

--- a/examples/controlflow/dotenv.example
+++ b/examples/controlflow/dotenv.example
@@ -1,3 +1,7 @@
 # copy to .env
 OPENAI_API_KEY=
 HUMANLAYER_API_KEY=
+
+# optionally, if you have a prefect backend for controlflow, you can set:
+PREFECT_API_URL=
+PREFECT_API_KEY=

--- a/examples/controlflow/requirements.txt
+++ b/examples/controlflow/requirements.txt
@@ -1,5 +1,4 @@
 controlflow
-python-dotenv
 # install humanlayer
 humanlayer==0.6.2
 # or if you want an editable version


### PR DESCRIPTION
using `cf.run` is preferred / more flexible at this point. lmk if there's a reason to keep the `load_dotenv`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `controlflow_math.py` to use `cf.run()` and enhance configuration options in `dotenv.example`.
> 
>   - **Behavior**:
>     - Replaces custom `do_math()` function with `cf.run()` in `controlflow_math.py` for more flexibility.
>   - **Configuration**:
>     - Adds optional Prefect backend settings `PREFECT_API_URL` and `PREFECT_API_KEY` to `dotenv.example`.
>     - Removes `version` key from `docker-compose.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 364c08359f8c51e3ccc649371a39c6dcdb4d703d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->