### PR TITLE
lock fastapi versions

### DIFF
--- a/examples/fastapi-webhooks/requirements.txt
+++ b/examples/fastapi-webhooks/requirements.txt
@@ -1,4 +1,4 @@
 fastapi
 uvicorn
 python-dotenv
-humanlayer>=0.6.2
+humanlayer==0.6.3

--- a/examples/fastapi/requirements.txt
+++ b/examples/fastapi/requirements.txt
@@ -1,4 +1,4 @@
 fastapi
 uvicorn
 python-dotenv
-humanlayer>=0.6.2
+humanlayer==0.6.3


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/humanlayer/humanlayer/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:

-->

### What I did

### How I did it

- [ ] I have ensured `make check test` passes

### How to verify it

### Description for the changelog

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
**- A picture of a cute animal (not mandatory but encouraged)**

-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Lock `humanlayer` version to `0.6.3` in FastAPI example requirements files.
> 
>   - **Dependencies**:
>     - Lock `humanlayer` version to `0.6.3` in `examples/fastapi-webhooks/requirements.txt` and `examples/fastapi/requirements.txt`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for bbc18d12176f5d41b79eeb0a1271e51cf0cc8cc1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->