### PR TITLE
slack-required

### DIFF
--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -36,11 +36,36 @@ dm_with_ceo = ContactChannel(
         channel_or_user_id="U123456",  # Must be an ID like C123456 or U123456, not #channel or @user
         context_about_channel_or_user="a DM with the CEO",  # Optional context for the LLM
         experimental_slack_blocks=True,  # Optional - enables rich message formatting
+        allowed_responder_ids=["U123456"],  # Optional - restrict who can respond
     )
 )
 
 hl = HumanLayer(contact_channel=dm_with_ceo)
 ```
+
+### Allowed Responders
+
+You can restrict which Slack users are allowed to respond to a message using `allowed_responder_ids`:
+
+```python
+# Only allow specific users to approve add operations
+add_approver_channel = ContactChannel(
+    slack=SlackContactChannel(
+        channel_or_user_id="C123456",
+        context_about_channel_or_user="the channel for add operations",
+        allowed_responder_ids=["U123456"],  # Only this user can approve
+    )
+)
+
+@hl.require_approval(contact_channel=add_approver_channel)
+def add(a: float, b: float) -> float:
+    """Add two numbers"""
+    return a + b
+```
+
+The `allowed_responder_ids` must be Slack user IDs (starting with `U`). Messages from other users will be ignored.
+
+See [01-math-example-allowed-repliers.py](https://github.com/humanlayer/humanlayer/tree/main/examples/langchain/01-math_example_allowed_repliers.py) for a complete example.
 
 You can also override the contact channel at the per-request level:
 

--- a/examples/langchain/01-math_example_allowed_repliers.py
+++ b/examples/langchain/01-math_example_allowed_repliers.py
@@ -1,0 +1,61 @@
+from dotenv import load_dotenv
+from langchain.agents import AgentType, initialize_agent
+from langchain_openai import ChatOpenAI
+from langchain.tools import StructuredTool
+
+from humanlayer import ContactChannel, HumanLayer, SlackContactChannel
+
+load_dotenv()
+
+hl = HumanLayer(
+    verbose=True,
+    run_id="langchain-math-allowed-repliers",
+)
+
+# Define channels with specific allowed responders
+add_approver_channel = ContactChannel(
+    slack=SlackContactChannel(
+        channel_or_user_id="C07HR5JL15F",  # Using the same channel as other examples
+        context_about_channel_or_user="the channel for add operations",
+        allowed_responder_ids=["U07HR5DNQBB"],  # Only this user can approve add operations
+    )
+)
+
+multiply_approver_channel = ContactChannel(
+    slack=SlackContactChannel(
+        channel_or_user_id="C07HR5JL15F",  # Using the same channel as other examples
+        context_about_channel_or_user="the channel for multiply operations",
+        allowed_responder_ids=["U07H7AGMA22"],  # Only this user can approve multiply operations
+    )
+)
+
+
+@hl.require_approval(contact_channel=add_approver_channel)
+def add(a: float, b: float) -> float:
+    """Add two numbers"""
+    return a + b
+
+
+@hl.require_approval(contact_channel=multiply_approver_channel)
+def multiply(a: float, b: float) -> float:
+    """Multiply two numbers"""
+    return a * b
+
+
+tools = [
+    StructuredTool.from_function(add),
+    StructuredTool.from_function(multiply),
+]
+
+llm = ChatOpenAI(model="gpt-4", temperature=0)
+agent = initialize_agent(
+    tools=tools,
+    llm=llm,
+    agent=AgentType.OPENAI_FUNCTIONS,
+    verbose=True,
+)
+
+if __name__ == "__main__":
+    result = agent.run("What is (4 + 5) * 3?")
+    print("\n\n----------Result----------\n\n")
+    print(result)

--- a/humanlayer/core/models.py
+++ b/humanlayer/core/models.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 logger = logging.getLogger(__name__)
 
@@ -32,9 +32,16 @@ class SlackContactChannel(BaseModel):
 
     # a list of responders to allow to respond to this message
     # other messages will be ignored
-    # allowed_responder_ids: list[str] | None
+    allowed_responder_ids: list[str] | None = None
 
     experimental_slack_blocks: bool | None = None
+
+    @field_validator("allowed_responder_ids")
+    @classmethod
+    def validate_allowed_responder_ids(cls, v: list[str] | None) -> list[str] | None:
+        if v is not None and len(v) == 0:
+            raise ValueError("allowed_responder_ids if provided must not be empty")
+        return v
 
 
 class SMSContactChannel(BaseModel):

--- a/humanlayer/core/models_test.py
+++ b/humanlayer/core/models_test.py
@@ -1,0 +1,26 @@
+import pytest
+from pydantic import ValidationError
+
+from humanlayer.core.models import SlackContactChannel
+
+
+def test_slack_contact_channel_allows_none_and_nonempty_list() -> None:
+    # Test None is allowed
+    channel = SlackContactChannel(channel_or_user_id="C123")
+    assert channel.allowed_responder_ids is None
+
+    # Test non-empty list is allowed
+    channel = SlackContactChannel(channel_or_user_id="C123", allowed_responder_ids=["U123", "U456"])
+    assert channel.allowed_responder_ids == ["U123", "U456"]
+
+
+def test_slack_contact_channel_rejects_empty_list() -> None:
+    # Test empty list raises error
+    with pytest.raises(ValidationError) as exc_info:
+        SlackContactChannel(channel_or_user_id="C123", allowed_responder_ids=[])
+    assert "allowed_responder_ids if provided must not be empty" in str(exc_info.value)
+
+
+def test_slack_contact_channel_allows_none() -> None:
+    channel = SlackContactChannel(channel_or_user_id="C123", allowed_responder_ids=None)
+    assert channel.allowed_responder_ids is None


### PR DESCRIPTION

### What I did

Add support for required slack responders, restricting who can respond to a slack message

### How I did it

- added model fields
- added model tests
- updated the docs
- [x] I have ensured `make check test` passes

### How to verify it

- get access to two slack accounts in the same workspace
- get the user ids and the channel ID of a channel they're both in
- update the new langchain example to use the channel/user ids you set, one for add and one for multiply
- run the example, check that only one user can respond to `add` operations and only one can respond to `multiply`

### Description for the changelog

Add support for required slack responders, restricting who can respond to a slack message

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `allowed_responder_ids` to restrict Slack message responders, with validation, examples, tests, and documentation updates.
> 
>   - **Behavior**:
>     - Add `allowed_responder_ids` to `SlackContactChannel` in `models.py` to restrict message responders.
>     - Validate `allowed_responder_ids` to ensure it's not empty if provided.
>   - **Examples**:
>     - New example `01-math_example_allowed_repliers.py` demonstrating usage of `allowed_responder_ids`.
>   - **Tests**:
>     - Add tests in `models_test.py` for `allowed_responder_ids` validation.
>   - **Documentation**:
>     - Update `slack.mdx` to document `allowed_responder_ids` usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 906c7e73677a9024cc10a133d9cab8e8c924e78d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->