### PR TITLE
Add state preservation support and update documentation

### DIFF
--- a/docs/core/state-management.mdx
+++ b/docs/core/state-management.mdx
@@ -6,6 +6,8 @@ icon: "database"
 
 HumanLayer provides built-in state preservation to help maintain context across agent interactions. This is particularly useful when building agents that need to maintain conversation history or workflow state across multiple human interactions.
 
+For a runnable example, see the [FastAPI Email Example](https://github.com/humanlayer/humanlayer/blob/main/examples/fastapi-email/app-statehooks.py).
+
 ## Overview
 
 State can be preserved in both function calls and human contacts through the `state` field:

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/uv.lock
+++ b/uv.lock
@@ -508,7 +508,7 @@ wheels = [
 
 [[package]]
 name = "humanlayer"
-version = "0.6.5"
+version = "0.6.6rc1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
What I did
-----------

- updated docs for state management to fix and issue w/ rendering

How I did it
-----------

- removed whitespace before closing tag
- also added a link to github example
- [] I have ensured `make check test` passes

How to verify it
--------

- Review the new "State Management" documentation.
- Run the updated examples, such as the FastAPI Email example with state hooks, to see state preservation in action.
- Execute `make check test` to ensure all tests pass.

Description for the changelog
---------

Added state preservation support to FunctionCallSpec and HumanContactSpec; updated documentation and examples.
