### PR TITLE
agent-webhooks docs and models for v1beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.4 (unreleased)
+
+- Add [v1beta2 webhook payload](https://humanlayer.dev/docs/core/response-webhooks) types to ts and python sdks
+
 ## 0.7.3
 
 This was an internal release with build/release process changes, but no user-facing changes.

--- a/docs/core/agent-webhooks.mdx
+++ b/docs/core/agent-webhooks.mdx
@@ -7,11 +7,19 @@ icon: "rocket"
 Agent webhooks are designed to allow you to launch an agent in response to a message from a platform like email, slack, etc.
 
 Not to be confused with [webhooks](/core/response-webhooks), which allows you to receive a notification when an [approval](/core/human-as-tool#approvals) or [human contact](/core/human-as-tool#human-contacts)
-is completed, Agent webhooks are specifically designed for kicking off new tasks and workflows
+is completed, Agent webhooks are specifically designed for kicking off new tasks and workflows. They use the same webhook
+console in the [HumanLayer dashboard](https://app.humanlayer.dev/), with an event type of `v1beta2.agent_email.received`.
 
 <Note>
   Agent webhooks are currently in beta. If you'd like to help us test and
   improve the feature, please reach out to us at contact@humanlayer.dev
+</Note>
+
+<Note>
+  Breaking Change 01/2025: Agent webhooks are transitioning to a new format.
+  Please use the `v1beta2.agent_email.received` event type to configure where
+  email webhooks are sent. The email address configuration functionality remains
+  unchanged.
 </Note>
 
 ## Use cases
@@ -32,66 +40,121 @@ To get started with agent webhooks, you'll need to:
 
 1. Implement an AI Agent in your language and/or framework of choice, and create an API endpoint that can launch the agent
 2. Create a publicly reachable URL that can receive webhooks from HumanLayer (we recommend [ngrok](https://ngrok.com/) to catch webhooks while you're developing locally)
-3. Create a new agent webhook in the [HumanLayer dashboard](https://app.humanlayer.dev/), setting the callback URL to your webhook endpoint
-
-![Create an agent webhook](/images/agent-webhooks.png)
-
-4. Test the webhook in the HumanLayer dashboard
-5. Test the webhook by sending an email to the webhook email address (slack support coming soon)
+3. Create a new agent webhook in the [HumanLayer dashboard](https://app.humanlayer.dev/)
+4. Configure your webhook endpoint to receive events with the `v1beta2.agent_email.received` event type in the Response Webhooks section of the [HumanLayer dashboard](https://app.humanlayer.dev/)
+5. Test the webhook by sending an email to the webhook email address
 
 ### Email Payload
 
 The webhook payload models are defined in [models_agent_webhook.py](https://github.com/humanlayer/humanlayer/blob/main/humanlayer/core/models_agent_webhook.py).
 
-For email webhooks, the payload will look like
+For email webhooks, the payload will have the following structure:
 
-<ParamField body="email_payload" type="object">
-  <Expandable title="EmailPayload">
-    <ParamField body="from_address" type="string" required>
-      Email address of the sender
+<ParamField body="webhook_payload" type="object">
+  <Expandable title="WebhookPayload">
+    <ParamField body="type" type="string" required>
+      The event type: "agent_email.received"
     </ParamField>
-    <ParamField body="to_address" type="string" required>
-      Email address of the recipient
+    <ParamField body="is_test" type="boolean">
+      Whether this is a test webhook
     </ParamField>
-    <ParamField body="subject" type="string" required>
-      Subject line of the email
-    </ParamField>
-    <ParamField body="body" type="string" required>
-      Body content of the email
-    </ParamField>
-    <ParamField body="message_id" type="string" required>
-      Unique message ID of the email
-    </ParamField>
-    <ParamField body="previous_thread" type="array">
-      Optional list of previous messages in the thread
-      <Expandable title="EmailMessage">
+    <ParamField body="event" type="object">
+      <Expandable title="EmailPayload">
         <ParamField body="from_address" type="string" required>
           Email address of the sender
         </ParamField>
-        <ParamField body="to_address" type="array" required>
-          List of recipient email addresses
-        </ParamField>
-        <ParamField body="cc_address" type="array" required>
-          List of CC'd email addresses
+        <ParamField body="to_address" type="string" required>
+          Email address of the recipient
         </ParamField>
         <ParamField body="subject" type="string" required>
           Subject line of the email
         </ParamField>
-        <ParamField body="content" type="string" required>
-          Content of the email
+        <ParamField body="body" type="string" required>
+          Body content of the email
         </ParamField>
-        <ParamField body="datetime" type="string" required>
-          Timestamp of when the email was sent
+        <ParamField body="message_id" type="string" required>
+          Unique message ID of the email
+        </ParamField>
+        <ParamField body="previous_thread" type="array">
+          Optional list of previous messages in the thread
+          <Expandable title="EmailMessage">
+            <ParamField body="from_address" type="string" required>
+              Email address of the sender
+            </ParamField>
+            <ParamField body="to_address" type="array" required>
+              List of recipient email addresses
+            </ParamField>
+            <ParamField body="cc_address" type="array" required>
+              List of CC'd email addresses
+            </ParamField>
+            <ParamField body="bcc_address" type="array" required>
+              List of BCC'd email addresses
+            </ParamField>
+            <ParamField body="subject" type="string" required>
+              Subject line of the email
+            </ParamField>
+            <ParamField body="content" type="string" required>
+              Content of the email
+            </ParamField>
+            <ParamField body="datetime" type="string" required>
+              Timestamp of when the email was sent
+            </ParamField>
+          </Expandable>
+        </ParamField>
+        <ParamField body="raw_email" type="string" required>
+          Raw email content including headers
         </ParamField>
       </Expandable>
-    </ParamField>
-    <ParamField body="raw_email" type="string" required>
-      Raw email content including headers
     </ParamField>
   </Expandable>
 </ParamField>
 
 a JSON example might look like
+
+```
+{
+  "event": {
+    "body": "Hello,\n\nJust a reminder about our important meeting scheduled for tomorrow at 2 PM. Please come prepared with your quarterly reports.\n\nBest regards,\nSender",
+    "from_address": "sender@example.com",
+    "message_id": "<20230615123456.ABC123@example.com>",
+    "previous_thread": [
+      {
+        "bcc_address": [],
+        "cc_address": [
+          "manager@example.com"
+        ],
+        "content": "Thank you for the update. I'll review the documents and get back to you soon.",
+        "datetime": "2023-06-14T15:30:00Z",
+        "from_address": "recipient@example.com",
+        "subject": "Re: Project Update",
+        "to_address": [
+          "sender@example.com"
+        ]
+      },
+      {
+        "bcc_address": [
+          "archive@example.com"
+        ],
+        "cc_address": [
+          "manager@example.com"
+        ],
+        "content": "Hi,\n\nI've attached the latest project documents for your review. Let me know if you have any questions.",
+        "datetime": "2023-06-14T14:00:00Z",
+        "from_address": "sender@example.com",
+        "subject": "Project Update",
+        "to_address": [
+          "recipient@example.com"
+        ]
+      }
+    ],
+    "raw_email": "From: sender@example.com\nTo: recipient@example.com\nSubject: Important Meeting Tomorrow\nDate: Thu, 15 Jun 2023 12:34:56 +0000\nMessage-ID: <20230615123456.ABC123@example.com>\n\nHello,\n\nJust a reminder about our important meeting scheduled for tomorrow at 2 PM. Please come prepared with your quarterly reports.\n\nBest regards,\nSender",
+    "subject": "Important Meeting Tomorrow",
+    "to_address": "recipient@example.com"
+  },
+  "is_test": true,
+  "type": "agent_email.received"
+}
+```
 
 ## State Preservation
 
@@ -114,34 +177,6 @@ function_call = FunctionCall(
     )
 )
 
-# The state will be returned in the webhook payload
-# allowing you to restore the conversation context
-```
-
-## Next Stepsjson
-
-{
-"from_address": "overworked-admin@coolcompany.com",
-"to_address": "cool-agent@humanlayer.dev",
-"subject": "FWD: help",
-"body": "can you add a ticket for this?",
-"message_id": "<1234567890@mailsrv.coolcompany.com>",
-"raw_email": "This is a placeholder for a test email - if this were a real email, it would include headers, etc.",
-"datetime": "2024-01-02T00:00:00Z",
-"previous_thread": [
-{
-"from_address": "needy-employee@coolcompany.com",
-"to_address": ["overworked-admin@coolcompany.com"],
-"cc_address": [],
-"subject": "help",
-"content": "i need some help",
-"raw_email": "i need some help",
-"datetime": "2024-01-01T00:00:00Z"
-}
-]
-}
-
-```
 
 ### Using Ngrok for local development
 

--- a/humanlayer-ts/src/models_agent_webhook.ts
+++ b/humanlayer-ts/src/models_agent_webhook.ts
@@ -1,0 +1,59 @@
+import { FunctionCall, HumanContact } from './models'
+
+type EmailMessage = {
+  from_address: string
+  to_address: string[]
+  cc_address: string[]
+  bcc_address: string[]
+  subject: string
+  content: string
+  datetime: string
+}
+
+type EmailPayload = {
+  from_address: string
+  to_address: string
+  subject: string
+  body: string
+  message_id: string
+  previous_thread?: EmailMessage[]
+  raw_email: string
+  is_test?: boolean
+}
+
+type SlackMessage = {
+  from_user_id: string
+  channel_id: string
+  content: string
+  message_id: string
+}
+
+type SlackThread = {
+  thread_ts: string
+  channel_id: string
+  events: SlackMessage[]
+}
+
+type V1Beta2EmailEventReceived = {
+  is_test?: boolean
+  type: 'agent_email.received'
+  event: EmailPayload
+}
+
+type V1Beta2SlackEventReceived = {
+  is_test?: boolean
+  type: 'agent_slack.received'
+  event: SlackThread
+}
+
+type V1Beta2FunctionCallCompleted = {
+  is_test?: boolean
+  type: 'function_call.completed'
+  event: FunctionCall
+}
+
+type V1Beta2HumanContactCompleted = {
+  is_test?: boolean
+  type: 'human_contact.completed'
+  event: HumanContact
+}

--- a/humanlayer/core/models_agent_webhook.py
+++ b/humanlayer/core/models_agent_webhook.py
@@ -9,11 +9,11 @@ For example, when an email is received, HumanLayer will send an EmailPayload to 
 configured webhook endpoint containing the email content and metadata.
 """
 
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from pydantic import BaseModel
 
-from humanlayer.core.models import EmailContactChannel
+from humanlayer.core.models import FunctionCall, HumanContact
 
 
 class EmailMessage(BaseModel):
@@ -22,6 +22,7 @@ class EmailMessage(BaseModel):
     from_address: str
     to_address: List[str]
     cc_address: List[str]
+    bcc_address: List[str]
     subject: str
     content: str
     datetime: str
@@ -39,14 +40,6 @@ class EmailPayload(BaseModel):
     raw_email: str
     is_test: bool | None = None  # will be set if the email is a test webhook from the server
 
-    def as_channel(self, context_about_user: str | None = None) -> EmailContactChannel:
-        return EmailContactChannel.in_reply_to(
-            from_address=self.from_address,
-            message_id=self.message_id,
-            subject=self.subject,
-            context_about_user=context_about_user,
-        )
-
 
 class SlackMessage(BaseModel):
     from_user_id: str
@@ -59,3 +52,27 @@ class SlackThread(BaseModel):
     thread_ts: str
     channel_id: str
     events: list[SlackMessage]
+
+
+class V1Beta2EmailEventReceived(BaseModel):
+    is_test: bool | None = None
+    type: Literal["agent_email.received"] = "agent_email.received"  # noqa: A003
+    event: EmailPayload
+
+
+class V1Beta2SlackEventReceived(BaseModel):
+    is_test: bool | None = None
+    type: Literal["agent_slack.received"] = "agent_slack.received"  # noqa: A003
+    event: SlackThread
+
+
+class V1Beta2FunctionCallCompleted(BaseModel):
+    is_test: bool | None = None
+    type: Literal["function_call.completed"] = "function_call.completed"  # noqa: A003
+    event: FunctionCall
+
+
+class V1Beta2HumanContactCompleted(BaseModel):
+    is_test: bool | None = None
+    type: Literal["human_contact.completed"] = "human_contact.completed"  # noqa: A003
+    event: HumanContact


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add v1beta2 webhook payload types for email and Slack events to TypeScript and Python SDKs, updating models and documentation.
> 
>   - **Webhooks**:
>     - Add `v1beta2` webhook payload types for email and Slack events in `models_agent_webhook.py` and `models_agent_webhook.ts`.
>     - Introduce `V1Beta2EmailEventReceived`, `V1Beta2SlackEventReceived`, `V1Beta2FunctionCallCompleted`, and `V1Beta2HumanContactCompleted` models.
>   - **Documentation**:
>     - Update `agent-webhooks.mdx` to include `v1beta2.agent_email.received` event type and payload structure.
>     - Add breaking change note for agent webhooks transitioning to new format by 01/2025.
>   - **Misc**:
>     - Update `CHANGELOG.md` with details of the new webhook payload types for the upcoming release.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for e49d8dc987fe3a450edf8556cff2675ccc0f70e1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->