### PR TITLE
Provide alternate email during smoketest runs

### DIFF
--- a/examples/langchain/09-email-contact.py
+++ b/examples/langchain/09-email-contact.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any
 from humanlayer import ContactChannel, EmailContactChannel
 from langchain_core.prompts import ChatPromptTemplate
@@ -17,7 +18,7 @@ hl = HumanLayer(
     verbose=True,
     contact_channel=ContactChannel(
         email=EmailContactChannel(
-            address="dexter@humanlayer.dev",
+            address=os.getenv("HL_EXAMPLE_CONTACT_EMAIL", "dexter@humanlayer.dev"),
             context_about_user="the user you are helping",
         )
     ),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make email address in `09-email-contact.py` configurable via `HL_EXAMPLE_CONTACT_EMAIL` environment variable.
> 
>   - **Behavior**:
>     - In `09-email-contact.py`, the email address for `EmailContactChannel` is now configurable via the `HL_EXAMPLE_CONTACT_EMAIL` environment variable, defaulting to `dexter@humanlayer.dev` if not set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for f334667dc1c31ac14a421e7194d25e3146414d0f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->