### PR TITLE
fix usage warnings

### DIFF
--- a/docs/frameworks/mastra.mdx
+++ b/docs/frameworks/mastra.mdx
@@ -21,7 +21,10 @@ npx create-mastra@latest
 When prompted, accept the default options for the setup.
 
 <Tip>
-  During the `create-mastra` setup, you'll be prompted to choose a model provider. While this guide uses OpenAI models in the examples, Mastra supports all models available through the Vercel AI SDK (e.g., OpenAI, Anthropic, Google, etc.). Accepting the defaults will typically select OpenAI.
+  During the `create-mastra` setup, you'll be prompted to choose a model
+  provider. While this guide uses OpenAI models in the examples, Mastra supports
+  all models available through the Vercel AI SDK (e.g., OpenAI, Anthropic,
+  Google, etc.). Accepting the defaults will typically select OpenAI.
 </Tip>
 
 This command will guide you through setting up a new Mastra project, asking for a project name and other configurations.
@@ -54,7 +57,8 @@ HUMANLAYER_API_KEY=your-humanlayer-key
 ```
 
 <Tip>
-  You can get your HumanLayer API key from the [HumanLayer dashboard](https://app.humanlayer.dev).
+  You can get your HumanLayer API key from the [HumanLayer
+  dashboard](https://app.humanlayer.dev).
 </Tip>
 
 ## Chef Agent Example
@@ -64,7 +68,10 @@ This example demonstrates building a "Chef Agent" that can check available ingre
 ### Tools Definition
 
 <Tip>
-  Mastra offers flexibility by supporting both its native tool format and the Vercel AI SDK tool format. For seamless integration with HumanLayer, this guide utilizes the Vercel AI SDK format. Learn more about adding tools in Mastra [here](https://mastra.ai/docs/agents/adding-tools).
+  Mastra offers flexibility by supporting both its native tool format and the
+  Vercel AI SDK tool format. For seamless integration with HumanLayer, this
+  guide utilizes the Vercel AI SDK format. Learn more about adding tools in
+  Mastra [here](https://mastra.ai/docs/agents/adding-tools).
 </Tip>
 
 ```typescript src/mastra/tools/kitchenTools.ts
@@ -107,22 +114,23 @@ export const checkIngredients = tool({
 
 // Tool to cook a meal (write operation, requires approval)
 const cookMealTool = tool({
-    description: "Cooks a specified meal using available ingredients.",
-    parameters: z.object({
-        mealName: z.string().describe("The name of the meal to cook, e.g., 'Chicken Stir-fry'"),
-    }),
-    execute: async ({ mealName }) => {
-        // Simulate the cooking process
-        console.log(`Cooking ${mealName}...`);
-        // In a real scenario, this might interact with smart kitchen devices,
-        // update inventory, or log the meal.
-        return `${mealName} has been cooked successfully!`;
-    },
+  description: "Cooks a specified meal using available ingredients.",
+  parameters: z.object({
+    mealName: z
+      .string()
+      .describe("The name of the meal to cook, e.g., 'Chicken Stir-fry'"),
+  }),
+  execute: async ({ mealName }) => {
+    // Simulate the cooking process
+    console.log(`Cooking ${mealName}...`);
+    // In a real scenario, this might interact with smart kitchen devices,
+    // update inventory, or log the meal.
+    return `${mealName} has been cooked successfully!`;
+  },
 });
 
 // Wrap the cookMealTool with HumanLayer approval
 export const cookMeal = hl.requireApproval({ cookMealTool });
-
 ```
 
 ### Agent Definition
@@ -176,7 +184,8 @@ To run your chef agent:
 4. When the agent attempts to use the `cookMeal` tool, HumanLayer will require approval before proceeding. The `checkIngredients` tool will execute without interruption.
 
 <Warning>
-  The agent will pause execution *only* when attempting to use the `cookMeal` tool, while waiting for human approval.
+  The agent will pause execution *only* when attempting to use the `cookMeal`
+  tool, while waiting for human approval.
 </Warning>
 
 ### Approving Actions via HumanLayer Dashboard

--- a/humanlayer/core/async_cloud.py
+++ b/humanlayer/core/async_cloud.py
@@ -28,14 +28,15 @@ class AsyncHumanLayerCloudConnection(BaseModel):
     _session: aiohttp.ClientSession | None = None
     http_timeout_seconds: int = 30
 
-    @model_validator(mode="after")  # type: ignore
-    def post_validate(self) -> None:
+    @model_validator(mode="after")
+    def post_validate(self) -> "AsyncHumanLayerCloudConnection":
         self.api_key = self.api_key or os.getenv("HUMANLAYER_API_KEY")
         self.api_base_url = self.api_base_url or os.getenv(
             "HUMANLAYER_API_BASE", "https://api.humanlayer.dev/humanlayer/v1"
         )
         if not self.api_key:
             raise ValueError("HUMANLAYER_API_KEY is required for cloud approvals")
+        return self
 
     async def request(
         self,

--- a/humanlayer/core/cloud.py
+++ b/humanlayer/core/cloud.py
@@ -4,7 +4,6 @@ import os
 
 import requests
 from pydantic import BaseModel, model_validator
-from typing_extensions import Self
 
 from humanlayer.core.models import (
     Escalation,
@@ -28,7 +27,7 @@ class HumanLayerCloudConnection(BaseModel):
     http_timeout_seconds: int = 30
 
     @model_validator(mode="after")
-    def post_validate(self) -> Self:
+    def post_validate(self) -> "HumanLayerCloudConnection":
         self.api_key = self.api_key or os.getenv("HUMANLAYER_API_KEY")
         self.api_base_url = self.api_base_url or os.getenv(
             "HUMANLAYER_API_BASE", "https://api.humanlayer.dev/humanlayer/v1"

--- a/humanlayer/core/cloud.py
+++ b/humanlayer/core/cloud.py
@@ -4,6 +4,7 @@ import os
 
 import requests
 from pydantic import BaseModel, model_validator
+from typing_extensions import Self
 
 from humanlayer.core.models import (
     Escalation,
@@ -26,14 +27,15 @@ class HumanLayerCloudConnection(BaseModel):
     api_base_url: str | None = None
     http_timeout_seconds: int = 30
 
-    @model_validator(mode="after")  # type: ignore
-    def post_validate(self) -> None:
+    @model_validator(mode="after")
+    def post_validate(self) -> Self:
         self.api_key = self.api_key or os.getenv("HUMANLAYER_API_KEY")
         self.api_base_url = self.api_base_url or os.getenv(
             "HUMANLAYER_API_BASE", "https://api.humanlayer.dev/humanlayer/v1"
         )
         if not self.api_key:
             raise ValueError("HUMANLAYER_API_KEY is required for cloud approvals")
+        return self
 
     def request(  # type: ignore
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,12 @@
 authors = [{ name = "humanlayer authors", email = "dexter@metalytics.dev" }]
 requires-python = "<4.0,>=3.10"
 dependencies = [
-  "pydantic<3.0.0,>=2.8.2",
-  "requests<3.0.0,>=2.32.3",
-  "python-slugify<9.0.0,>=8.0.4",
-  "python-dotenv<2.0.0,>=1.0.1",
-  "click<9.0.0,>=8.1.7",
-  "aiohttp<4.0.0,>=3.11.10",
+  "pydantic>=2.8.2,<3.0.0",
+  "requests>=2.32.3,<3.0.0",
+  "python-slugify>=8.0.4,<9.0.0",
+  "python-dotenv>=1.0.1,<2.0.0",
+  "click>=8.1.7,<9.0.0",
+  "aiohttp>=3.11.10,<4.0.0",
 ]
 name = "humanlayer"
 version = "0.7.8-alpha.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,13 @@
 [project]
-authors = [
-    {name = "humanlayer authors", email = "dexter@metalytics.dev"},
-]
+authors = [{ name = "humanlayer authors", email = "dexter@metalytics.dev" }]
 requires-python = "<4.0,>=3.10"
 dependencies = [
-    "pydantic<3.0.0,>=2.8.2",
-    "requests<3.0.0,>=2.32.3",
-    "python-slugify<9.0.0,>=8.0.4",
-    "python-dotenv<2.0.0,>=1.0.1",
-    "click<9.0.0,>=8.1.7",
-    "aiohttp<4.0.0,>=3.11.10",
+  "pydantic<3.0.0,>=2.8.2",
+  "requests<3.0.0,>=2.32.3",
+  "python-slugify<9.0.0,>=8.0.4",
+  "python-dotenv<2.0.0,>=1.0.1",
+  "click<9.0.0,>=8.1.7",
+  "aiohttp<4.0.0,>=3.11.10",
 ]
 name = "humanlayer"
 version = "0.7.8-alpha.1"
@@ -25,22 +23,22 @@ humanlayer = "humanlayer.cli.main:cli"
 
 [dependency-groups]
 dev = [
-    "pytest<8.0.0,>=7.2.0",
-    "pytest-cov<5.0.0,>=4.0.0",
-    "deptry<1.0.0,>=0.12.0",
-    "mypy<2.0.0,>=1.5.1",
-    "pre-commit<4.0.0,>=3.4.0",
-    "tox<5.0.0,>=4.11.1",
-    "ruff<1.0.0,>=0.5.6",
-    "types-requests<3.0.0.0,>=2.32.0.20240712",
-    "types-python-slugify<9.0.0.0,>=8.0.2.20240310",
-    "black<25.0.0,>=24.8.0",
-    "pytest-asyncio<0.22.0",
+  "pytest<8.0.0,>=7.2.0",
+  "pytest-cov<5.0.0,>=4.0.0",
+  "deptry<1.0.0,>=0.12.0",
+  "mypy<2.0.0,>=1.5.1",
+  "pre-commit<4.0.0,>=3.4.0",
+  "tox<5.0.0,>=4.11.1",
+  "ruff<1.0.0,>=0.5.6",
+  "types-requests<3.0.0.0,>=2.32.0.20240712",
+  "types-python-slugify<9.0.0.0,>=8.0.2.20240310",
+  "black<25.0.0,>=24.8.0",
+  "pytest-asyncio<0.22.0",
 ]
 docs = [
-    "mkdocs<2.0.0,>=1.4.2",
-    "mkdocs-material<10.0.0,>=9.2.7",
-    "mkdocstrings[python]<1.0.0,>=0.23.0",
+  "mkdocs<2.0.0,>=1.4.2",
+  "mkdocs-material<10.0.0,>=9.2.7",
+  "mkdocstrings[python]<1.0.0,>=0.23.0",
 ]
 
 [tool.pdm.build]


### PR DESCRIPTION
[model_validator](https://docs.pydantic.dev/latest/concepts/validators/#model-validators) decorated functions are meant to return self

this was throwing warnings on instantiation of `HumanLayerCloudConnection`

```python
/Users/nate/github.com/zzstoatzz/assistant/.venv/lib/python3.13/site-packages/humanlayer/core/approval.py:101: UserWarning: A custom validator is returning a value other than `self`.
Returning anything other than `self` from a top level model validator isn't supported when validating via `__init__`.
See the `model_validator` docs (https://docs.pydantic.dev/latest/concepts/validators/#model-validators) for more details.
```

also the diff in `docs` is from prettier that apparently got into main without being formatted

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/user-attachments/assets/79c1f6a2-aec4-486a-a716-71b2cf9380e5)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `post_validate()` in `HumanLayerCloudConnection` now returns `self` to resolve instantiation warnings.
> 
>   - **Behavior**:
>     - `post_validate()` in `HumanLayerCloudConnection` now returns `self` to comply with Pydantic `model_validator` requirements.
>     - Resolves warnings during instantiation of `HumanLayerCloudConnection`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for a08c8ad2cda9805fcc555d1ae6f34400e1416ec3. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->