### PR TITLE
wip npx humanlayer login

### DIFF
--- a/hlyr/src/commands/login.ts
+++ b/hlyr/src/commands/login.ts
@@ -1,0 +1,91 @@
+import chalk from 'chalk'
+import readline from 'readline'
+import { spawn } from 'child_process'
+import { loadConfigFile, saveConfigFile, getDefaultConfigPath } from '../config.js'
+
+interface LoginOptions {
+  apiBase?: string
+}
+
+export async function loginCommand(options: LoginOptions): Promise<void> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
+
+  const question = (prompt: string): Promise<string> => {
+    return new Promise(resolve => {
+      rl.question(prompt, resolve)
+    })
+  }
+
+  try {
+    const appUrl = process.env.HUMANLAYER_APP_URL || 'https://app.humanlayer.dev'
+    const loginUrl = `${appUrl}/cli-login`
+
+    console.log(chalk.blue('HumanLayer Login'))
+    console.log(chalk.gray(`To get your API token, visit: ${loginUrl}`))
+    console.log('')
+
+    // Try to open the URL in the default browser
+    const openBrowser = async (url: string) => {
+      const platform = process.platform
+      let command: string
+
+      if (platform === 'darwin') {
+        command = 'open'
+      } else if (platform === 'win32') {
+        command = 'start'
+      } else {
+        command = 'xdg-open'
+      }
+
+      try {
+        spawn(command, [url], { detached: true, stdio: 'ignore' }).unref()
+        console.log(chalk.green('Opening browser...'))
+      } catch (error) {
+        console.log(chalk.yellow(`Could not open browser automatically: ${error}`))
+      }
+    }
+
+    const browserPrompt = await question(
+      'Press Enter to open in default browser or ESC to continue manually: ',
+    )
+    if (browserPrompt !== '\u001b') {
+      // ESC key
+      await openBrowser(loginUrl)
+    }
+    console.log('')
+
+    const token = await question('Paste your API token: ')
+
+    if (!token.trim()) {
+      console.error(chalk.red('Error: No token provided'))
+      process.exit(1)
+    }
+
+    const configPath = getDefaultConfigPath()
+    console.log(chalk.yellow(`Token will be written to: ${configPath}`))
+
+    const proceed = await question('Continue? (y/N): ')
+    if (proceed.toLowerCase() !== 'y' && proceed.toLowerCase() !== 'yes') {
+      console.log(chalk.gray('Login cancelled'))
+      process.exit(0)
+    }
+
+    const existingConfig = loadConfigFile()
+    const newConfig = {
+      ...existingConfig,
+      api_token: token.trim(),
+      api_base_url: options.apiBase || 'https://api.humanlayer.dev',
+    }
+
+    saveConfigFile(newConfig)
+    console.log(chalk.green('Login successful!'))
+  } catch (error) {
+    console.error(chalk.red(`Error during login: ${error}`))
+    process.exit(1)
+  } finally {
+    rl.close()
+  }
+}

--- a/hlyr/src/config.ts
+++ b/hlyr/src/config.ts
@@ -9,6 +9,8 @@ dotenv.config()
 
 export type ConfigFile = {
   channel: ContactChannel
+  api_token?: string
+  api_base_url?: string
 }
 
 export function loadConfigFile(configFile?: string): ConfigFile {
@@ -96,4 +98,18 @@ export function buildContactChannel(options: any, config: ConfigFile) {
   }
 
   return contactChannel
+}
+
+export function saveConfigFile(config: ConfigFile, configFile?: string): void {
+  const configPath = configFile || path.join(process.env.HOME || '', '.humanlayer.json')
+
+  console.log(chalk.yellow(`Writing config to ${configPath}`))
+
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
+
+  console.log(chalk.green('Config saved successfully'))
+}
+
+export function getDefaultConfigPath(): string {
+  return path.join(process.env.HOME || '', '.humanlayer.json')
 }

--- a/hlyr/src/index.ts
+++ b/hlyr/src/index.ts
@@ -4,10 +4,17 @@ import { Command } from 'commander'
 import chalk from 'chalk'
 import { humanlayer } from 'humanlayer'
 import { loadConfigFile, buildContactChannel } from './config.js'
+import { loginCommand } from './commands/login.js'
 
 const program = new Command()
 
-program.name('humanlayer').description('HumanLayer, but on your command-line.').version('0.1.0')
+program.name('hlyr').description('HumanLayer, but on your command-line.').version('0.1.0')
+
+program
+  .command('login')
+  .description('Login to HumanLayer and save API token')
+  .option('--api-base <url>', 'API base URL', 'https://api.humanlayer.dev')
+  .action(loginCommand)
 
 program
   .command('contact_human')
@@ -20,7 +27,6 @@ program
   .option('--slack-blocks [boolean]', 'Use experimental Slack blocks', true)
   .option('--email-address <email>', 'Email address to contact')
   .option('--email-context <context>', 'Context about the email recipient')
-  .option('--config-file <file>', 'Path to config file')
   .action(async options => {
     let message = options.message
 
@@ -37,7 +43,7 @@ program
     }
 
     try {
-      const config = loadConfigFile(options.configFile)
+      const config = loadConfigFile()
       const contactChannel = buildContactChannel(options, config)
 
       if (Object.keys(contactChannel).length === 0) {


### PR DESCRIPTION
oustanding todos

- default to xdg config home or ~/.config/humanlayer/ instead of ~/.humanlayer.json
- if --config-file is set, store it there