### PR TITLE
some leftover hld tests failures

### DIFF
--- a/hld/daemon/daemon_integration_test.go
+++ b/hld/daemon/daemon_integration_test.go
@@ -5,7 +5,6 @@ package daemon
 
 import (
 	"context"
-	"github.com/humanlayer/humanlayer/hld/internal/testutil"
 	"net"
 	"os"
 	"os/exec"

--- a/hld/daemon/daemon_subscription_integration_test.go
+++ b/hld/daemon/daemon_subscription_integration_test.go
@@ -164,8 +164,11 @@ func TestDaemonSubscriptionIntegration(t *testing.T) {
 
 		// Make sure client 1 doesn't get resolved events
 		select {
-		case notification := <-eventChan1:
-			t.Errorf("Client 1 unexpectedly received event - Type: %q, Data: %+v", notification.Event.Type, notification.Event.Data)
+		case notification, ok := <-eventChan1:
+			if ok && notification.Event.Type != "" {
+				t.Errorf("Client 1 unexpectedly received event - Type: %q, Data: %+v", notification.Event.Type, notification.Event.Data)
+			}
+			// If channel is closed (!ok) or empty event, that's fine during cleanup
 		case <-time.After(100 * time.Millisecond):
 			// Expected - no event
 		}

--- a/hld/session/manager_test.go
+++ b/hld/session/manager_test.go
@@ -7,11 +7,12 @@ import (
 	"time"
 
 	claudecode "github.com/humanlayer/humanlayer/claudecode-go"
+	"github.com/humanlayer/humanlayer/hld/bus"
 	"go.uber.org/mock/gomock"
 )
 
 func TestNewManager(t *testing.T) {
-	var eventBus *bus.EventBus = nil // no bus for this test
+	var eventBus bus.EventBus = nil // no bus for this test
 	manager, err := NewManager(eventBus)
 
 	if err != nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix test failures in `hld` package by handling closed channels and adjusting event bus type in tests.
> 
>   - **Tests**:
>     - In `daemon_subscription_integration_test.go`, modify `TestDaemonSubscriptionIntegration` to handle closed channels by checking `ok` status and empty events.
>     - In `manager_test.go`, change `eventBus` type from `*bus.EventBus` to `bus.EventBus` in `TestNewManager`.
>   - **Imports**:
>     - Remove unused import `testutil` from `daemon_integration_test.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for a7ecd975ada3c453850100a8265440d638478693. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->