### PR TITLE
Expose conversation data via RPC

### DIFF
--- a/hld/client/client.go
+++ b/hld/client/client.go
@@ -286,6 +286,42 @@ func (c *client) SendDecision(callID, approvalType, decision, comment string) er
 	return nil
 }
 
+// GetConversation fetches the conversation history for a session
+func (c *client) GetConversation(sessionID string) (*rpc.GetConversationResponse, error) {
+	req := rpc.GetConversationRequest{
+		SessionID: sessionID,
+	}
+	var resp rpc.GetConversationResponse
+	if err := c.call("getConversation", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetConversationByClaudeSessionID fetches the conversation history by Claude session ID
+func (c *client) GetConversationByClaudeSessionID(claudeSessionID string) (*rpc.GetConversationResponse, error) {
+	req := rpc.GetConversationRequest{
+		ClaudeSessionID: claudeSessionID,
+	}
+	var resp rpc.GetConversationResponse
+	if err := c.call("getConversation", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetSessionState fetches the current state of a session
+func (c *client) GetSessionState(sessionID string) (*rpc.GetSessionStateResponse, error) {
+	req := rpc.GetSessionStateRequest{
+		SessionID: sessionID,
+	}
+	var resp rpc.GetSessionStateResponse
+	if err := c.call("getSessionState", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // Reconnect attempts to reconnect to the daemon
 func (c *client) Reconnect() error {
 	c.mu.Lock()

--- a/hld/client/types.go
+++ b/hld/client/types.go
@@ -24,6 +24,15 @@ type Client interface {
 	// SendDecision sends a decision (approve/deny/respond) for an approval
 	SendDecision(callID, approvalType, decision, comment string) error
 
+	// GetConversation fetches the conversation history for a session
+	GetConversation(sessionID string) (*rpc.GetConversationResponse, error)
+
+	// GetConversationByClaudeSessionID fetches the conversation history by Claude session ID
+	GetConversationByClaudeSessionID(claudeSessionID string) (*rpc.GetConversationResponse, error)
+
+	// GetSessionState fetches the current state of a session
+	GetSessionState(sessionID string) (*rpc.GetSessionStateResponse, error)
+
 	// Subscribe subscribes to events from the daemon
 	Subscribe(req rpc.SubscribeRequest) (<-chan rpc.EventNotification, error)
 

--- a/hld/daemon/daemon.go
+++ b/hld/daemon/daemon.go
@@ -152,7 +152,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	d.rpcServer.SetSubscriptionHandlers(subscriptionHandlers)
 
 	// Register session handlers
-	sessionHandlers := rpc.NewSessionHandlers(d.sessions)
+	sessionHandlers := rpc.NewSessionHandlers(d.sessions, d.store)
 	sessionHandlers.Register(d.rpcServer)
 
 	// Always register approval handlers (even without API key)

--- a/hld/daemon/daemon_conversation_integration_test.go
+++ b/hld/daemon/daemon_conversation_integration_test.go
@@ -1,0 +1,347 @@
+//go:build integration
+// +build integration
+
+package daemon
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/humanlayer/humanlayer/hld/client"
+	"github.com/humanlayer/humanlayer/hld/internal/testutil"
+	"github.com/humanlayer/humanlayer/hld/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetConversationIntegration tests fetching conversation data through the daemon
+func TestGetConversationIntegration(t *testing.T) {
+	socketPath := testutil.SocketPath(t, "conversation")
+
+	// Set environment for test
+	os.Setenv("HUMANLAYER_DAEMON_SOCKET", socketPath)
+	os.Setenv("HUMANLAYER_DATABASE_PATH", ":memory:") // Use in-memory database for tests
+	defer func() {
+		os.Unsetenv("HUMANLAYER_DAEMON_SOCKET")
+		os.Unsetenv("HUMANLAYER_DATABASE_PATH")
+	}()
+
+	// Create and start daemon
+	daemon, err := New()
+	require.NoError(t, err, "Failed to create daemon")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start daemon in background
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- daemon.Run(ctx)
+	}()
+
+	// Wait for daemon to be ready
+	deadline := time.Now().Add(5 * time.Second)
+	var daemonClient client.Client
+	for time.Now().Before(deadline) {
+		daemonClient, err = client.New(socketPath)
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.NoError(t, err, "Failed to connect to daemon")
+	defer daemonClient.Close()
+
+	// Verify daemon is healthy
+	err = daemonClient.Health()
+	require.NoError(t, err, "Daemon health check failed")
+
+	t.Run("GetConversation with mock data", func(t *testing.T) {
+		// Since we can't easily launch a real Claude session in tests,
+		// we'll directly insert test data into the store
+		ctx := context.Background()
+
+		// Create test session
+		sessionID := "test-session-1"
+		claudeSessionID := "claude-test-1"
+
+		session := &store.Session{
+			ID:              sessionID,
+			RunID:           "test-run-1",
+			ClaudeSessionID: claudeSessionID,
+			Query:           "Test query",
+			Status:          store.SessionStatusRunning,
+			CreatedAt:       time.Now(),
+			LastActivityAt:  time.Now(),
+		}
+
+		err := daemon.store.CreateSession(ctx, session)
+		require.NoError(t, err)
+
+		// Add conversation events
+		events := []*store.ConversationEvent{
+			{
+				SessionID:       sessionID,
+				ClaudeSessionID: claudeSessionID,
+				EventType:       store.EventTypeMessage,
+				Role:            "user",
+				Content:         "Hello Claude!",
+			},
+			{
+				SessionID:       sessionID,
+				ClaudeSessionID: claudeSessionID,
+				EventType:       store.EventTypeMessage,
+				Role:            "assistant",
+				Content:         "Hello! How can I help you today?",
+			},
+			{
+				SessionID:       sessionID,
+				ClaudeSessionID: claudeSessionID,
+				EventType:       store.EventTypeToolCall,
+				ToolID:          "tool-1",
+				ToolName:        "calculator",
+				ToolInputJSON:   `{"operation": "add", "a": 5, "b": 3}`,
+			},
+		}
+
+		for _, event := range events {
+			err := daemon.store.AddConversationEvent(ctx, event)
+			require.NoError(t, err)
+		}
+
+		// Test GetConversation by session ID
+		resp, err := daemonClient.GetConversation(sessionID)
+		require.NoError(t, err)
+		assert.Len(t, resp.Events, 3)
+		assert.Equal(t, "user", resp.Events[0].Role)
+		assert.Equal(t, "Hello Claude!", resp.Events[0].Content)
+		assert.Equal(t, "assistant", resp.Events[1].Role)
+		assert.Equal(t, "calculator", resp.Events[2].ToolName)
+
+		// Test GetConversation by Claude session ID
+		resp2, err := daemonClient.GetConversationByClaudeSessionID(claudeSessionID)
+		require.NoError(t, err)
+		assert.Equal(t, resp.Events, resp2.Events)
+	})
+
+	t.Run("GetSessionState", func(t *testing.T) {
+		// Create a completed session
+		sessionID := "test-session-2"
+		now := time.Now()
+		completedAt := now.Add(5 * time.Minute)
+		costUSD := 0.02
+		totalTokens := 500
+		durationMS := 300000
+
+		session := &store.Session{
+			ID:              sessionID,
+			RunID:           "test-run-2",
+			ClaudeSessionID: "claude-test-2",
+			Query:           "Write a poem",
+			Model:           "claude-3-sonnet",
+			Status:          store.SessionStatusRunning,
+			CreatedAt:       now,
+			LastActivityAt:  now,
+		}
+
+		err := daemon.store.CreateSession(context.Background(), session)
+		require.NoError(t, err)
+
+		// Update the session with completion data (mimicking what happens in real usage)
+		statusCompleted := store.SessionStatusCompleted
+		update := store.SessionUpdate{
+			Status:         &statusCompleted,
+			LastActivityAt: &completedAt,
+			CompletedAt:    &completedAt,
+			CostUSD:        &costUSD,
+			TotalTokens:    &totalTokens,
+			DurationMS:     &durationMS,
+		}
+		err = daemon.store.UpdateSession(context.Background(), sessionID, update)
+		require.NoError(t, err)
+
+		// Verify the session was stored correctly by reading it back directly
+		storedSession, err := daemon.store.GetSession(context.Background(), sessionID)
+		require.NoError(t, err)
+		require.NotNil(t, storedSession.CostUSD, "CostUSD should not be nil")
+		require.NotNil(t, storedSession.TotalTokens, "TotalTokens should not be nil")
+		require.NotNil(t, storedSession.CompletedAt, "CompletedAt should not be nil")
+		t.Logf("Stored session - CostUSD: %v, TotalTokens: %v",
+			*storedSession.CostUSD, *storedSession.TotalTokens)
+
+		// Get session state via RPC
+		resp, err := daemonClient.GetSessionState(sessionID)
+		require.NoError(t, err)
+		assert.Equal(t, sessionID, resp.Session.ID)
+		assert.Equal(t, "test-run-2", resp.Session.RunID)
+		assert.Equal(t, "claude-test-2", resp.Session.ClaudeSessionID)
+		assert.Equal(t, store.SessionStatusCompleted, resp.Session.Status)
+		assert.Equal(t, "Write a poem", resp.Session.Query)
+		assert.Equal(t, "claude-3-sonnet", resp.Session.Model)
+
+		// Check optional fields
+		assert.InDelta(t, 0.02, resp.Session.CostUSD, 0.001)
+		assert.Equal(t, 500, resp.Session.TotalTokens)
+		assert.Equal(t, 300000, resp.Session.DurationMS)
+		assert.NotEmpty(t, resp.Session.CompletedAt)
+	})
+
+	t.Run("GetConversation for nonexistent session", func(t *testing.T) {
+		// When a session doesn't exist, GetSessionConversation returns an error
+		// because it needs to look up the claude_session_id first
+		_, err := daemonClient.GetConversation("nonexistent-session")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get conversation")
+	})
+
+	t.Run("GetSessionState for nonexistent session", func(t *testing.T) {
+		_, err := daemonClient.GetSessionState("nonexistent-session")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get session")
+	})
+
+	// Test with approval correlation
+	t.Run("GetConversation with approval", func(t *testing.T) {
+		sessionID := "test-session-3"
+		claudeSessionID := "claude-test-3"
+
+		// Create session
+		session := &store.Session{
+			ID:              sessionID,
+			RunID:           "test-run-3",
+			ClaudeSessionID: claudeSessionID,
+			Query:           "Delete important file",
+			Status:          store.SessionStatusRunning,
+			CreatedAt:       time.Now(),
+			LastActivityAt:  time.Now(),
+		}
+		err := daemon.store.CreateSession(context.Background(), session)
+		require.NoError(t, err)
+
+		// Add tool call with approval
+		event := &store.ConversationEvent{
+			SessionID:       sessionID,
+			ClaudeSessionID: claudeSessionID,
+			EventType:       store.EventTypeToolCall,
+			ToolID:          "tool-2",
+			ToolName:        "file_delete",
+			ToolInputJSON:   `{"path": "/important/file.txt"}`,
+			ApprovalStatus:  store.ApprovalStatusPending,
+			ApprovalID:      "approval-123",
+		}
+		err = daemon.store.AddConversationEvent(context.Background(), event)
+		require.NoError(t, err)
+
+		// Get conversation
+		resp, err := daemonClient.GetConversation(sessionID)
+		require.NoError(t, err)
+		assert.Len(t, resp.Events, 1)
+		assert.Equal(t, "file_delete", resp.Events[0].ToolName)
+		assert.Equal(t, store.ApprovalStatusPending, resp.Events[0].ApprovalStatus)
+		assert.Equal(t, "approval-123", resp.Events[0].ApprovalID)
+	})
+
+	// Shutdown daemon
+	cancel()
+
+	// Wait for daemon to exit
+	select {
+	case err := <-errCh:
+		assert.NoError(t, err, "Daemon exited with error")
+	case <-time.After(5 * time.Second):
+		t.Error("Daemon did not exit in time")
+	}
+}
+
+// TestConversationRealtime tests real-time updates to conversations
+func TestConversationRealtime(t *testing.T) {
+	socketPath := testutil.SocketPath(t, "realtime")
+
+	// Set environment for test
+	os.Setenv("HUMANLAYER_DAEMON_SOCKET", socketPath)
+	os.Setenv("HUMANLAYER_DATABASE_PATH", ":memory:")
+	defer func() {
+		os.Unsetenv("HUMANLAYER_DAEMON_SOCKET")
+		os.Unsetenv("HUMANLAYER_DATABASE_PATH")
+	}()
+
+	// Create and start daemon
+	daemon, err := New()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start daemon
+	go daemon.Run(ctx)
+
+	// Wait for daemon to be ready
+	deadline := time.Now().Add(5 * time.Second)
+	var daemonClient client.Client
+	for time.Now().Before(deadline) {
+		daemonClient, err = client.New(socketPath)
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.NoError(t, err)
+	defer daemonClient.Close()
+
+	// Create a session
+	sessionID := "realtime-session"
+	claudeSessionID := "claude-realtime"
+
+	session := &store.Session{
+		ID:              sessionID,
+		RunID:           "realtime-run",
+		ClaudeSessionID: claudeSessionID,
+		Query:           "Realtime test",
+		Status:          store.SessionStatusRunning,
+		CreatedAt:       time.Now(),
+		LastActivityAt:  time.Now(),
+	}
+	err = daemon.store.CreateSession(context.Background(), session)
+	require.NoError(t, err)
+
+	// Initially empty
+	resp, err := daemonClient.GetConversation(sessionID)
+	require.NoError(t, err)
+	assert.Len(t, resp.Events, 0)
+
+	// Add first event
+	event1 := &store.ConversationEvent{
+		SessionID:       sessionID,
+		ClaudeSessionID: claudeSessionID,
+		EventType:       store.EventTypeMessage,
+		Role:            "user",
+		Content:         "First message",
+	}
+	err = daemon.store.AddConversationEvent(context.Background(), event1)
+	require.NoError(t, err)
+
+	// Check conversation has one event
+	resp, err = daemonClient.GetConversation(sessionID)
+	require.NoError(t, err)
+	assert.Len(t, resp.Events, 1)
+	assert.Equal(t, "First message", resp.Events[0].Content)
+
+	// Add more events
+	event2 := &store.ConversationEvent{
+		SessionID:       sessionID,
+		ClaudeSessionID: claudeSessionID,
+		EventType:       store.EventTypeMessage,
+		Role:            "assistant",
+		Content:         "Response message",
+	}
+	err = daemon.store.AddConversationEvent(context.Background(), event2)
+	require.NoError(t, err)
+
+	// Check conversation has two events
+	resp, err = daemonClient.GetConversation(sessionID)
+	require.NoError(t, err)
+	assert.Len(t, resp.Events, 2)
+	assert.Equal(t, "Response message", resp.Events[1].Content)
+}

--- a/hld/rpc/handlers.go
+++ b/hld/rpc/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	claudecode "github.com/humanlayer/humanlayer/claudecode-go"
 	"github.com/humanlayer/humanlayer/hld/session"
@@ -162,7 +163,7 @@ func (h *SessionHandlers) HandleGetConversation(ctx context.Context, params json
 			ClaudeSessionID:   event.ClaudeSessionID,
 			Sequence:          event.Sequence,
 			EventType:         event.EventType,
-			CreatedAt:         event.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			CreatedAt:         event.CreatedAt.Format(time.RFC3339),
 			Role:              event.Role,
 			Content:           event.Content,
 			ToolID:            event.ToolID,
@@ -208,14 +209,14 @@ func (h *SessionHandlers) HandleGetSessionState(ctx context.Context, params json
 		Query:           session.Query,
 		Model:           session.Model,
 		WorkingDir:      session.WorkingDir,
-		CreatedAt:       session.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-		LastActivityAt:  session.LastActivityAt.Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt:       session.CreatedAt.Format(time.RFC3339),
+		LastActivityAt:  session.LastActivityAt.Format(time.RFC3339),
 		ErrorMessage:    session.ErrorMessage,
 	}
 
 	// Set optional fields
 	if session.CompletedAt != nil {
-		state.CompletedAt = session.CompletedAt.Format("2006-01-02T15:04:05Z07:00")
+		state.CompletedAt = session.CompletedAt.Format(time.RFC3339)
 	}
 	if session.CostUSD != nil {
 		state.CostUSD = *session.CostUSD

--- a/hld/rpc/handlers.go
+++ b/hld/rpc/handlers.go
@@ -7,17 +7,20 @@ import (
 
 	claudecode "github.com/humanlayer/humanlayer/claudecode-go"
 	"github.com/humanlayer/humanlayer/hld/session"
+	"github.com/humanlayer/humanlayer/hld/store"
 )
 
 // SessionHandlers provides RPC handlers for session management
 type SessionHandlers struct {
 	manager session.SessionManager
+	store   store.ConversationStore
 }
 
 // NewSessionHandlers creates new session RPC handlers
-func NewSessionHandlers(manager session.SessionManager) *SessionHandlers {
+func NewSessionHandlers(manager session.SessionManager, store store.ConversationStore) *SessionHandlers {
 	return &SessionHandlers{
 		manager: manager,
+		store:   store,
 	}
 }
 
@@ -123,8 +126,116 @@ func (h *SessionHandlers) HandleListSessions(ctx context.Context, params json.Ra
 	}, nil
 }
 
+// HandleGetConversation handles the GetConversation RPC method
+func (h *SessionHandlers) HandleGetConversation(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	var req GetConversationRequest
+	if err := json.Unmarshal(params, &req); err != nil {
+		return nil, fmt.Errorf("invalid request: %w", err)
+	}
+
+	// Validate that either SessionID or ClaudeSessionID is provided
+	if req.SessionID == "" && req.ClaudeSessionID == "" {
+		return nil, fmt.Errorf("either session_id or claude_session_id is required")
+	}
+
+	var events []*store.ConversationEvent
+	var err error
+
+	if req.ClaudeSessionID != "" {
+		// Get conversation by Claude session ID
+		events, err = h.store.GetConversation(ctx, req.ClaudeSessionID)
+	} else {
+		// Get conversation by session ID
+		events, err = h.store.GetSessionConversation(ctx, req.SessionID)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get conversation: %w", err)
+	}
+
+	// Convert store events to RPC events
+	rpcEvents := make([]ConversationEvent, len(events))
+	for i, event := range events {
+		rpcEvents[i] = ConversationEvent{
+			ID:                event.ID,
+			SessionID:         event.SessionID,
+			ClaudeSessionID:   event.ClaudeSessionID,
+			Sequence:          event.Sequence,
+			EventType:         event.EventType,
+			CreatedAt:         event.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			Role:              event.Role,
+			Content:           event.Content,
+			ToolID:            event.ToolID,
+			ToolName:          event.ToolName,
+			ToolInputJSON:     event.ToolInputJSON,
+			ToolResultForID:   event.ToolResultForID,
+			ToolResultContent: event.ToolResultContent,
+			IsCompleted:       event.IsCompleted,
+			ApprovalStatus:    event.ApprovalStatus,
+			ApprovalID:        event.ApprovalID,
+		}
+	}
+
+	return &GetConversationResponse{
+		Events: rpcEvents,
+	}, nil
+}
+
+// HandleGetSessionState handles the GetSessionState RPC method
+func (h *SessionHandlers) HandleGetSessionState(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	var req GetSessionStateRequest
+	if err := json.Unmarshal(params, &req); err != nil {
+		return nil, fmt.Errorf("invalid request: %w", err)
+	}
+
+	// Validate required fields
+	if req.SessionID == "" {
+		return nil, fmt.Errorf("session_id is required")
+	}
+
+	// Get session from store
+	session, err := h.store.GetSession(ctx, req.SessionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get session: %w", err)
+	}
+
+	// Convert to RPC session state
+	state := SessionState{
+		ID:              session.ID,
+		RunID:           session.RunID,
+		ClaudeSessionID: session.ClaudeSessionID,
+		Status:          session.Status,
+		Query:           session.Query,
+		Model:           session.Model,
+		WorkingDir:      session.WorkingDir,
+		CreatedAt:       session.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		LastActivityAt:  session.LastActivityAt.Format("2006-01-02T15:04:05Z07:00"),
+		ErrorMessage:    session.ErrorMessage,
+	}
+
+	// Set optional fields
+	if session.CompletedAt != nil {
+		state.CompletedAt = session.CompletedAt.Format("2006-01-02T15:04:05Z07:00")
+	}
+	if session.CostUSD != nil {
+		state.CostUSD = *session.CostUSD
+	}
+	if session.TotalTokens != nil {
+		state.TotalTokens = *session.TotalTokens
+	}
+	if session.DurationMS != nil {
+		state.DurationMS = *session.DurationMS
+	}
+
+	return &GetSessionStateResponse{
+		Session: state,
+	}, nil
+}
+
 // Register registers all session handlers with the RPC server
 func (h *SessionHandlers) Register(server *Server) {
 	server.Register("launchSession", h.HandleLaunchSession)
 	server.Register("listSessions", h.HandleListSessions)
+	server.Register("getConversation", h.HandleGetConversation)
+	server.Register("getSessionState", h.HandleGetSessionState)
 }

--- a/hld/rpc/handlers_test.go
+++ b/hld/rpc/handlers_test.go
@@ -1,0 +1,239 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/humanlayer/humanlayer/hld/session"
+	"github.com/humanlayer/humanlayer/hld/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestHandleGetConversation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockManager := session.NewMockSessionManager(ctrl)
+	mockStore := store.NewMockConversationStore(ctrl)
+
+	handlers := NewSessionHandlers(mockManager, mockStore)
+
+	t.Run("get conversation by session ID", func(t *testing.T) {
+		sessionID := "sess-123"
+		claudeSessionID := "claude-456"
+
+		// Mock data
+		events := []*store.ConversationEvent{
+			{
+				ID:              1,
+				SessionID:       sessionID,
+				ClaudeSessionID: claudeSessionID,
+				Sequence:        1,
+				EventType:       store.EventTypeMessage,
+				CreatedAt:       time.Now(),
+				Role:            "assistant",
+				Content:         "Hello! How can I help you?",
+			},
+			{
+				ID:              2,
+				SessionID:       sessionID,
+				ClaudeSessionID: claudeSessionID,
+				Sequence:        2,
+				EventType:       store.EventTypeToolCall,
+				CreatedAt:       time.Now(),
+				ToolID:          "tool-1",
+				ToolName:        "calculator",
+				ToolInputJSON:   `{"operation": "add", "a": 1, "b": 2}`,
+			},
+		}
+
+		mockStore.EXPECT().
+			GetSessionConversation(gomock.Any(), sessionID).
+			Return(events, nil)
+
+		req := GetConversationRequest{
+			SessionID: sessionID,
+		}
+		reqJSON, _ := json.Marshal(req)
+
+		result, err := handlers.HandleGetConversation(context.Background(), reqJSON)
+		require.NoError(t, err)
+
+		resp, ok := result.(*GetConversationResponse)
+		require.True(t, ok)
+		assert.Len(t, resp.Events, 2)
+		assert.Equal(t, "assistant", resp.Events[0].Role)
+		assert.Equal(t, "Hello! How can I help you?", resp.Events[0].Content)
+		assert.Equal(t, "calculator", resp.Events[1].ToolName)
+	})
+
+	t.Run("get conversation by Claude session ID", func(t *testing.T) {
+		claudeSessionID := "claude-456"
+
+		events := []*store.ConversationEvent{
+			{
+				ID:              1,
+				SessionID:       "sess-123",
+				ClaudeSessionID: claudeSessionID,
+				Sequence:        1,
+				EventType:       store.EventTypeMessage,
+				CreatedAt:       time.Now(),
+				Role:            "user",
+				Content:         "What is 2+2?",
+			},
+		}
+
+		mockStore.EXPECT().
+			GetConversation(gomock.Any(), claudeSessionID).
+			Return(events, nil)
+
+		req := GetConversationRequest{
+			ClaudeSessionID: claudeSessionID,
+		}
+		reqJSON, _ := json.Marshal(req)
+
+		result, err := handlers.HandleGetConversation(context.Background(), reqJSON)
+		require.NoError(t, err)
+
+		resp, ok := result.(*GetConversationResponse)
+		require.True(t, ok)
+		assert.Len(t, resp.Events, 1)
+		assert.Equal(t, "user", resp.Events[0].Role)
+	})
+
+	t.Run("missing both session IDs", func(t *testing.T) {
+		req := GetConversationRequest{}
+		reqJSON, _ := json.Marshal(req)
+
+		_, err := handlers.HandleGetConversation(context.Background(), reqJSON)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "either session_id or claude_session_id is required")
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		_, err := handlers.HandleGetConversation(context.Background(), []byte(`invalid json`))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid request")
+	})
+}
+
+func TestHandleGetSessionState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockManager := session.NewMockSessionManager(ctrl)
+	mockStore := store.NewMockConversationStore(ctrl)
+
+	handlers := NewSessionHandlers(mockManager, mockStore)
+
+	t.Run("successful get session state", func(t *testing.T) {
+		sessionID := "sess-123"
+		now := time.Now()
+		completedAt := now.Add(10 * time.Minute)
+		costUSD := 0.05
+		totalTokens := 1500
+		durationMS := 600000
+
+		dbSession := &store.Session{
+			ID:              sessionID,
+			RunID:           "run-456",
+			ClaudeSessionID: "claude-789",
+			Status:          store.SessionStatusCompleted,
+			Query:           "Help me write a function",
+			Model:           "claude-3-opus",
+			WorkingDir:      "/home/user/project",
+			CreatedAt:       now,
+			LastActivityAt:  completedAt,
+			CompletedAt:     &completedAt,
+			CostUSD:         &costUSD,
+			TotalTokens:     &totalTokens,
+			DurationMS:      &durationMS,
+			ErrorMessage:    "",
+		}
+
+		mockStore.EXPECT().
+			GetSession(gomock.Any(), sessionID).
+			Return(dbSession, nil)
+
+		req := GetSessionStateRequest{
+			SessionID: sessionID,
+		}
+		reqJSON, _ := json.Marshal(req)
+
+		result, err := handlers.HandleGetSessionState(context.Background(), reqJSON)
+		require.NoError(t, err)
+
+		resp, ok := result.(*GetSessionStateResponse)
+		require.True(t, ok)
+		assert.Equal(t, sessionID, resp.Session.ID)
+		assert.Equal(t, "run-456", resp.Session.RunID)
+		assert.Equal(t, "claude-789", resp.Session.ClaudeSessionID)
+		assert.Equal(t, store.SessionStatusCompleted, resp.Session.Status)
+		assert.Equal(t, 0.05, resp.Session.CostUSD)
+		assert.Equal(t, 1500, resp.Session.TotalTokens)
+		assert.Equal(t, 600000, resp.Session.DurationMS)
+		assert.NotEmpty(t, resp.Session.CompletedAt)
+	})
+
+	t.Run("session with error", func(t *testing.T) {
+		sessionID := "sess-error"
+		now := time.Now()
+
+		dbSession := &store.Session{
+			ID:             sessionID,
+			RunID:          "run-error",
+			Status:         store.SessionStatusFailed,
+			Query:          "Failed query",
+			CreatedAt:      now,
+			LastActivityAt: now,
+			ErrorMessage:   "Connection timeout",
+		}
+
+		mockStore.EXPECT().
+			GetSession(gomock.Any(), sessionID).
+			Return(dbSession, nil)
+
+		req := GetSessionStateRequest{
+			SessionID: sessionID,
+		}
+		reqJSON, _ := json.Marshal(req)
+
+		result, err := handlers.HandleGetSessionState(context.Background(), reqJSON)
+		require.NoError(t, err)
+
+		resp, ok := result.(*GetSessionStateResponse)
+		require.True(t, ok)
+		assert.Equal(t, store.SessionStatusFailed, resp.Session.Status)
+		assert.Equal(t, "Connection timeout", resp.Session.ErrorMessage)
+	})
+
+	t.Run("missing session ID", func(t *testing.T) {
+		req := GetSessionStateRequest{}
+		reqJSON, _ := json.Marshal(req)
+
+		_, err := handlers.HandleGetSessionState(context.Background(), reqJSON)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "session_id is required")
+	})
+
+	t.Run("session not found", func(t *testing.T) {
+		sessionID := "nonexistent"
+
+		mockStore.EXPECT().
+			GetSession(gomock.Any(), sessionID).
+			Return(nil, assert.AnError)
+
+		req := GetSessionStateRequest{
+			SessionID: sessionID,
+		}
+		reqJSON, _ := json.Marshal(req)
+
+		_, err := handlers.HandleGetSessionState(context.Background(), reqJSON)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get session")
+	})
+}

--- a/hld/rpc/types.go
+++ b/hld/rpc/types.go
@@ -8,3 +8,70 @@ type HealthCheckResponse struct {
 	Status  string `json:"status"`
 	Version string `json:"version"`
 }
+
+// GetConversationRequest is the request for fetching conversation history
+type GetConversationRequest struct {
+	SessionID       string `json:"session_id,omitempty"`        // Get by session ID
+	ClaudeSessionID string `json:"claude_session_id,omitempty"` // Get by Claude session ID
+}
+
+// ConversationEvent represents a single event in the conversation
+type ConversationEvent struct {
+	ID              int64  `json:"id"`
+	SessionID       string `json:"session_id"`
+	ClaudeSessionID string `json:"claude_session_id"`
+	Sequence        int    `json:"sequence"`
+	EventType       string `json:"event_type"` // 'message', 'tool_call', 'tool_result', 'system'
+	CreatedAt       string `json:"created_at"` // ISO 8601 timestamp
+
+	// Message fields
+	Role    string `json:"role,omitempty"` // user, assistant, system
+	Content string `json:"content,omitempty"`
+
+	// Tool call fields
+	ToolID        string `json:"tool_id,omitempty"`
+	ToolName      string `json:"tool_name,omitempty"`
+	ToolInputJSON string `json:"tool_input_json,omitempty"`
+
+	// Tool result fields
+	ToolResultForID   string `json:"tool_result_for_id,omitempty"`
+	ToolResultContent string `json:"tool_result_content,omitempty"`
+
+	// Approval tracking
+	IsCompleted    bool   `json:"is_completed"`
+	ApprovalStatus string `json:"approval_status,omitempty"` // NULL, 'pending', 'approved', 'denied'
+	ApprovalID     string `json:"approval_id,omitempty"`
+}
+
+// GetConversationResponse is the response for fetching conversation history
+type GetConversationResponse struct {
+	Events []ConversationEvent `json:"events"`
+}
+
+// GetSessionStateRequest is the request for fetching session state
+type GetSessionStateRequest struct {
+	SessionID string `json:"session_id"`
+}
+
+// SessionState represents the current state of a session
+type SessionState struct {
+	ID              string  `json:"id"`
+	RunID           string  `json:"run_id"`
+	ClaudeSessionID string  `json:"claude_session_id,omitempty"`
+	Status          string  `json:"status"` // starting, running, completed, failed, waiting_input
+	Query           string  `json:"query"`
+	Model           string  `json:"model,omitempty"`
+	WorkingDir      string  `json:"working_dir,omitempty"`
+	CreatedAt       string  `json:"created_at"`
+	LastActivityAt  string  `json:"last_activity_at"`
+	CompletedAt     string  `json:"completed_at,omitempty"`
+	ErrorMessage    string  `json:"error_message,omitempty"`
+	CostUSD         float64 `json:"cost_usd,omitempty"`
+	TotalTokens     int     `json:"total_tokens,omitempty"`
+	DurationMS      int     `json:"duration_ms,omitempty"`
+}
+
+// GetSessionStateResponse is the response for fetching session state
+type GetSessionStateResponse struct {
+	Session SessionState `json:"session"`
+}


### PR DESCRIPTION


**What I did**

- ✅ Added RPC types in `hld/rpc/types.go` for GetConversation and GetSessionState requests/responses
- ✅ Created `ConversationEvent` and `SessionState` structs with all fields from store layer
- ✅ Implemented `HandleGetConversation` in `hld/rpc/handlers.go` supporting both session ID and Claude session ID lookups
- ✅ Implemented `HandleGetSessionState` returning full session metadata including optional fields
- ✅ Updated `SessionHandlers` to accept store dependency via `NewSessionHandlers(manager, store)`
- ✅ Added client methods: `GetConversation()`, `GetConversationByClaudeSessionID()`, and `GetSessionState()`
- ✅ Registered new handlers in the `Register()` method
- ✅ Unit tests with mocked store verify handler logic and error cases
- ✅ Integration tests use real daemon/client/store stack with in-memory SQLite


**How I did it**

<!--
Describe the work you did, tests you ran, changes you made, etc
-->

- [x] I have ensured `make check test` passes

**How to verify it**

<!--
Describe how to test this, which examples to run to verify it, or anything
else that would be helpful to folks exploring this work
-->

**Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
**- A picture of a cute animal (not mandatory but encouraged)**

-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Expose conversation data and session state via new RPC methods with supporting client methods and tests.
> 
>   - **Behavior**:
>     - Implemented `HandleGetConversation` and `HandleGetSessionState` in `handlers.go` to expose conversation data and session state via RPC.
>     - Supports fetching conversation by `session_id` or `claude_session_id`.
>     - Returns full session metadata including optional fields.
>   - **Client Methods**:
>     - Added `GetConversation()`, `GetConversationByClaudeSessionID()`, and `GetSessionState()` in `client.go`.
>   - **Data Structures**:
>     - Added `GetConversationRequest`, `GetConversationResponse`, `GetSessionStateRequest`, and `GetSessionStateResponse` in `types.go`.
>     - Defined `ConversationEvent` and `SessionState` structs.
>   - **Tests**:
>     - Added unit tests in `handlers_test.go` for new handlers.
>     - Added integration tests in `daemon_conversation_integration_test.go` for end-to-end validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 71a91b8c8de97fd4e81aff9d8b30d3993586f679. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->