### PR TITLE
Add multi-turn conversation support with session continuation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,44 +1,13 @@
-<!--
-Please make sure you've read and understood our contributing guidelines;
-https://github.com/humanlayer/humanlayer/blob/master/CONTRIBUTING.md
+## What problem(s) was I solving?
 
-If this is a bug fix, make sure your description includes "fixes #xxxx", or
-"closes #xxxx"
+## What user-facing changes did I ship?
 
-Please provide the following information:
+## How I implemented it
 
--->
-
-**What I did**
-
-<!--
-A succint description of the user-facing changes, at most 2-3 bullet points.
-Less about the code changes that happened, more about the outcomes this work drives
--->
-
-**How I did it**
-
-<!--
-Describe the work you did, tests you ran, changes you made, etc
--->
+## How to verify it
 
 - [ ] I have ensured `make check test` passes
 
-**How to verify it**
+## Description for the changelog
 
-<!--
-Describe how to test this, which examples to run to verify it, or anything
-else that would be helpful to folks exploring this work
--->
-
-**Description for the changelog**
-
-<!--
-Write a short (one line) summary that describes the changes in this
-pull request for inclusion in the changelog:
--->
-
-<!--
-**- A picture of a cute animal (not mandatory but encouraged)**
-
--->
+## A picture of a cute animal (not mandatory but encouraged)

--- a/claudecode-go/types.go
+++ b/claudecode-go/types.go
@@ -2,6 +2,7 @@ package claudecode
 
 import (
 	"os/exec"
+	"sync"
 	"time"
 )
 
@@ -140,5 +141,24 @@ type Session struct {
 	cmd    *exec.Cmd
 	done   chan struct{}
 	result *Result
-	err    error
+
+	// Thread-safe error handling
+	mu  sync.RWMutex
+	err error
+}
+
+// SetError safely sets the error
+func (s *Session) SetError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err == nil {
+		s.err = err
+	}
+}
+
+// Error safely gets the error
+func (s *Session) Error() error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.err
 }

--- a/hld/client/client.go
+++ b/hld/client/client.go
@@ -256,6 +256,15 @@ func (c *client) ListSessions() (*rpc.ListSessionsResponse, error) {
 	return &resp, nil
 }
 
+// ContinueSession continues an existing completed session with a new query
+func (c *client) ContinueSession(req rpc.ContinueSessionRequest) (*rpc.ContinueSessionResponse, error) {
+	var resp rpc.ContinueSessionResponse
+	if err := c.call("continueSession", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // FetchApprovals fetches pending approvals from the daemon
 func (c *client) FetchApprovals(sessionID string) ([]approval.PendingApproval, error) {
 	req := rpc.FetchApprovalsRequest{

--- a/hld/client/types.go
+++ b/hld/client/types.go
@@ -18,6 +18,9 @@ type Client interface {
 	// ListSessions lists all active sessions
 	ListSessions() (*rpc.ListSessionsResponse, error)
 
+	// ContinueSession continues an existing completed session with a new query
+	ContinueSession(req rpc.ContinueSessionRequest) (*rpc.ContinueSessionResponse, error)
+
 	// FetchApprovals fetches pending approvals from the daemon
 	FetchApprovals(sessionID string) ([]approval.PendingApproval, error)
 

--- a/hld/daemon/daemon_continue_session_integration_test.go
+++ b/hld/daemon/daemon_continue_session_integration_test.go
@@ -1,0 +1,515 @@
+package daemon
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/humanlayer/humanlayer/hld/bus"
+	"github.com/humanlayer/humanlayer/hld/config"
+	"github.com/humanlayer/humanlayer/hld/internal/testutil"
+	"github.com/humanlayer/humanlayer/hld/rpc"
+	"github.com/humanlayer/humanlayer/hld/session"
+	"github.com/humanlayer/humanlayer/hld/store"
+)
+
+func TestIntegrationContinueSession(t *testing.T) {
+	// Use test-specific socket path
+	socketPath := testutil.SocketPath(t, "continue-session")
+
+	// Create daemon components
+	eventBus := bus.NewEventBus()
+	sqliteStore, err := store.NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+	defer func() { _ = sqliteStore.Close() }()
+
+	sessionManager, err := session.NewManager(eventBus, sqliteStore)
+	if err != nil {
+		t.Fatalf("Failed to create session manager: %v", err)
+	}
+
+	// Create daemon
+	d := &Daemon{
+		socketPath: socketPath,
+		config:     &config.Config{SocketPath: socketPath, DatabasePath: ":memory:"},
+		eventBus:   eventBus,
+		store:      sqliteStore,
+		sessions:   sessionManager,
+		rpcServer:  rpc.NewServer(),
+	}
+
+	// Register RPC handlers
+	sessionHandlers := rpc.NewSessionHandlers(sessionManager, sqliteStore)
+	sessionHandlers.Register(d.rpcServer)
+
+	// Start daemon
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		if err := d.Run(ctx); err != nil {
+			t.Logf("daemon run error: %v", err)
+		}
+	}()
+
+	// Wait for daemon to be ready
+	time.Sleep(200 * time.Millisecond)
+
+	// Create helper function to send RPC requests
+	sendRPC := func(t *testing.T, method string, params interface{}) (json.RawMessage, error) {
+		conn, err := net.Dial("unix", socketPath)
+		if err != nil {
+			t.Fatalf("failed to connect to daemon: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		request := map[string]interface{}{
+			"jsonrpc": "2.0",
+			"method":  method,
+			"params":  params,
+			"id":      1,
+		}
+
+		data, err := json.Marshal(request)
+		if err != nil {
+			t.Fatalf("failed to marshal request: %v", err)
+		}
+
+		if _, err := conn.Write(append(data, '\n')); err != nil {
+			t.Fatalf("failed to write request: %v", err)
+		}
+
+		scanner := bufio.NewScanner(conn)
+		if !scanner.Scan() {
+			t.Fatal("no response received")
+		}
+
+		var response map[string]interface{}
+		if err := json.Unmarshal(scanner.Bytes(), &response); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if errObj, ok := response["error"]; ok {
+			if errMap, ok := errObj.(map[string]interface{}); ok {
+				if msg, ok := errMap["message"].(string); ok {
+					return nil, fmt.Errorf("%s", msg)
+				}
+			}
+			return nil, fmt.Errorf("RPC error: %v", errObj)
+		}
+
+		if result, ok := response["result"]; ok {
+			resultBytes, err := json.Marshal(result)
+			if err != nil {
+				t.Fatalf("failed to marshal result: %v", err)
+			}
+			return resultBytes, nil
+		}
+
+		return nil, fmt.Errorf("no result in response")
+	}
+
+	t.Run("ContinueSession_RequiresCompletedParent", func(t *testing.T) {
+		// Create a parent session that's still running
+		parentSessionID := "parent-running"
+		parentSession := &store.Session{
+			ID:              parentSessionID,
+			RunID:           "run-parent",
+			ClaudeSessionID: "claude-parent",
+			Status:          store.SessionStatusRunning, // Not completed
+			Query:           "original query",
+			CreatedAt:       time.Now(),
+			LastActivityAt:  time.Now(),
+		}
+
+		// Insert parent session directly into database
+		if err := d.store.CreateSession(ctx, parentSession); err != nil {
+			t.Fatalf("Failed to create parent session: %v", err)
+		}
+
+		// Try to continue the running session
+		req := rpc.ContinueSessionRequest{
+			SessionID: parentSessionID,
+			Query:     "continue this",
+		}
+
+		_, err := sendRPC(t, "continueSession", req)
+		if err == nil {
+			t.Error("Expected error when continuing running session")
+		}
+		if err.Error() != "cannot continue session with status running (must be completed)" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("ContinueSession_RequiresClaudeSessionID", func(t *testing.T) {
+		// Create a parent session without claude_session_id
+		parentSessionID := "parent-no-claude"
+		parentSession := &store.Session{
+			ID:              parentSessionID,
+			RunID:           "run-no-claude",
+			ClaudeSessionID: "", // Missing
+			Status:          store.SessionStatusCompleted,
+			Query:           "original query",
+			CreatedAt:       time.Now(),
+			LastActivityAt:  time.Now(),
+			CompletedAt:     &time.Time{},
+		}
+
+		// Insert parent session
+		if err := d.store.CreateSession(ctx, parentSession); err != nil {
+			t.Fatalf("Failed to create parent session: %v", err)
+		}
+
+		// Try to continue without claude_session_id
+		req := rpc.ContinueSessionRequest{
+			SessionID: parentSessionID,
+			Query:     "continue this",
+		}
+
+		_, err := sendRPC(t, "continueSession", req)
+		if err == nil {
+			t.Error("Expected error when continuing session without claude_session_id")
+		}
+		if err.Error() != "parent session missing claude_session_id (cannot resume)" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("ContinueSession_CreatesChildSession", func(t *testing.T) {
+		// Create a valid completed parent session
+		parentSessionID := "parent-valid"
+		claudeSessionID := "claude-valid"
+		parentSession := &store.Session{
+			ID:              parentSessionID,
+			RunID:           "run-valid",
+			ClaudeSessionID: claudeSessionID,
+			Status:          store.SessionStatusCompleted,
+			Query:           "original query",
+			Model:           "claude-3-opus",
+			WorkingDir:      "/test/dir",
+			CreatedAt:       time.Now(),
+			LastActivityAt:  time.Now(),
+			CompletedAt:     &time.Time{},
+		}
+
+		// Insert parent session
+		if err := d.store.CreateSession(ctx, parentSession); err != nil {
+			t.Fatalf("Failed to create parent session: %v", err)
+		}
+
+		// Add some conversation history to parent
+		events := []*store.ConversationEvent{
+			{
+				SessionID:       parentSessionID,
+				ClaudeSessionID: claudeSessionID,
+				EventType:       store.EventTypeMessage,
+				Role:            "user",
+				Content:         "original query",
+			},
+			{
+				SessionID:       parentSessionID,
+				ClaudeSessionID: claudeSessionID,
+				EventType:       store.EventTypeMessage,
+				Role:            "assistant",
+				Content:         "Original response",
+			},
+		}
+
+		for _, event := range events {
+			if err := d.store.AddConversationEvent(ctx, event); err != nil {
+				t.Fatalf("Failed to add conversation event: %v", err)
+			}
+		}
+
+		// Continue the session
+		req := rpc.ContinueSessionRequest{
+			SessionID:          parentSessionID,
+			Query:              "follow up question",
+			SystemPrompt:       "You are helpful",
+			CustomInstructions: "Be concise",
+			MaxTurns:           3,
+		}
+
+		result, err := sendRPC(t, "continueSession", req)
+		if err != nil {
+			// Expected - Claude binary might not exist in test environment
+			if err.Error() != "failed to continue session: failed to launch resumed Claude session: failed to start claude: exec: \"claude\": executable file not found in $PATH" {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			// Even if Claude fails to launch, we should have created the session
+			return
+		}
+
+		// Parse response
+		var resp rpc.ContinueSessionResponse
+		if err := json.Unmarshal(result, &resp); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+
+		// Verify response
+		if resp.SessionID == "" {
+			t.Error("Expected session ID in response")
+		}
+		if resp.RunID == "" {
+			t.Error("Expected run ID in response")
+		}
+		if resp.ParentSessionID != parentSessionID {
+			t.Errorf("Expected parent_session_id %s, got %s", parentSessionID, resp.ParentSessionID)
+		}
+
+		// Verify the new session was created with parent reference
+		newSession, err := d.store.GetSession(ctx, resp.SessionID)
+		if err != nil {
+			t.Fatalf("Failed to get new session: %v", err)
+		}
+
+		if newSession.ParentSessionID != parentSessionID {
+			t.Errorf("Expected parent_session_id %s, got %s", parentSessionID, newSession.ParentSessionID)
+		}
+		if newSession.Query != "follow up question" {
+			t.Errorf("Expected query 'follow up question', got %s", newSession.Query)
+		}
+		if newSession.SystemPrompt != "You are helpful" {
+			t.Errorf("Expected system prompt override, got %s", newSession.SystemPrompt)
+		}
+		if newSession.CustomInstructions != "Be concise" {
+			t.Errorf("Expected custom instructions override, got %s", newSession.CustomInstructions)
+		}
+		if newSession.MaxTurns != 3 {
+			t.Errorf("Expected max turns 3, got %d", newSession.MaxTurns)
+		}
+	})
+
+	t.Run("ContinueSession_HandlesOptionalMCPConfig", func(t *testing.T) {
+		// Create parent session
+		parentSessionID := "parent-mcp"
+		parentSession := &store.Session{
+			ID:              parentSessionID,
+			RunID:           "run-mcp",
+			ClaudeSessionID: "claude-mcp",
+			Status:          store.SessionStatusCompleted,
+			Query:           "original",
+			CreatedAt:       time.Now(),
+			LastActivityAt:  time.Now(),
+			CompletedAt:     &time.Time{},
+		}
+
+		if err := d.store.CreateSession(ctx, parentSession); err != nil {
+			t.Fatalf("Failed to create parent session: %v", err)
+		}
+
+		// Create MCP config
+		mcpConfig := map[string]interface{}{
+			"mcpServers": map[string]interface{}{
+				"test-server": map[string]interface{}{
+					"command": "node",
+					"args":    []string{"server.js"},
+					"env": map[string]string{
+						"TEST": "value",
+					},
+				},
+			},
+		}
+
+		mcpConfigJSON, err := json.Marshal(mcpConfig)
+		if err != nil {
+			t.Fatalf("Failed to marshal MCP config: %v", err)
+		}
+
+		// Continue with MCP config
+		req := rpc.ContinueSessionRequest{
+			SessionID: parentSessionID,
+			Query:     "with mcp",
+			MCPConfig: string(mcpConfigJSON),
+		}
+
+		_, err = sendRPC(t, "continueSession", req)
+		// Expected to fail (no Claude binary), but session should be created
+		if err != nil && !containsError(err, "failed to launch resumed Claude session") {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("GetConversation_IncludesParentHistory", func(t *testing.T) {
+		// Create a chain of sessions: grandparent -> parent -> child
+		grandparentID := "grandparent"
+		parentID := "parent-chain"
+		childID := "child"
+
+		// Create grandparent session
+		grandparent := &store.Session{
+			ID:              grandparentID,
+			RunID:           "run-gp",
+			ClaudeSessionID: "claude-gp",
+			Status:          store.SessionStatusCompleted,
+			Query:           "grandparent query",
+			CreatedAt:       time.Now(),
+			LastActivityAt:  time.Now(),
+			CompletedAt:     &time.Time{},
+		}
+		if err := d.store.CreateSession(ctx, grandparent); err != nil {
+			t.Fatalf("Failed to create grandparent: %v", err)
+		}
+
+		// Add grandparent events
+		gpEvents := []*store.ConversationEvent{
+			{
+				SessionID:       grandparentID,
+				ClaudeSessionID: "claude-gp",
+				EventType:       store.EventTypeMessage,
+				Role:            "user",
+				Content:         "grandparent query",
+			},
+			{
+				SessionID:       grandparentID,
+				ClaudeSessionID: "claude-gp",
+				EventType:       store.EventTypeMessage,
+				Role:            "assistant",
+				Content:         "grandparent response",
+			},
+		}
+		for _, event := range gpEvents {
+			if err := d.store.AddConversationEvent(ctx, event); err != nil {
+				t.Fatalf("Failed to add grandparent event: %v", err)
+			}
+		}
+
+		// Create parent session
+		parent := &store.Session{
+			ID:              parentID,
+			RunID:           "run-p",
+			ClaudeSessionID: "claude-p",
+			ParentSessionID: grandparentID,
+			Status:          store.SessionStatusCompleted,
+			Query:           "parent query",
+			CreatedAt:       time.Now(),
+			LastActivityAt:  time.Now(),
+			CompletedAt:     &time.Time{},
+		}
+		if err := d.store.CreateSession(ctx, parent); err != nil {
+			t.Fatalf("Failed to create parent: %v", err)
+		}
+
+		// Add parent events
+		pEvents := []*store.ConversationEvent{
+			{
+				SessionID:       parentID,
+				ClaudeSessionID: "claude-p",
+				EventType:       store.EventTypeMessage,
+				Role:            "user",
+				Content:         "parent query",
+			},
+			{
+				SessionID:       parentID,
+				ClaudeSessionID: "claude-p",
+				EventType:       store.EventTypeMessage,
+				Role:            "assistant",
+				Content:         "parent response",
+			},
+		}
+		for _, event := range pEvents {
+			if err := d.store.AddConversationEvent(ctx, event); err != nil {
+				t.Fatalf("Failed to add parent event: %v", err)
+			}
+		}
+
+		// Create child session
+		child := &store.Session{
+			ID:              childID,
+			RunID:           "run-c",
+			ClaudeSessionID: "claude-c",
+			ParentSessionID: parentID,
+			Status:          store.SessionStatusCompleted,
+			Query:           "child query",
+			CreatedAt:       time.Now(),
+			LastActivityAt:  time.Now(),
+			CompletedAt:     &time.Time{},
+		}
+		if err := d.store.CreateSession(ctx, child); err != nil {
+			t.Fatalf("Failed to create child: %v", err)
+		}
+
+		// Add child events
+		cEvents := []*store.ConversationEvent{
+			{
+				SessionID:       childID,
+				ClaudeSessionID: "claude-c",
+				EventType:       store.EventTypeMessage,
+				Role:            "user",
+				Content:         "child query",
+			},
+			{
+				SessionID:       childID,
+				ClaudeSessionID: "claude-c",
+				EventType:       store.EventTypeMessage,
+				Role:            "assistant",
+				Content:         "child response",
+			},
+		}
+		for _, event := range cEvents {
+			if err := d.store.AddConversationEvent(ctx, event); err != nil {
+				t.Fatalf("Failed to add child event: %v", err)
+			}
+		}
+
+		// Get conversation for child session - should include full history
+		req := rpc.GetConversationRequest{
+			SessionID: childID,
+		}
+		result, err := sendRPC(t, "getConversation", req)
+		if err != nil {
+			t.Fatalf("Failed to get conversation: %v", err)
+		}
+
+		// Parse response
+		var conversation rpc.GetConversationResponse
+		if err := json.Unmarshal(result, &conversation); err != nil {
+			t.Fatalf("Failed to unmarshal conversation: %v", err)
+		}
+
+		// Verify we got all events in correct order
+		if len(conversation.Events) != 6 {
+			t.Errorf("Expected 6 events (2 from each session), got %d", len(conversation.Events))
+		}
+
+		// Verify chronological order
+		expectedContents := []string{
+			"grandparent query",
+			"grandparent response",
+			"parent query",
+			"parent response",
+			"child query",
+			"child response",
+		}
+
+		for i, event := range conversation.Events {
+			if i < len(expectedContents) && event.Content != expectedContents[i] {
+				t.Errorf("Event %d: expected content '%s', got '%s'",
+					i, expectedContents[i], event.Content)
+			}
+		}
+	})
+}
+
+func containsError(err error, substr string) bool {
+	if err == nil {
+		return false
+	}
+	return len(err.Error()) >= len(substr) && contains(err.Error(), substr)
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/hld/rpc/handlers_continue_session_test.go
+++ b/hld/rpc/handlers_continue_session_test.go
@@ -1,0 +1,248 @@
+package rpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/humanlayer/humanlayer/hld/session"
+	"github.com/humanlayer/humanlayer/hld/store"
+	"go.uber.org/mock/gomock"
+)
+
+func TestHandleContinueSession(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockManager := session.NewMockSessionManager(ctrl)
+	mockStore := store.NewMockConversationStore(ctrl)
+	handlers := NewSessionHandlers(mockManager, mockStore)
+
+	testCases := []struct {
+		name          string
+		request       string
+		setupMocks    func()
+		expectedError string
+		validateResp  func(t *testing.T, resp *ContinueSessionResponse)
+	}{
+		{
+			name: "successful continue session",
+			request: `{
+				"session_id": "parent-123",
+				"query": "follow up question",
+				"system_prompt": "You are helpful",
+				"max_turns": 5
+			}`,
+			setupMocks: func() {
+				mockManager.EXPECT().ContinueSession(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, req session.ContinueSessionConfig) (*session.Session, error) {
+						// Validate request
+						if req.ParentSessionID != "parent-123" {
+							t.Errorf("Expected parent session ID 'parent-123', got %s", req.ParentSessionID)
+						}
+						if req.Query != "follow up question" {
+							t.Errorf("Expected query 'follow up question', got %s", req.Query)
+						}
+						if req.SystemPrompt != "You are helpful" {
+							t.Errorf("Expected system prompt 'You are helpful', got %s", req.SystemPrompt)
+						}
+						if req.MaxTurns != 5 {
+							t.Errorf("Expected max turns 5, got %d", req.MaxTurns)
+						}
+
+						// Return mock session
+						return &session.Session{
+							ID:        "child-456",
+							RunID:     "run-child",
+							Status:    session.StatusRunning,
+							StartTime: time.Now(),
+						}, nil
+					})
+
+				// Note: We don't mock GetSession here because the handler correctly
+				// returns empty claude_session_id (it's not available until events stream)
+			},
+			validateResp: func(t *testing.T, resp *ContinueSessionResponse) {
+				if resp.SessionID != "child-456" {
+					t.Errorf("Expected session ID 'child-456', got %s", resp.SessionID)
+				}
+				if resp.RunID != "run-child" {
+					t.Errorf("Expected run ID 'run-child', got %s", resp.RunID)
+				}
+				// claude_session_id should be empty initially (populated when events stream)
+				if resp.ClaudeSessionID != "" {
+					t.Errorf("Expected empty claude session ID initially, got %s", resp.ClaudeSessionID)
+				}
+				if resp.ParentSessionID != "parent-123" {
+					t.Errorf("Expected parent session ID 'parent-123', got %s", resp.ParentSessionID)
+				}
+			},
+		},
+		{
+			name: "continue session with MCP config",
+			request: `{
+				"session_id": "parent-mcp",
+				"query": "with mcp",
+				"mcp_config": "{\"mcpServers\": {\"test\": {\"command\": \"node\"}}}"
+			}`,
+			setupMocks: func() {
+				mockManager.EXPECT().ContinueSession(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, req session.ContinueSessionConfig) (*session.Session, error) {
+						// Validate MCP config was parsed
+						if req.MCPConfig == nil {
+							t.Error("Expected MCP config to be parsed")
+						}
+						if req.MCPConfig.MCPServers == nil {
+							t.Error("Expected MCP servers to be set")
+						}
+						if _, ok := req.MCPConfig.MCPServers["test"]; !ok {
+							t.Error("Expected 'test' server in MCP config")
+						}
+
+						return &session.Session{
+							ID:        "child-mcp",
+							RunID:     "run-mcp",
+							Status:    session.StatusRunning,
+							StartTime: time.Now(),
+						}, nil
+					})
+
+				// No GetSession mock needed - claude_session_id won't be available yet
+			},
+			validateResp: func(t *testing.T, resp *ContinueSessionResponse) {
+				if resp.SessionID != "child-mcp" {
+					t.Errorf("Expected session ID 'child-mcp', got %s", resp.SessionID)
+				}
+			},
+		},
+		{
+			name:    "missing session ID",
+			request: `{"query": "no session"}`,
+			setupMocks: func() {
+				// No mocks needed - validation fails early
+			},
+			expectedError: "session_id is required",
+		},
+		{
+			name:    "missing query",
+			request: `{"session_id": "parent-123"}`,
+			setupMocks: func() {
+				// No mocks needed - validation fails early
+			},
+			expectedError: "query is required",
+		},
+		{
+			name:    "invalid MCP config JSON",
+			request: `{"session_id": "parent-123", "query": "test", "mcp_config": "invalid json"}`,
+			setupMocks: func() {
+				// No mocks needed - validation fails early
+			},
+			expectedError: "invalid mcp_config JSON",
+		},
+		{
+			name:    "invalid JSON request",
+			request: `{invalid json}`,
+			setupMocks: func() {
+				// No mocks needed - parsing fails
+			},
+			expectedError: "invalid request:",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setupMocks()
+
+			resp, err := handlers.HandleContinueSession(context.Background(), []byte(tc.request))
+
+			if tc.expectedError != "" {
+				if err == nil {
+					t.Errorf("Expected error containing '%s', got nil", tc.expectedError)
+				} else if !containsStr(err.Error(), tc.expectedError) {
+					t.Errorf("Expected error containing '%s', got '%s'", tc.expectedError, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			continueResp, ok := resp.(*ContinueSessionResponse)
+			if !ok {
+				t.Fatalf("Expected *ContinueSessionResponse, got %T", resp)
+			}
+
+			if tc.validateResp != nil {
+				tc.validateResp(t, continueResp)
+			}
+		})
+	}
+}
+
+func TestHandleContinueSession_ToolsConfiguration(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockManager := session.NewMockSessionManager(ctrl)
+	mockStore := store.NewMockConversationStore(ctrl)
+	handlers := NewSessionHandlers(mockManager, mockStore)
+
+	request := `{
+		"session_id": "parent-tools",
+		"query": "with tools config",
+		"permission_prompt_tool": "mcp__humanlayer__tool",
+		"allowed_tools": ["tool1", "tool2"],
+		"disallowed_tools": ["dangerous_tool"]
+	}`
+
+	mockManager.EXPECT().ContinueSession(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, req session.ContinueSessionConfig) (*session.Session, error) {
+			// Validate tools configuration
+			if req.PermissionPromptTool != "mcp__humanlayer__tool" {
+				t.Errorf("Expected permission prompt tool 'mcp__humanlayer__tool', got %s", req.PermissionPromptTool)
+			}
+			if len(req.AllowedTools) != 2 || req.AllowedTools[0] != "tool1" || req.AllowedTools[1] != "tool2" {
+				t.Errorf("Expected allowed tools [tool1, tool2], got %v", req.AllowedTools)
+			}
+			if len(req.DisallowedTools) != 1 || req.DisallowedTools[0] != "dangerous_tool" {
+				t.Errorf("Expected disallowed tools [dangerous_tool], got %v", req.DisallowedTools)
+			}
+
+			return &session.Session{
+				ID:        "child-tools",
+				RunID:     "run-tools",
+				Status:    session.StatusRunning,
+				StartTime: time.Now(),
+			}, nil
+		})
+
+	// No GetSession mock needed - claude_session_id won't be available yet
+
+	resp, err := handlers.HandleContinueSession(context.Background(), []byte(request))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	continueResp, ok := resp.(*ContinueSessionResponse)
+	if !ok {
+		t.Fatalf("Expected *ContinueSessionResponse, got %T", resp)
+	}
+
+	if continueResp.SessionID != "child-tools" {
+		t.Errorf("Expected session ID 'child-tools', got %s", continueResp.SessionID)
+	}
+}
+
+func containsStr(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && contains(s, substr))
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/hld/rpc/types.go
+++ b/hld/rpc/types.go
@@ -58,6 +58,7 @@ type SessionState struct {
 	ID              string  `json:"id"`
 	RunID           string  `json:"run_id"`
 	ClaudeSessionID string  `json:"claude_session_id,omitempty"`
+	ParentSessionID string  `json:"parent_session_id,omitempty"`
 	Status          string  `json:"status"` // starting, running, completed, failed, waiting_input
 	Query           string  `json:"query"`
 	Model           string  `json:"model,omitempty"`
@@ -74,4 +75,26 @@ type SessionState struct {
 // GetSessionStateResponse is the response for fetching session state
 type GetSessionStateResponse struct {
 	Session SessionState `json:"session"`
+}
+
+// ContinueSessionRequest is the request for continuing an existing session
+type ContinueSessionRequest struct {
+	SessionID            string   `json:"session_id"`                       // The session to continue (required)
+	Query                string   `json:"query"`                            // The new query/message to send (required)
+	SystemPrompt         string   `json:"system_prompt,omitempty"`          // Override system prompt
+	AppendSystemPrompt   string   `json:"append_system_prompt,omitempty"`   // Append to system prompt
+	MCPConfig            string   `json:"mcp_config,omitempty"`             // JSON string of MCP config (to avoid import cycle)
+	PermissionPromptTool string   `json:"permission_prompt_tool,omitempty"` // MCP tool for permission prompts
+	AllowedTools         []string `json:"allowed_tools,omitempty"`          // Allowed tools list
+	DisallowedTools      []string `json:"disallowed_tools,omitempty"`       // Disallowed tools list
+	CustomInstructions   string   `json:"custom_instructions,omitempty"`    // Custom instructions
+	MaxTurns             int      `json:"max_turns,omitempty"`              // Max conversation turns
+}
+
+// ContinueSessionResponse is the response for continuing a session
+type ContinueSessionResponse struct {
+	SessionID       string `json:"session_id"`        // The new session ID
+	RunID           string `json:"run_id"`            // The new run ID
+	ClaudeSessionID string `json:"claude_session_id"` // The new Claude session ID (unique for each resume)
+	ParentSessionID string `json:"parent_session_id"` // The parent session ID
 }

--- a/hld/session/manager_test.go
+++ b/hld/session/manager_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -114,3 +115,280 @@ func TestGetSessionInfo(t *testing.T) {
 // Note: Most of the old tests were removed because they tested internal implementation
 // details (in-memory maps) that no longer exist. The real functionality is now
 // tested by the integration tests which use actual SQLite database.
+
+func TestContinueSession_ValidatesParentExists(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockConversationStore(ctrl)
+	manager, _ := NewManager(nil, mockStore)
+
+	// Test parent not found
+	mockStore.EXPECT().GetSession(gomock.Any(), "not-found").Return(nil, fmt.Errorf("session not found"))
+
+	req := ContinueSessionConfig{
+		ParentSessionID: "not-found",
+		Query:           "continue this",
+	}
+	_, err := manager.ContinueSession(context.Background(), req)
+	if err == nil {
+		t.Error("Expected error for non-existent parent session")
+	}
+	if err.Error() != "failed to get parent session: session not found" {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestContinueSession_ValidatesParentStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockConversationStore(ctrl)
+	manager, _ := NewManager(nil, mockStore)
+
+	testCases := []struct {
+		name          string
+		parentStatus  string
+		expectedError string
+	}{
+		{
+			name:          "running session",
+			parentStatus:  store.SessionStatusRunning,
+			expectedError: "cannot continue session with status running (must be completed)",
+		},
+		{
+			name:          "failed session",
+			parentStatus:  store.SessionStatusFailed,
+			expectedError: "cannot continue session with status failed (must be completed)",
+		},
+		{
+			name:          "starting session",
+			parentStatus:  store.SessionStatusStarting,
+			expectedError: "cannot continue session with status starting (must be completed)",
+		},
+		{
+			name:          "waiting input session",
+			parentStatus:  store.SessionStatusWaitingInput,
+			expectedError: "cannot continue session with status waiting_input (must be completed)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			parentSession := &store.Session{
+				ID:              "parent-1",
+				RunID:           "run-1",
+				ClaudeSessionID: "claude-1",
+				Status:          tc.parentStatus,
+				Query:           "original query",
+				CreatedAt:       time.Now(),
+			}
+			mockStore.EXPECT().GetSession(gomock.Any(), "parent-1").Return(parentSession, nil)
+
+			req := ContinueSessionConfig{
+				ParentSessionID: "parent-1",
+				Query:           "continue this",
+			}
+			_, err := manager.ContinueSession(context.Background(), req)
+			if err == nil {
+				t.Error("Expected error for non-completed parent session")
+			}
+			if err.Error() != tc.expectedError {
+				t.Errorf("Expected error '%s', got: %v", tc.expectedError, err)
+			}
+		})
+	}
+}
+
+func TestContinueSession_ValidatesClaudeSessionID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockConversationStore(ctrl)
+	manager, _ := NewManager(nil, mockStore)
+
+	// Parent without claude_session_id
+	parentSession := &store.Session{
+		ID:              "parent-1",
+		RunID:           "run-1",
+		ClaudeSessionID: "", // Empty
+		Status:          store.SessionStatusCompleted,
+		Query:           "original query",
+		CreatedAt:       time.Now(),
+	}
+	mockStore.EXPECT().GetSession(gomock.Any(), "parent-1").Return(parentSession, nil)
+
+	req := ContinueSessionConfig{
+		ParentSessionID: "parent-1",
+		Query:           "continue this",
+	}
+	_, err := manager.ContinueSession(context.Background(), req)
+	if err == nil {
+		t.Error("Expected error for parent without claude_session_id")
+	}
+	if err.Error() != "parent session missing claude_session_id (cannot resume)" {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestContinueSession_CreatesNewSessionWithParentReference(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockConversationStore(ctrl)
+	manager, _ := NewManager(nil, mockStore)
+
+	// Mock parent session
+	parentSession := &store.Session{
+		ID:              "parent-1",
+		RunID:           "run-1",
+		ClaudeSessionID: "claude-1",
+		Status:          store.SessionStatusCompleted,
+		Query:           "original query",
+		Model:           "claude-3-opus",
+		WorkingDir:      "/test/dir",
+		CreatedAt:       time.Now(),
+	}
+	mockStore.EXPECT().GetSession(gomock.Any(), "parent-1").Return(parentSession, nil)
+
+	// Expect session creation with parent reference
+	mockStore.EXPECT().CreateSession(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx interface{}, session *store.Session) error {
+			// Validate the created session
+			if session.ParentSessionID != "parent-1" {
+				t.Errorf("Expected parent_session_id to be 'parent-1', got '%s'", session.ParentSessionID)
+			}
+			if session.Query != "continue this" {
+				t.Errorf("Expected query 'continue this', got '%s'", session.Query)
+			}
+			if session.Status != store.SessionStatusStarting {
+				t.Errorf("Expected status 'starting', got '%s'", session.Status)
+			}
+			// Should not inherit claude_session_id (will be set from streaming events)
+			if session.ClaudeSessionID != "" {
+				t.Errorf("Expected empty claude_session_id, got '%s'", session.ClaudeSessionID)
+			}
+			return nil
+		})
+
+	// Expect status update to running (we can't test the full flow without mocking Claude client)
+	// May be called twice if Claude fails to launch in background
+	mockStore.EXPECT().UpdateSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	req := ContinueSessionConfig{
+		ParentSessionID: "parent-1",
+		Query:           "continue this",
+	}
+
+	// Try to continue session - this tests our logic, not Claude launch
+	session, err := manager.ContinueSession(context.Background(), req)
+
+	// If Claude binary exists, it might succeed; if not, it will fail
+	// Either way, our mock expectations should have been met (session created with parent)
+	if err != nil {
+		// Expected - Claude binary might not exist in test environment
+		if !containsError(err, "failed to launch resumed Claude session") {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	} else {
+		// Claude launched successfully - verify session has expected properties
+		if session.ID == "" {
+			t.Error("Expected session ID to be set")
+		}
+		if session.RunID == "" {
+			t.Error("Expected run ID to be set")
+		}
+	}
+}
+
+func TestContinueSession_HandlesOptionalOverrides(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockConversationStore(ctrl)
+	manager, _ := NewManager(nil, mockStore)
+
+	// Mock parent session
+	parentSession := &store.Session{
+		ID:              "parent-1",
+		RunID:           "run-1",
+		ClaudeSessionID: "claude-1",
+		Status:          store.SessionStatusCompleted,
+		Query:           "original query",
+		CreatedAt:       time.Now(),
+	}
+	mockStore.EXPECT().GetSession(gomock.Any(), "parent-1").Return(parentSession, nil)
+
+	// Test with various overrides
+	req := ContinueSessionConfig{
+		ParentSessionID:      "parent-1",
+		Query:                "continue with overrides",
+		SystemPrompt:         "You are a pirate",
+		AppendSystemPrompt:   "Always say arr",
+		PermissionPromptTool: "mcp__custom__tool",
+		AllowedTools:         []string{"tool1", "tool2"},
+		DisallowedTools:      []string{"dangerous_tool"},
+		CustomInstructions:   "Be helpful",
+		MaxTurns:             5,
+	}
+
+	// Expect session creation
+	mockStore.EXPECT().CreateSession(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx interface{}, session *store.Session) error {
+			// Validate overrides are stored
+			if session.SystemPrompt != "You are a pirate" {
+				t.Errorf("Expected system prompt override, got '%s'", session.SystemPrompt)
+			}
+			if session.CustomInstructions != "Be helpful" {
+				t.Errorf("Expected custom instructions override, got '%s'", session.CustomInstructions)
+			}
+			if session.MaxTurns != 5 {
+				t.Errorf("Expected max turns 5, got %d", session.MaxTurns)
+			}
+			return nil
+		})
+
+	// Expect status update
+	// May be called twice if Claude fails to launch in background
+	mockStore.EXPECT().UpdateSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	session, err := manager.ContinueSession(context.Background(), req)
+
+	// Test passes if our mock expectations were met (session created with overrides)
+	// Whether Claude actually launches depends on the environment
+	if err != nil {
+		// Expected - Claude binary might not exist
+		if !containsError(err, "failed to launch resumed Claude session") {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	} else {
+		// Claude launched - verify session properties
+		if session.ID == "" {
+			t.Error("Expected session ID to be set")
+		}
+		if session.RunID == "" {
+			t.Error("Expected run ID to be set")
+		}
+	}
+}
+
+// Helper function to check if error contains a substring
+func containsError(err error, substr string) bool {
+	if err == nil {
+		return false
+	}
+	return contains(err.Error(), substr)
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+
+func containsStr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/hld/session/types.go
+++ b/hld/session/types.go
@@ -42,10 +42,27 @@ type Info struct {
 	Result    *claudecode.Result `json:"result,omitempty"`
 }
 
+// ContinueSessionConfig contains the configuration for continuing a session
+type ContinueSessionConfig struct {
+	ParentSessionID      string                // The parent session to resume from
+	Query                string                // The new query
+	SystemPrompt         string                // Optional system prompt override
+	AppendSystemPrompt   string                // Optional append to system prompt
+	MCPConfig            *claudecode.MCPConfig // Optional MCP config override
+	PermissionPromptTool string                // Optional permission prompt tool
+	AllowedTools         []string              // Optional allowed tools override
+	DisallowedTools      []string              // Optional disallowed tools override
+	CustomInstructions   string                // Optional custom instructions
+	MaxTurns             int                   // Optional max turns override
+}
+
 // SessionManager defines the interface for managing Claude Code sessions
 type SessionManager interface {
 	// LaunchSession starts a new Claude Code session
 	LaunchSession(ctx context.Context, config claudecode.SessionConfig) (*Session, error)
+
+	// ContinueSession resumes an existing completed session with a new query and optional config overrides
+	ContinueSession(ctx context.Context, req ContinueSessionConfig) (*Session, error)
 
 	// GetSessionInfo returns session info from the database by ID
 	GetSessionInfo(sessionID string) (*Info, error)


### PR DESCRIPTION
 ## What problem(s) was I solving?

  HumanLayer's TUI was missing multi-turn conversation support - users couldn't continue completed sessions with follow-up questions, limiting its usefulness as a Claude Code replacement for interactive development workflows.

  ## What user-facing changes did I ship?

  - **Multi-turn conversation support**: Users can now continue completed sessions with new queries via `ContinueSession` RPC
  - **Full conversation history**: Child sessions include complete parent conversation history in chronological order
  - **Session relationship tracking**: Parent-child session relationships are stored and queryable through the database

  ## How I implemented it

  - **Session continuation logic**: Added `ContinueSession` RPC method with comprehensive validation (requires completed parent, claude_session_id for resumption)
  - **Parent-child relationships**: Enhanced database schema with `parent_session_id` field and conversation history walking across session chains
  - **Claude resumption integration**: Implemented `--resume` flag support using parent session's `claude_session_id` with full config override capabilities (system prompt, MCP config,
   tools, etc.)
  - **Thread-safety improvements**: Fixed race conditions in claudecode-go client with proper mutex protection for error handling
  - **Comprehensive validation**: Added request validation, session state checks, and proper error handling for edge cases

  ## How to verify it

  - [x] I have ensured `make check test` passes
  - Start a session, let it complete, then use `ContinueSession` RPC to add follow-up questions
  - Verify conversation history includes full parent chain in correct chronological order
  - Test error cases: continuing running sessions, missing claude_session_id, invalid requests

  ## Description for the changelog

  Add multi-turn conversation support with session continuation, parent-child relationships, and full conversation history walking across resumed sessions.

  ## A picture of a cute animal (not mandatory but encouraged)

  🐾 (Backend work complete - TUI interface coming in Phase 5!)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add multi-turn conversation support with session continuation, including full conversation history and parent-child session tracking.
> 
>   - **Behavior**:
>     - Adds `ContinueSession` RPC method in `handlers.go` to allow continuation of completed sessions with new queries.
>     - Child sessions include full parent conversation history in chronological order.
>     - Parent-child session relationships are stored in the database.
>   - **Database**:
>     - Updates schema in `sqlite.go` to include `parent_session_id` for tracking session relationships.
>     - Implements `GetSessionConversation` in `sqlite.go` to retrieve full conversation history across session chains.
>   - **Client**:
>     - Adds `ContinueSession` method in `client.go` to interact with the new RPC method.
>     - Ensures thread-safety in `claudecode-go/client.go` by using mutexes for error handling.
>   - **Tests**:
>     - Adds `daemon_continue_session_integration_test.go` to test session continuation scenarios.
>     - Adds unit tests in `handlers_continue_session_test.go` and `manager_test.go` to verify logic and edge cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 1254c93ddef3cc95035ef71c743728c49c822b8f. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->