### PR TITLE
Resolve issue tied to clashing keyboard shortcuts

### DIFF
--- a/humanlayer-wui/src/App.tsx
+++ b/humanlayer-wui/src/App.tsx
@@ -10,6 +10,7 @@ import SessionDetail from './components/internal/SessionDetail'
 import { ThemeProvider } from './components/providers/ThemeProvider'
 import { SessionLauncher } from './components/SessionLauncher'
 import { useSessionLauncher, useSessionLauncherHotkeys } from './hooks/useSessionLauncher'
+import { useHotkeysContext } from 'react-hotkeys-hook'
 
 interface StoreState {
   /* Sessions */
@@ -74,6 +75,7 @@ function App() {
   const [approvals, setApprovals] = useState<any[]>([])
   const [activeSessionId] = useState<string | null>(null)
   const [connected, setConnected] = useState(false)
+  const { activeScopes } = useHotkeysContext()
 
   // Session launcher state
   const { isOpen, close } = useSessionLauncher()
@@ -124,6 +126,11 @@ function App() {
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [handleKeyDown])
+
+  // log active scopes for now to understand how hotkeys scopes work
+  useEffect(() => {
+    console.log('activeScopes', activeScopes)
+  }, [activeScopes])
 
   // Cleanup subscription when component unmounts or session changes
   useEffect(() => {

--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -8,7 +8,8 @@ import {
   TableHeader,
   TableRow,
 } from '../ui/table'
-import { useHotkeys } from 'react-hotkeys-hook'
+import { useHotkeys, useHotkeysContext } from 'react-hotkeys-hook'
+import { useEffect } from 'react'
 
 interface SessionTableProps {
   sessions: SessionInfo[]
@@ -20,6 +21,8 @@ interface SessionTableProps {
   focusedSession: SessionInfo | null
 }
 
+export const SessionTableHotkeysScope = "session-table"
+
 export default function SessionTable({
   sessions,
   handleFocusSession,
@@ -29,13 +32,22 @@ export default function SessionTable({
   handleActivateSession,
   focusedSession,
 }: SessionTableProps) {
-  useHotkeys('j', () => handleFocusNextSession?.())
-  useHotkeys('k', () => handleFocusPreviousSession?.())
+  const { enableScope, disableScope  } = useHotkeysContext()
+
+  useEffect(() => {
+      enableScope(SessionTableHotkeysScope)
+      return () => {
+        disableScope(SessionTableHotkeysScope)
+      }
+  }, [])
+
+  useHotkeys('j', () => handleFocusNextSession?.(), { scopes: SessionTableHotkeysScope })
+  useHotkeys('k', () => handleFocusPreviousSession?.(), { scopes: SessionTableHotkeysScope })
   useHotkeys('enter', () => {
     if (focusedSession) {
       handleActivateSession?.(focusedSession)
     }
-  })
+  }, { scopes: SessionTableHotkeysScope })
 
   return (
     <Table>

--- a/humanlayer-wui/src/main.tsx
+++ b/humanlayer-wui/src/main.tsx
@@ -2,11 +2,14 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import { ThemeProvider } from './contexts/ThemeContext'
+import { HotkeysProvider } from 'react-hotkeys-hook'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <ThemeProvider>
-      <App />
-    </ThemeProvider>
+    <HotkeysProvider>
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
+    </HotkeysProvider>
   </React.StrictMode>,
 )


### PR DESCRIPTION
## What problem(s) was I solving?

## What user-facing changes did I ship?

## How I implemented it

## How to verify it

- [ ] I have ensured `make check test` passes

## Description for the changelog

## A picture of a cute animal (not mandatory but encouraged)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implemented scoped hotkeys in `ThemeSelector` and `SessionTable` to resolve clashing keyboard shortcuts using `react-hotkeys-hook`.
> 
>   - **Hotkeys Management**:
>     - Introduced `HotkeysProvider` in `main.tsx` to manage hotkey contexts.
>     - Scoped hotkeys in `ThemeSelector.tsx` and `SessionTable.tsx` using `useHotkeysContext` to enable/disable specific scopes.
>   - **ThemeSelector Component**:
>     - Added `ThemeSelectorHotkeysScope` to manage hotkeys for theme selection.
>     - Implemented hotkeys for toggling dropdown (`ctrl+t`), navigating (`j`, `k`, `ArrowUp`, `ArrowDown`), selecting (`enter`), and closing (`escape`).
>   - **SessionTable Component**:
>     - Added `SessionTableHotkeysScope` to manage hotkeys for session navigation.
>     - Implemented hotkeys for focusing next/previous session (`j`, `k`) and activating session (`enter`).
>   - **App Component**:
>     - Logged active hotkey scopes to console for debugging purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 3c0e1629ee320c8a9ea13ce4922e5d3a887f1cfe. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->