### PR TITLE
Add Gruvbox Dark and Light themes to WUI

### DIFF
--- a/humanlayer-wui/src/App.css
+++ b/humanlayer-wui/src/App.css
@@ -142,6 +142,34 @@
   --terminal-error: #dc3545;
 }
 
+/* Gruvbox Dark - Material palette, medium contrast */
+[data-theme='gruvbox-dark'] {
+  --terminal-bg: #282828;
+  --terminal-bg-alt: #32302f;
+  --terminal-fg: #d4be98;
+  --terminal-fg-dim: #928374;
+  --terminal-accent: #a9b665;
+  --terminal-accent-alt: #89b482;
+  --terminal-border: #504945;
+  --terminal-success: #a9b665;
+  --terminal-warning: #d8a657;
+  --terminal-error: #ea6962;
+}
+
+/* Gruvbox Light - Material palette, medium contrast */
+[data-theme='gruvbox-light'] {
+  --terminal-bg: #fbf1c7;
+  --terminal-bg-alt: #f2e5bc;
+  --terminal-fg: #654735;
+  --terminal-fg-dim: #928374;
+  --terminal-accent: #6c782e;
+  --terminal-accent-alt: #4c7a5d;
+  --terminal-border: #d5c4a1;
+  --terminal-success: #6c782e;
+  --terminal-warning: #b47109;
+  --terminal-error: #c14a4a;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/humanlayer-wui/src/components/ThemeSelector.tsx
+++ b/humanlayer-wui/src/components/ThemeSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { useTheme, type Theme } from '@/contexts/ThemeContext'
-import { Moon, Sun, Coffee, Cat, ScanEye, Framer } from 'lucide-react'
+import { Moon, Sun, Coffee, Cat, ScanEye, Framer, Box } from 'lucide-react'
 import { useHotkeys, useHotkeysContext } from 'react-hotkeys-hook'
 import { SessionTableHotkeysScope } from './internal/SessionTable'
 
@@ -12,6 +12,8 @@ const themes: { value: Theme; label: string; icon: React.ComponentType<{ classNa
   { value: 'high-contrast', label: 'High Contrast', icon: ScanEye },
   { value: 'framer-dark', label: 'Framer Dark', icon: Framer },
   { value: 'framer-light', label: 'Framer Light', icon: Framer },
+  { value: 'gruvbox-dark', label: 'Gruvbox Dark', icon: Box },
+  { value: 'gruvbox-light', label: 'Gruvbox Light', icon: Box },
 ]
 
 export const ThemeSelectorHotkeysScope = 'theme-selector'

--- a/humanlayer-wui/src/contexts/ThemeContext.tsx
+++ b/humanlayer-wui/src/contexts/ThemeContext.tsx
@@ -8,6 +8,8 @@ export type Theme =
   | 'high-contrast'
   | 'framer-dark'
   | 'framer-light'
+  | 'gruvbox-dark'
+  | 'gruvbox-light'
 
 interface ThemeContextType {
   theme: Theme


### PR DESCRIPTION
## What problem(s) was I solving?

The WUI had a limited selection of 7 color themes, missing popular warm-toned themes that many developers prefer. After conducting research on the Gruvbox Material colorscheme (a popular Vim theme known for its warm, earthy tones and reduced eye strain), I identified an opportunity to expand the theme options to better serve user preferences.

## What user-facing changes did I ship?

- Added two new theme options to the WUI theme selector: "Gruvbox Dark" and "Gruvbox Light"
- Both themes are now available in the theme selector dropdown (accessible via the palette icon or Ctrl+T)
- Users can switch to these themes for a warmer, more comfortable viewing experience with earthy color tones

## How I implemented it

Based on the research documented in `thoughts/shared/research/2025-06-24_10-42-32_wui_color_schemes_gruvbox.md`, I:

1. Extracted color values from the Gruvbox Material palette (medium contrast variant)
2. Added CSS custom property definitions for both themes in `humanlayer-wui/src/App.css`:
   - `gruvbox-dark`: Dark theme with warm background (#282828) and muted accent colors
   - `gruvbox-light`: Light theme with cream background (#fbf1c7) and complementary colors
3. Updated the TypeScript theme type in `humanlayer-wui/src/contexts/ThemeContext.tsx` to include the new theme options
4. Added the themes to the theme selector component in `humanlayer-wui/src/components/ThemeSelector.tsx` with Box icons

The implementation follows the existing WUI pattern of using CSS custom properties with the `data-theme` attribute, ensuring consistency with the current theme system.

## How to verify it

- [x] I have ensured `make check test` passes

Manual verification steps:
- [x] Launch the WUI application
- [x] Open the theme selector (click palette icon or press Ctrl+T)
- [x] Select "Gruvbox Dark" theme and verify the dark warm-toned colors are applied
- [x] Select "Gruvbox Light" theme and verify the light cream-toned colors are applied
- [x] Verify theme persistence by refreshing the page
- [x] Check that all UI elements (buttons, borders, text, status indicators) display correctly with appropriate contrast

## Description for the changelog

Add Gruvbox Dark and Light themes to WUI for users who prefer warm, earthy color tones