### PR TITLE
Fix thoughts init for git worktrees

### DIFF
--- a/hlyr/src/commands/thoughts/init.ts
+++ b/hlyr/src/commands/thoughts/init.ts
@@ -163,7 +163,30 @@ These files will be automatically synchronized with your thoughts repository whe
 }
 
 function setupGitHooks(repoPath: string): void {
-  const hooksDir = path.join(repoPath, '.git', 'hooks')
+  // Use git rev-parse to find the common git directory for hooks (handles worktrees)
+  // In worktrees, hooks are stored in the common git directory, not the worktree-specific one
+  let gitCommonDir: string
+  try {
+    gitCommonDir = execSync('git rev-parse --git-common-dir', {
+      cwd: repoPath,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    }).trim()
+
+    // If the path is relative, make it absolute
+    if (!path.isAbsolute(gitCommonDir)) {
+      gitCommonDir = path.join(repoPath, gitCommonDir)
+    }
+  } catch (error) {
+    throw new Error(`Failed to find git common directory: ${error}`)
+  }
+
+  const hooksDir = path.join(gitCommonDir, 'hooks')
+
+  // Ensure hooks directory exists (might not exist in some setups)
+  if (!fs.existsSync(hooksDir)) {
+    fs.mkdirSync(hooksDir, { recursive: true })
+  }
 
   // Pre-commit hook
   const preCommitPath = path.join(hooksDir, 'pre-commit')

--- a/hlyr/src/thoughtsConfig.ts
+++ b/hlyr/src/thoughtsConfig.ts
@@ -61,8 +61,10 @@ export function ensureThoughtsRepoExists(
     fs.mkdirSync(expandedGlobal, { recursive: true })
   }
 
-  // Check if we're in a git repo
-  const isGitRepo = fs.existsSync(path.join(expandedRepo, '.git'))
+  // Check if we're in a git repo (handle both .git directory and .git file for worktrees)
+  const gitPath = path.join(expandedRepo, '.git')
+  const isGitRepo =
+    fs.existsSync(gitPath) && (fs.statSync(gitPath).isDirectory() || fs.statSync(gitPath).isFile())
 
   if (!isGitRepo) {
     // Initialize as git repo


### PR DESCRIPTION
- Use git rev-parse --git-common-dir instead of --git-dir for hooks location
- Ensure hooks directory exists before writing (might not exist in some git setups)
- Handle both .git directories (regular repos) and .git files (worktrees) in git detection

The issue was that worktrees have their hooks in the common git directory, not the worktree-specific directory. Using --git-common-dir ensures hooks are placed in the correct shared location that all worktrees can use.

## What problem(s) was I solving?

## What user-facing changes did I ship?

## How I implemented it

## How to verify it

- [ ] I have ensured `make check test` passes

## Description for the changelog

## A picture of a cute animal (not mandatory but encouraged)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix git hooks setup for worktrees by using `--git-common-dir` and ensuring hooks directory exists.
> 
>   - **Behavior**:
>     - Use `git rev-parse --git-common-dir` in `setupGitHooks()` in `init.ts` to locate hooks directory for worktrees.
>     - Ensure hooks directory exists before writing in `setupGitHooks()`.
>     - Handle both `.git` directories and `.git` files in `ensureThoughtsRepoExists()` in `thoughtsConfig.ts` for git detection.
>   - **Misc**:
>     - Update comments in `init.ts` to reflect changes in git hooks setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 69ae0ace6525c6265c9d5c2d85956f2a6e2d1bed. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->