### PR TITLE
Fix session event handling

### DIFF
--- a/hld/approval/manager.go
+++ b/hld/approval/manager.go
@@ -192,6 +192,19 @@ func (m *DefaultManager) ApproveFunctionCall(ctx context.Context, callID string,
 					slog.Info("updated session status back to running after approval",
 						"session_id", session.ID,
 						"approval_id", callID)
+					
+					// Publish session status change event
+					if m.EventBus != nil {
+						m.EventBus.Publish(bus.Event{
+							Type: bus.EventSessionStatusChanged,
+							Data: map[string]interface{}{
+								"session_id": session.ID,
+								"run_id":     fc.RunID,
+								"old_status": string(store.SessionStatusWaitingInput),
+								"new_status": string(store.SessionStatusRunning),
+							},
+						})
+					}
 				}
 			}
 		}
@@ -264,6 +277,19 @@ func (m *DefaultManager) DenyFunctionCall(ctx context.Context, callID string, re
 					slog.Info("updated session status back to running after denial",
 						"session_id", session.ID,
 						"approval_id", callID)
+					
+					// Publish session status change event
+					if m.EventBus != nil {
+						m.EventBus.Publish(bus.Event{
+							Type: bus.EventSessionStatusChanged,
+							Data: map[string]interface{}{
+								"session_id": session.ID,
+								"run_id":     fc.RunID,
+								"old_status": string(store.SessionStatusWaitingInput),
+								"new_status": string(store.SessionStatusRunning),
+							},
+						})
+					}
 				}
 			}
 		}

--- a/hld/approval/manager.go
+++ b/hld/approval/manager.go
@@ -197,6 +197,7 @@ func (m *DefaultManager) ApproveFunctionCall(ctx context.Context, callID string,
 					if m.EventBus != nil {
 						m.EventBus.Publish(bus.Event{
 							Type: bus.EventSessionStatusChanged,
+                                                          // TODO(4): Can this be a static type later on? Why isn't it currently? Is this because of JSON RPC or a go thing?
 							Data: map[string]interface{}{
 								"session_id": session.ID,
 								"run_id":     fc.RunID,

--- a/hld/approval/manager.go
+++ b/hld/approval/manager.go
@@ -192,7 +192,7 @@ func (m *DefaultManager) ApproveFunctionCall(ctx context.Context, callID string,
 					slog.Info("updated session status back to running after approval",
 						"session_id", session.ID,
 						"approval_id", callID)
-					
+
 					// Publish session status change event
 					if m.EventBus != nil {
 						m.EventBus.Publish(bus.Event{
@@ -277,7 +277,7 @@ func (m *DefaultManager) DenyFunctionCall(ctx context.Context, callID string, re
 					slog.Info("updated session status back to running after denial",
 						"session_id", session.ID,
 						"approval_id", callID)
-					
+
 					// Publish session status change event
 					if m.EventBus != nil {
 						m.EventBus.Publish(bus.Event{

--- a/humanlayer-wui/src-tauri/src/daemon_client/subscriptions.rs
+++ b/humanlayer-wui/src-tauri/src/daemon_client/subscriptions.rs
@@ -196,7 +196,9 @@ async fn handle_subscription(
 
             // Handle cancellation
             _ = cancel_rx.recv() => {
-                info!("Subscription {} cancelled", id);
+                info!("Subscription {} cancelled, closing connection", id);
+                // Explicitly shutdown the stream to ensure the Go daemon detects closure
+                let _ = stream.shutdown().await;
                 break;
             }
 

--- a/humanlayer-wui/src-tauri/src/lib.rs
+++ b/humanlayer-wui/src-tauri/src/lib.rs
@@ -255,14 +255,14 @@ async fn unsubscribe_from_events(
     subscription_id: String,
 ) -> std::result::Result<(), String> {
     tracing::info!("unsubscribe_from_events: Unsubscribing from subscription {}", subscription_id);
-    
+
     let client_guard = state.client.lock().await;
-    
+
     match &*client_guard {
         Some(client) => {
             // Parse the subscription ID
             let id = subscription_id.parse::<u64>().map_err(|e| format!("Invalid subscription ID: {}", e))?;
-            
+
             client.unsubscribe(id).await.map_err(|e| e.to_string())?;
             tracing::info!("unsubscribe_from_events: Successfully unsubscribed from subscription {}", id);
             Ok(())

--- a/humanlayer-wui/src-tauri/src/lib.rs
+++ b/humanlayer-wui/src-tauri/src/lib.rs
@@ -212,28 +212,29 @@ async fn subscribe_to_events(
         Some(client) => {
             tracing::info!("subscribe_to_events: Client found, attempting to subscribe");
             match client.subscribe(request).await {
-                Ok(mut receiver) => {
-                    tracing::info!("subscribe_to_events: Subscription created successfully, spawning event forwarder");
+                Ok((subscription_id, mut receiver)) => {
+                    tracing::info!("subscribe_to_events: Subscription created successfully with ID {}, spawning event forwarder", subscription_id);
                     // Spawn a task to forward events to the frontend
                     tokio::spawn(async move {
-                        tracing::info!("subscribe_to_events: Event forwarder task started");
+                        tracing::info!("subscribe_to_events: Event forwarder task started for subscription {}", subscription_id);
                         while let Some(event) = receiver.recv().await {
                             tracing::info!(
-                                "subscribe_to_events: Received event from daemon - type: {:?}, data: {:?}",
+                                "subscribe_to_events: Subscription {} received event - type: {:?}, data: {:?}",
+                                subscription_id,
                                 event.event.event_type,
                                 event.event.data
                             );
                             // Emit the event to the frontend
                             if let Err(e) = app.emit("daemon-event", event) {
-                                error!("Failed to emit event: {}", e);
+                                error!("Failed to emit event for subscription {}: {}", subscription_id, e);
                             } else {
-                                tracing::info!("subscribe_to_events: Event emitted to frontend successfully");
+                                tracing::info!("subscribe_to_events: Event emitted to frontend successfully for subscription {}", subscription_id);
                             }
                         }
-                        tracing::warn!("subscribe_to_events: Event receiver channel closed");
+                        tracing::warn!("subscribe_to_events: Event receiver channel closed for subscription {}", subscription_id);
                     });
-                    tracing::info!("subscribe_to_events: Subscription setup completed successfully");
-                    Ok("Subscription created".to_string())
+                    tracing::info!("subscribe_to_events: Subscription {} setup completed successfully", subscription_id);
+                    Ok(subscription_id.to_string())
                 }
                 Err(e) => {
                     tracing::error!("subscribe_to_events: Failed to create subscription - {}", e);
@@ -243,6 +244,31 @@ async fn subscribe_to_events(
         }
         None => {
             tracing::error!("subscribe_to_events: No daemon client connected");
+            Err("Not connected to daemon".to_string())
+        }
+    }
+}
+
+#[tauri::command]
+async fn unsubscribe_from_events(
+    state: State<'_, AppState>,
+    subscription_id: String,
+) -> std::result::Result<(), String> {
+    tracing::info!("unsubscribe_from_events: Unsubscribing from subscription {}", subscription_id);
+    
+    let client_guard = state.client.lock().await;
+    
+    match &*client_guard {
+        Some(client) => {
+            // Parse the subscription ID
+            let id = subscription_id.parse::<u64>().map_err(|e| format!("Invalid subscription ID: {}", e))?;
+            
+            client.unsubscribe(id).await.map_err(|e| e.to_string())?;
+            tracing::info!("unsubscribe_from_events: Successfully unsubscribed from subscription {}", id);
+            Ok(())
+        }
+        None => {
+            tracing::error!("unsubscribe_from_events: No daemon client connected");
             Err("Not connected to daemon".to_string())
         }
     }
@@ -287,6 +313,7 @@ pub fn run() {
             deny_function_call,
             respond_to_human_contact,
             subscribe_to_events,
+            unsubscribe_from_events,
             interrupt_session,
         ])
         .run(tauri::generate_context!())

--- a/humanlayer-wui/src/components/internal/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail.tsx
@@ -298,7 +298,7 @@ function eventToDisplayObject(
             />
           </div>
           {toolInput.edits.map((edit: any, index: number) => (
-            <div key={index} className="mb-4 last:mb-0">
+            <div key={index} className="mb-8 last:mb-0">
               {toolInput.edits.length > 1 && (
                 <div className="mb-2 text-sm font-medium text-muted-foreground">
                   Edit {index + 1} of {toolInput.edits.length}
@@ -621,7 +621,6 @@ function ConversationContent({
   isSplitView?: boolean
   onToggleSplitView?: () => void
 }) {
-  // const { formattedEvents, loading, error } = useFormattedConversation(sessionId)
   const { events, loading, error, isInitialLoad } = useConversation(sessionId, undefined, 1000)
   const [denyingApprovalId, setDenyingApprovalId] = useState<string | null>(null)
   const [focusSource, setFocusSource] = useState<'mouse' | 'keyboard' | null>(null)

--- a/humanlayer-wui/src/hooks/useApprovals.ts
+++ b/humanlayer-wui/src/hooks/useApprovals.ts
@@ -112,7 +112,7 @@ export function useApprovalsWithSubscription(sessionId?: string): UseApprovalsRe
 
     const subscribe = async () => {
       try {
-        unsubscribe = await daemonClient.subscribeToEvents(
+        const { unlisten } = await daemonClient.subscribeToEvents(
           {
             event_types: ['new_approval', 'approval_resolved', 'session_status_changed'],
             session_id: sessionId,
@@ -138,6 +138,7 @@ export function useApprovalsWithSubscription(sessionId?: string): UseApprovalsRe
             },
           },
         )
+        unsubscribe = unlisten
       } catch (err) {
         console.error('Failed to subscribe to events:', err)
         // Fall back to polling on subscription failure

--- a/humanlayer-wui/src/hooks/useSessions.ts
+++ b/humanlayer-wui/src/hooks/useSessions.ts
@@ -139,7 +139,10 @@ export function useSession(sessionId: string | undefined) {
 
               console.log('useSession.onEvent() - event.event.type:', event.event.type)
 
-              if (event.event.type === 'session_status_changed' || event.event.type === 'new_approval') {
+              if (
+                event.event.type === 'session_status_changed' ||
+                event.event.type === 'new_approval'
+              ) {
                 // Refresh session details when status changes or new approvals arrive
                 fetchSession()
               }
@@ -159,7 +162,7 @@ export function useSession(sessionId: string | undefined) {
             },
           },
         )
-        
+
         // Only set these if we're still active (component hasn't unmounted)
         if (isActive) {
           unlisten = subscription.unlisten
@@ -184,10 +187,10 @@ export function useSession(sessionId: string | undefined) {
     return () => {
       isActive = false
       console.log('useSession: Cleanup - unsubscribing from events', { sessionId, subscriptionId })
-      
+
       // First stop listening to events
       unlisten?.()
-      
+
       // Then unsubscribe from the backend to close the connection
       if (subscriptionId) {
         daemonClient.unsubscribeFromEvents(subscriptionId).catch(error => {

--- a/humanlayer-wui/src/hooks/useSessions.ts
+++ b/humanlayer-wui/src/hooks/useSessions.ts
@@ -128,7 +128,7 @@ export function useSession(sessionId: string | undefined) {
         console.log('useSession: Subscribing to events for session:', sessionId)
         const subscription = await daemonClient.subscribeToEvents(
           {
-            event_types: ['session_status_changed'],
+            event_types: ['session_status_changed', 'new_approval'],
             session_id: sessionId,
           },
           {
@@ -137,8 +137,10 @@ export function useSession(sessionId: string | undefined) {
 
               if (!isActive) return
 
-              if (event.event.type === 'session_status_changed') {
-                // Refresh session details when status changes
+              console.log('useSession.onEvent() - event.event.type:', event.event.type)
+
+              if (event.event.type === 'session_status_changed' || event.event.type === 'new_approval') {
+                // Refresh session details when status changes or new approvals arrive
                 fetchSession()
               }
             },

--- a/humanlayer-wui/src/hooks/useSubscriptions.ts
+++ b/humanlayer-wui/src/hooks/useSubscriptions.ts
@@ -20,7 +20,7 @@ export function useSessionSubscriptions(connected: boolean = true) {
 
     const subscribe = async () => {
       try {
-        unsubscribe = await daemonClient.subscribeToEvents(
+        const subscription = await daemonClient.subscribeToEvents(
           {
             event_types: ['session_status_changed', 'approval_requested', 'approval_resolved'],
           },
@@ -64,6 +64,7 @@ export function useSessionSubscriptions(connected: boolean = true) {
           },
         )
 
+        unsubscribe = subscription.unlisten
         isSubscribedRef.current = true
         console.log('Subscribed to session events')
       } catch (err) {

--- a/humanlayer-wui/src/lib/daemon/client.ts
+++ b/humanlayer-wui/src/lib/daemon/client.ts
@@ -69,8 +69,8 @@ export class DaemonClient {
 
       onError?: (error: Error) => void
     } = {},
-  ): Promise<() => void> {
-    await invoke('subscribe_to_events', { request })
+  ): Promise<{ unlisten: () => void; subscriptionId: string }> {
+    const subscriptionId = await invoke<string>('subscribe_to_events', { request })
 
     // Listen for daemon events and forward to handlers
     const unlisten = await listen<EventNotification>('daemon-event', event => {
@@ -82,7 +82,11 @@ export class DaemonClient {
       }
     })
 
-    return unlisten
+    return { unlisten, subscriptionId }
+  }
+
+  async unsubscribeFromEvents(subscriptionId: string): Promise<void> {
+    await invoke('unsubscribe_from_events', { subscriptionId })
   }
 
   async interruptSession(sessionId: string): Promise<void> {


### PR DESCRIPTION
## What problem(s) was I solving?

The SessionDetail page in humanlayer-wui was not updating in real-time when the session status changed. Specifically:

1. When new approvals arrived (requiring human input), the UI didn't reflect that the session was waiting for input
2. When approvals were resolved (approved/denied), the UI didn't update to show the session was running again
3. Users had to manually refresh the page to see status changes

Additionally, there was a resource leak where event subscriptions were accumulating without proper cleanup when navigating between session views.

## What user-facing changes did I ship?

- **Real-time session status updates**: The SessionDetail page now automatically updates when:
  - A new approval arrives → Session status shows "waiting_input" 
  - An approval is approved/denied → Session status returns to "running"
  - An approval is resolved externally → Session status returns to "running"
  
- **Better resource management**: Fixed subscription cleanup to prevent memory leaks when navigating between sessions

- **Improved UI spacing**: Added better spacing between multiple edits in the MultiEdit tool display

## How I implemented it

### 1. Fixed subscription cleanup architecture
- Added proper unsubscribe mechanism across the stack (Rust → Tauri → TypeScript → React)
- Modified `subscribeToEvents` to return both an unlisten function and subscription ID
- Implemented `unsubscribe_from_events` Tauri command that properly closes the Unix socket
- Updated React hooks to call both unlisten() and unsubscribeFromEvents() on cleanup
- Added protection against React StrictMode double-subscriptions

### 2. Added missing event publishing
- Modified `correlateApproval` in `approval/poller.go` to publish `EventSessionStatusChanged` when status changes to `waiting_input`
- Updated `ApproveFunctionCall` and `DenyFunctionCall` in `approval/manager.go` to publish events when status changes back to `running`
- Added event publishing when approvals are resolved externally (in the poller reconciliation)

### 3. Updated frontend subscriptions
- Modified `useSession` hook to listen for both `session_status_changed` and `new_approval` events
- Fixed `useApprovalsWithSubscription` and `useSubscriptions` hooks to handle the new subscription return type

## How to verify it

- [x] I have ensured `make check test` passes (Note: claudecode-go tests fail but are unrelated to this PR - all modified components pass)

### Manual testing steps:
1. Open a SessionDetail page for a running session
2. Trigger an approval (e.g., have the agent try to use a tool)
3. Verify the session status changes to "waiting_input" automatically
4. Approve or deny the approval
5. Verify the session status changes back to "running" automatically
6. Navigate between different sessions and verify no console errors about failed unsubscribes

## Description for the changelog

Fixed real-time session status updates in the web UI when approvals arrive or are resolved, and fixed subscription cleanup to prevent resource leaks