### PR TITLE
fix resumed sessions to inherit all configuration from parent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ test-hlyr: ## Test hlyr CLI tool
 	@$(MAKE) -C hlyr test VERBOSE=$(VERBOSE)
 
 .PHONY: test-hld
-test-hld: ## Test hld daemon (unit tests only)
-	@$(MAKE) -C hld test-unit VERBOSE=$(VERBOSE)
+test-hld: ## Test hld daemon (unit and integration tests)
+	@$(MAKE) -C hld test VERBOSE=$(VERBOSE)
 
 .PHONY: test-hld-integration
 test-hld-integration: ## Test hld daemon (including integration tests)

--- a/hld/Makefile
+++ b/hld/Makefile
@@ -5,13 +5,32 @@ build:
 	go build -o hld ./cmd/hld
 
 # Run all tests
-test: test-unit test-integration
+test:
+	@if [ -n "$$VERBOSE" ]; then \
+		$(MAKE) test-unit test-integration; \
+	else \
+		$(MAKE) test-quiet; \
+	fi
+
+# Run all tests with quiet output
+test-quiet:
+	@. ../hack/run_silent.sh && print_header "hld" "Daemon tests"
+	@$(MAKE) test-unit-quiet
+	@$(MAKE) test-integration-quiet
 
 # Base test-unit target overridden below
 
 # Run integration tests (requires build tag)
 test-integration: build
-	CGO_LDFLAGS="-Wl,-w" go test -v -tags=integration -run Integration ./daemon/...
+	@if [ -n "$$VERBOSE" ]; then \
+		CGO_LDFLAGS="-Wl,-w" go test -v -tags=integration -run Integration ./daemon/...; \
+	else \
+		$(MAKE) test-integration-quiet; \
+	fi
+
+# Run integration tests with quiet output
+test-integration-quiet: build
+	@. ../hack/run_silent.sh && run_silent_with_test_count "Integration tests passed" "CGO_LDFLAGS=\"-Wl,-w\" go test -json -tags=integration -run Integration ./daemon/..." "go"
 
 # Run tests with race detection
 test-race:

--- a/hld/daemon/daemon_conversation_integration_test.go
+++ b/hld/daemon/daemon_conversation_integration_test.go
@@ -193,7 +193,9 @@ func TestGetConversationIntegration(t *testing.T) {
 		// because it needs to look up the claude_session_id first
 		_, err := daemonClient.GetConversation("nonexistent-session")
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to get conversation")
+		if err != nil {
+			assert.Contains(t, err.Error(), "failed to get conversation")
+		}
 	})
 
 	t.Run("GetSessionState for nonexistent session", func(t *testing.T) {

--- a/hld/daemon/daemon_session_state_integration_test.go
+++ b/hld/daemon/daemon_session_state_integration_test.go
@@ -33,14 +33,14 @@ func TestSessionStateTransitionsIntegration(t *testing.T) {
 	// access the same database (in-memory databases are unique per connection)
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "test.db")
-	
+
 	// Create the store
 	testStore, err := store.NewSQLiteStore(dbPath)
 	if err != nil {
 		t.Fatalf("failed to create test store: %v", err)
 	}
 	defer testStore.Close()
-	
+
 	// Set environment variables to ensure consistent test behavior
 	t.Setenv("HUMANLAYER_DATABASE_PATH", dbPath)
 	t.Setenv("HUMANLAYER_API_KEY", "test-key")

--- a/hld/session/continue_inheritance_test.go
+++ b/hld/session/continue_inheritance_test.go
@@ -1,0 +1,471 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	claudecode "github.com/humanlayer/humanlayer/claudecode-go"
+	"github.com/humanlayer/humanlayer/hld/bus"
+	"github.com/humanlayer/humanlayer/hld/store"
+)
+
+func TestContinueSessionInheritance(t *testing.T) {
+	ctx := context.Background()
+
+	// Create test components
+	eventBus := bus.NewEventBus()
+	sqliteStore, err := store.NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+	defer func() { _ = sqliteStore.Close() }()
+
+	manager, err := NewManager(eventBus, sqliteStore)
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+
+	t.Run("InheritsAllConfigurationFields", func(t *testing.T) {
+		// Create parent session with full configuration
+		parentSessionID := "parent-full-config"
+		parentSession := &store.Session{
+			ID:                   parentSessionID,
+			RunID:                "run-parent",
+			ClaudeSessionID:      "claude-parent",
+			Status:               store.SessionStatusCompleted,
+			Query:                "original query",
+			Model:                "claude-3-opus-20240229",
+			WorkingDir:           "/tmp/test",
+			MaxTurns:             10,
+			SystemPrompt:         "You are a helpful assistant",
+			AppendSystemPrompt:   "Be concise",
+			CustomInstructions:   "Follow best practices",
+			PermissionPromptTool: "hlyr",
+			AllowedTools:         `["tool1", "tool2"]`,
+			DisallowedTools:      `["tool3"]`,
+			CreatedAt:            time.Now(),
+			LastActivityAt:       time.Now(),
+			CompletedAt:          &time.Time{},
+		}
+
+		if err := sqliteStore.CreateSession(ctx, parentSession); err != nil {
+			t.Fatalf("Failed to create parent session: %v", err)
+		}
+
+		// Continue session with minimal config (only required fields)
+		req := ContinueSessionConfig{
+			ParentSessionID: parentSessionID,
+			Query:           "follow up question",
+		}
+
+		// This will fail because Claude binary doesn't exist in test env,
+		// but we can still check that the config was built correctly
+		_, _ = manager.ContinueSession(ctx, req)
+
+		// We expect it to fail at launch, but let's check the session was created with inherited config
+		sessions, err := sqliteStore.ListSessions(ctx)
+		if err != nil {
+			t.Fatalf("Failed to list sessions: %v", err)
+		}
+
+		// Should have parent and child sessions
+		if len(sessions) < 2 {
+			t.Fatalf("Expected at least 2 sessions, got %d", len(sessions))
+		}
+
+		// Find the child session (most recent)
+		var childSession *store.Session
+		for _, s := range sessions {
+			if s.ParentSessionID == parentSessionID {
+				childSession = s
+				break
+			}
+		}
+
+		if childSession == nil {
+			t.Fatal("Child session not found")
+		}
+
+		// Verify all fields were inherited
+		if childSession.Model != parentSession.Model {
+			t.Errorf("Model not inherited: got %s, want %s", childSession.Model, parentSession.Model)
+		}
+		if childSession.WorkingDir != parentSession.WorkingDir {
+			t.Errorf("WorkingDir not inherited: got %s, want %s", childSession.WorkingDir, parentSession.WorkingDir)
+		}
+		if childSession.SystemPrompt != parentSession.SystemPrompt {
+			t.Errorf("SystemPrompt not inherited: got %s, want %s", childSession.SystemPrompt, parentSession.SystemPrompt)
+		}
+		if childSession.AppendSystemPrompt != parentSession.AppendSystemPrompt {
+			t.Errorf("AppendSystemPrompt not inherited: got %s, want %s", childSession.AppendSystemPrompt, parentSession.AppendSystemPrompt)
+		}
+		if childSession.CustomInstructions != parentSession.CustomInstructions {
+			t.Errorf("CustomInstructions not inherited: got %s, want %s", childSession.CustomInstructions, parentSession.CustomInstructions)
+		}
+		if childSession.PermissionPromptTool != parentSession.PermissionPromptTool {
+			t.Errorf("PermissionPromptTool not inherited: got %s, want %s", childSession.PermissionPromptTool, parentSession.PermissionPromptTool)
+		}
+		// Compare allowed tools (deserialize to compare content, not formatting)
+		var childAllowed, parentAllowed []string
+		if err := json.Unmarshal([]byte(childSession.AllowedTools), &childAllowed); err != nil {
+			t.Fatalf("Failed to unmarshal child allowed tools: %v", err)
+		}
+		if err := json.Unmarshal([]byte(parentSession.AllowedTools), &parentAllowed); err != nil {
+			t.Fatalf("Failed to unmarshal parent allowed tools: %v", err)
+		}
+		if len(childAllowed) != len(parentAllowed) {
+			t.Errorf("AllowedTools length mismatch: got %d, want %d", len(childAllowed), len(parentAllowed))
+		} else {
+			for i, tool := range childAllowed {
+				if tool != parentAllowed[i] {
+					t.Errorf("AllowedTools[%d] not inherited: got %s, want %s", i, tool, parentAllowed[i])
+				}
+			}
+		}
+
+		// Compare disallowed tools
+		var childDisallowed, parentDisallowed []string
+		if err := json.Unmarshal([]byte(childSession.DisallowedTools), &childDisallowed); err != nil {
+			t.Fatalf("Failed to unmarshal child disallowed tools: %v", err)
+		}
+		if err := json.Unmarshal([]byte(parentSession.DisallowedTools), &parentDisallowed); err != nil {
+			t.Fatalf("Failed to unmarshal parent disallowed tools: %v", err)
+		}
+		if len(childDisallowed) != len(parentDisallowed) {
+			t.Errorf("DisallowedTools length mismatch: got %d, want %d", len(childDisallowed), len(parentDisallowed))
+		} else {
+			for i, tool := range childDisallowed {
+				if tool != parentDisallowed[i] {
+					t.Errorf("DisallowedTools[%d] not inherited: got %s, want %s", i, tool, parentDisallowed[i])
+				}
+			}
+		}
+
+		// MaxTurns should NOT be inherited (as per spec)
+		if childSession.MaxTurns == parentSession.MaxTurns {
+			t.Error("MaxTurns should not be inherited")
+		}
+	})
+
+	t.Run("InheritsMCPServers", func(t *testing.T) {
+		// Create parent session
+		parentSessionID := "parent-mcp"
+		parentSession := &store.Session{
+			ID:                   parentSessionID,
+			RunID:                "run-mcp",
+			ClaudeSessionID:      "claude-mcp",
+			Status:               store.SessionStatusCompleted,
+			Query:                "mcp query",
+			Model:                "claude-3-opus-20240229",
+			WorkingDir:           "/tmp/test",
+			SystemPrompt:         "Test prompt",
+			PermissionPromptTool: "hlyr",
+			CreatedAt:            time.Now(),
+			LastActivityAt:       time.Now(),
+			CompletedAt:          &time.Time{},
+		}
+
+		if err := sqliteStore.CreateSession(ctx, parentSession); err != nil {
+			t.Fatalf("Failed to create parent session: %v", err)
+		}
+
+		// Store MCP servers for parent
+		mcpServers := []store.MCPServer{
+			{
+				SessionID: parentSessionID,
+				Name:      "test-server-1",
+				Command:   "node",
+				ArgsJSON:  `["server1.js", "--port", "3000"]`,
+				EnvJSON:   `{"NODE_ENV": "test", "API_KEY": "secret"}`,
+			},
+			{
+				SessionID: parentSessionID,
+				Name:      "test-server-2",
+				Command:   "python",
+				ArgsJSON:  `["server2.py"]`,
+				EnvJSON:   `{"PYTHONPATH": "/usr/lib"}`,
+			},
+		}
+		if err := sqliteStore.StoreMCPServers(ctx, parentSessionID, mcpServers); err != nil {
+			t.Fatalf("Failed to store MCP servers: %v", err)
+		}
+
+		// Continue session
+		req := ContinueSessionConfig{
+			ParentSessionID: parentSessionID,
+			Query:           "mcp follow up",
+		}
+
+		_, _ = manager.ContinueSession(ctx, req)
+		// Expected to fail due to missing Claude binary
+
+		// Find the child session
+		sessions, err := sqliteStore.ListSessions(ctx)
+		if err != nil {
+			t.Fatalf("Failed to list sessions: %v", err)
+		}
+
+		var childSession *store.Session
+		for _, s := range sessions {
+			if s.ParentSessionID == parentSessionID {
+				childSession = s
+				break
+			}
+		}
+
+		if childSession == nil {
+			t.Fatal("Child session not found")
+		}
+
+		// Get MCP servers for child session
+		childMCPServers, err := sqliteStore.GetMCPServers(ctx, childSession.ID)
+		if err != nil {
+			t.Fatalf("Failed to get child MCP servers: %v", err)
+		}
+
+		// Should have inherited the MCP servers
+		if len(childMCPServers) != len(mcpServers) {
+			t.Errorf("MCP servers not inherited: got %d, want %d", len(childMCPServers), len(mcpServers))
+		}
+
+		// Verify server details (accounting for HUMANLAYER_RUN_ID being added)
+		for i, server := range childMCPServers {
+			if server.Name != mcpServers[i].Name {
+				t.Errorf("MCP server %d name mismatch: got %s, want %s", i, server.Name, mcpServers[i].Name)
+			}
+			if server.Command != mcpServers[i].Command {
+				t.Errorf("MCP server %d command mismatch: got %s, want %s", i, server.Command, mcpServers[i].Command)
+			}
+
+			// Compare args (deserialize to compare content)
+			var childArgs, parentArgs []string
+			if err := json.Unmarshal([]byte(server.ArgsJSON), &childArgs); err != nil {
+				t.Fatalf("Failed to unmarshal child args: %v", err)
+			}
+			if err := json.Unmarshal([]byte(mcpServers[i].ArgsJSON), &parentArgs); err != nil {
+				t.Fatalf("Failed to unmarshal parent args: %v", err)
+			}
+			if len(childArgs) != len(parentArgs) {
+				t.Errorf("MCP server %d args length mismatch", i)
+			} else {
+				for j, arg := range childArgs {
+					if arg != parentArgs[j] {
+						t.Errorf("MCP server %d arg[%d] mismatch: got %s, want %s", i, j, arg, parentArgs[j])
+					}
+				}
+			}
+
+			// Compare env (deserialize and check that parent env is subset of child env)
+			var childEnv, parentEnv map[string]string
+			if err := json.Unmarshal([]byte(server.EnvJSON), &childEnv); err != nil {
+				t.Fatalf("Failed to unmarshal child env: %v", err)
+			}
+			if err := json.Unmarshal([]byte(mcpServers[i].EnvJSON), &parentEnv); err != nil {
+				t.Fatalf("Failed to unmarshal parent env: %v", err)
+			}
+
+			// Child should have all parent env vars plus HUMANLAYER_RUN_ID
+			for key, val := range parentEnv {
+				if childEnv[key] != val {
+					t.Errorf("MCP server %d env[%s] mismatch: got %s, want %s", i, key, childEnv[key], val)
+				}
+			}
+
+			// Should have HUMANLAYER_RUN_ID added
+			if _, ok := childEnv["HUMANLAYER_RUN_ID"]; !ok {
+				t.Errorf("MCP server %d missing HUMANLAYER_RUN_ID in env", i)
+			}
+		}
+	})
+
+	t.Run("OverridesWorkCorrectly", func(t *testing.T) {
+		// Create parent session
+		parentSessionID := "parent-override"
+		parentSession := &store.Session{
+			ID:                   parentSessionID,
+			RunID:                "run-override",
+			ClaudeSessionID:      "claude-override",
+			Status:               store.SessionStatusCompleted,
+			Query:                "original",
+			Model:                "claude-3-opus-20240229",
+			WorkingDir:           "/tmp/test",
+			SystemPrompt:         "Original system prompt",
+			AppendSystemPrompt:   "Original append",
+			CustomInstructions:   "Original instructions",
+			PermissionPromptTool: "original-tool",
+			AllowedTools:         `["original1", "original2"]`,
+			DisallowedTools:      `["original3"]`,
+			CreatedAt:            time.Now(),
+			LastActivityAt:       time.Now(),
+			CompletedAt:          &time.Time{},
+		}
+
+		if err := sqliteStore.CreateSession(ctx, parentSession); err != nil {
+			t.Fatalf("Failed to create parent session: %v", err)
+		}
+
+		// Continue with overrides
+		req := ContinueSessionConfig{
+			ParentSessionID:      parentSessionID,
+			Query:                "override query",
+			SystemPrompt:         "Override system prompt",
+			AppendSystemPrompt:   "Override append",
+			CustomInstructions:   "Override instructions",
+			PermissionPromptTool: "override-tool",
+			AllowedTools:         []string{"override1", "override2", "override3"},
+			DisallowedTools:      []string{"override4", "override5"},
+			MaxTurns:             5,
+		}
+
+		_, _ = manager.ContinueSession(ctx, req)
+		// Expected to fail due to missing Claude binary
+
+		// Find the child session
+		sessions, err := sqliteStore.ListSessions(ctx)
+		if err != nil {
+			t.Fatalf("Failed to list sessions: %v", err)
+		}
+
+		var childSession *store.Session
+		for _, s := range sessions {
+			if s.ParentSessionID == parentSessionID {
+				childSession = s
+				break
+			}
+		}
+
+		if childSession == nil {
+			t.Fatal("Child session not found")
+		}
+
+		// Verify overrides were applied
+		if childSession.SystemPrompt != "Override system prompt" {
+			t.Errorf("SystemPrompt override failed: got %s", childSession.SystemPrompt)
+		}
+		if childSession.AppendSystemPrompt != "Override append" {
+			t.Errorf("AppendSystemPrompt override failed: got %s", childSession.AppendSystemPrompt)
+		}
+		if childSession.CustomInstructions != "Override instructions" {
+			t.Errorf("CustomInstructions override failed: got %s", childSession.CustomInstructions)
+		}
+		if childSession.PermissionPromptTool != "override-tool" {
+			t.Errorf("PermissionPromptTool override failed: got %s", childSession.PermissionPromptTool)
+		}
+
+		// Check allowed tools
+		var allowedTools []string
+		if err := json.Unmarshal([]byte(childSession.AllowedTools), &allowedTools); err != nil {
+			t.Fatalf("Failed to unmarshal AllowedTools: %v", err)
+		}
+		if len(allowedTools) != 3 || allowedTools[0] != "override1" {
+			t.Errorf("AllowedTools override failed: got %v", allowedTools)
+		}
+
+		// Check disallowed tools
+		var disallowedTools []string
+		if err := json.Unmarshal([]byte(childSession.DisallowedTools), &disallowedTools); err != nil {
+			t.Fatalf("Failed to unmarshal DisallowedTools: %v", err)
+		}
+		if len(disallowedTools) != 2 || disallowedTools[0] != "override4" {
+			t.Errorf("DisallowedTools override failed: got %v", disallowedTools)
+		}
+
+		if childSession.MaxTurns != 5 {
+			t.Errorf("MaxTurns override failed: got %d", childSession.MaxTurns)
+		}
+	})
+
+	t.Run("MCPConfigOverride", func(t *testing.T) {
+		// Create parent session with MCP
+		parentSessionID := "parent-mcp-override"
+		parentSession := &store.Session{
+			ID:              parentSessionID,
+			RunID:           "run-mcp-override",
+			ClaudeSessionID: "claude-mcp-override",
+			Status:          store.SessionStatusCompleted,
+			Query:           "original",
+			Model:           "claude-3-opus-20240229",
+			WorkingDir:      "/tmp/test",
+			CreatedAt:       time.Now(),
+			LastActivityAt:  time.Now(),
+			CompletedAt:     &time.Time{},
+		}
+
+		if err := sqliteStore.CreateSession(ctx, parentSession); err != nil {
+			t.Fatalf("Failed to create parent session: %v", err)
+		}
+
+		// Store original MCP servers
+		originalServers := []store.MCPServer{
+			{
+				SessionID: parentSessionID,
+				Name:      "original-server",
+				Command:   "original-cmd",
+				ArgsJSON:  `["original"]`,
+				EnvJSON:   `{"ORIGINAL": "true"}`,
+			},
+		}
+		if err := sqliteStore.StoreMCPServers(ctx, parentSessionID, originalServers); err != nil {
+			t.Fatalf("Failed to store MCP servers: %v", err)
+		}
+
+		// Continue with MCP override
+		overrideMCP := &claudecode.MCPConfig{
+			MCPServers: map[string]claudecode.MCPServer{
+				"override-server": {
+					Command: "override-cmd",
+					Args:    []string{"override"},
+					Env:     map[string]string{"OVERRIDE": "true"},
+				},
+			},
+		}
+
+		req := ContinueSessionConfig{
+			ParentSessionID: parentSessionID,
+			Query:           "override query",
+			MCPConfig:       overrideMCP,
+		}
+
+		_, _ = manager.ContinueSession(ctx, req)
+		// Expected to fail due to missing Claude binary
+
+		// Find the child session
+		sessions, err := sqliteStore.ListSessions(ctx)
+		if err != nil {
+			t.Fatalf("Failed to list sessions: %v", err)
+		}
+
+		var childSession *store.Session
+		for _, s := range sessions {
+			if s.ParentSessionID == parentSessionID {
+				childSession = s
+				break
+			}
+		}
+
+		if childSession == nil {
+			t.Fatal("Child session not found")
+		}
+
+		// Get MCP servers for child
+		childMCPServers, err := sqliteStore.GetMCPServers(ctx, childSession.ID)
+		if err != nil {
+			t.Fatalf("Failed to get child MCP servers: %v", err)
+		}
+
+		// Should have the override server, not the original
+		if len(childMCPServers) != 1 {
+			t.Fatalf("Expected 1 MCP server, got %d", len(childMCPServers))
+		}
+
+		server := childMCPServers[0]
+		if server.Name != "override-server" {
+			t.Errorf("MCP server name not overridden: got %s", server.Name)
+		}
+		if server.Command != "override-cmd" {
+			t.Errorf("MCP server command not overridden: got %s", server.Command)
+		}
+	})
+}

--- a/hld/session/manager.go
+++ b/hld/session/manager.go
@@ -197,54 +197,83 @@ func (m *Manager) LaunchSession(ctx context.Context, config claudecode.SessionCo
 func (m *Manager) monitorSession(ctx context.Context, sessionID, runID string, claudeSession *claudecode.Session, startTime time.Time, config claudecode.SessionConfig) {
 	// Get the session ID from the Claude session once available
 	var claudeSessionID string
-	for event := range claudeSession.Events {
-		// Store raw event for debugging
-		eventJSON, err := json.Marshal(event)
-		if err != nil {
-			slog.Error("failed to marshal event", "error", err)
-		} else {
-			if err := m.store.StoreRawEvent(ctx, sessionID, string(eventJSON)); err != nil {
-				slog.Debug("failed to store raw event", "error", err)
-			}
-		}
 
-		// Capture Claude session ID
-		if event.SessionID != "" && claudeSessionID == "" {
-			claudeSessionID = event.SessionID
-			// Note: Claude session ID captured for resume capability
-			slog.Debug("captured Claude session ID",
-				"session_id", sessionID,
-				"claude_session_id", claudeSessionID)
-
-			// Update database
-			update := store.SessionUpdate{
-				ClaudeSessionID: &claudeSessionID,
-			}
-			if err := m.store.UpdateSession(ctx, sessionID, update); err != nil {
-				slog.Error("failed to update session in database", "error", err)
+eventLoop:
+	for {
+		select {
+		case <-ctx.Done():
+			// Context cancelled, stop processing
+			slog.Debug("monitorSession context cancelled, stopping event processing",
+				"session_id", sessionID)
+			return
+		case event, ok := <-claudeSession.Events:
+			if !ok {
+				// Channel closed, exit loop
+				break eventLoop
 			}
 
-			// Inject the pending query now that we have Claude session ID
-			if queryVal, ok := m.pendingQueries.LoadAndDelete(sessionID); ok {
-				if query, ok := queryVal.(string); ok && query != "" {
-					if err := m.injectQueryAsFirstEvent(ctx, sessionID, claudeSessionID, query); err != nil {
-						slog.Error("failed to inject query as first event",
-							"sessionID", sessionID,
-							"claudeSessionID", claudeSessionID,
-							"error", err)
+			// Check context before each database operation
+			if ctx.Err() != nil {
+				slog.Debug("context cancelled during event processing",
+					"session_id", sessionID)
+				return
+			}
+
+			// Store raw event for debugging
+			eventJSON, err := json.Marshal(event)
+			if err != nil {
+				slog.Error("failed to marshal event", "error", err)
+			} else {
+				if err := m.store.StoreRawEvent(ctx, sessionID, string(eventJSON)); err != nil {
+					slog.Debug("failed to store raw event", "error", err)
+				}
+			}
+
+			// Capture Claude session ID
+			if event.SessionID != "" && claudeSessionID == "" {
+				claudeSessionID = event.SessionID
+				// Note: Claude session ID captured for resume capability
+				slog.Debug("captured Claude session ID",
+					"session_id", sessionID,
+					"claude_session_id", claudeSessionID)
+
+				// Update database
+				update := store.SessionUpdate{
+					ClaudeSessionID: &claudeSessionID,
+				}
+				if err := m.store.UpdateSession(ctx, sessionID, update); err != nil {
+					slog.Error("failed to update session in database", "error", err)
+				}
+
+				// Inject the pending query now that we have Claude session ID
+				if queryVal, ok := m.pendingQueries.LoadAndDelete(sessionID); ok {
+					if query, ok := queryVal.(string); ok && query != "" {
+						if err := m.injectQueryAsFirstEvent(ctx, sessionID, claudeSessionID, query); err != nil {
+							slog.Error("failed to inject query as first event",
+								"sessionID", sessionID,
+								"claudeSessionID", claudeSessionID,
+								"error", err)
+						}
 					}
 				}
 			}
-		}
 
-		// Process and store event
-		if err := m.processStreamEvent(ctx, sessionID, claudeSessionID, event); err != nil {
-			slog.Error("failed to process stream event", "error", err)
+			// Process and store event
+			if err := m.processStreamEvent(ctx, sessionID, claudeSessionID, event); err != nil {
+				slog.Error("failed to process stream event", "error", err)
+			}
 		}
 	}
 
 	// Wait for session to complete
 	result, err := claudeSession.Wait()
+
+	// Check if context was cancelled before updating database
+	if ctx.Err() != nil {
+		slog.Debug("context cancelled, skipping final session updates",
+			"session_id", sessionID)
+		return
+	}
 
 	endTime := time.Now()
 	if err != nil {

--- a/hld/session/manager_test.go
+++ b/hld/session/manager_test.go
@@ -279,6 +279,9 @@ func TestContinueSession_CreatesNewSessionWithParentReference(t *testing.T) {
 	}
 	mockStore.EXPECT().GetSession(gomock.Any(), "parent-1").Return(parentSession, nil)
 
+	// Expect GetMCPServers call (even if it returns empty)
+	mockStore.EXPECT().GetMCPServers(gomock.Any(), "parent-1").Return([]store.MCPServer{}, nil)
+
 	// Expect session creation with parent reference
 	mockStore.EXPECT().CreateSession(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx interface{}, session *store.Session) error {
@@ -298,6 +301,9 @@ func TestContinueSession_CreatesNewSessionWithParentReference(t *testing.T) {
 			}
 			return nil
 		})
+
+	// Expect MCP servers to be stored (may or may not be called)
+	mockStore.EXPECT().StoreMCPServers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	// Expect status update to running (we can't test the full flow without mocking Claude client)
 	// May be called twice if Claude fails to launch in background
@@ -348,6 +354,9 @@ func TestContinueSession_HandlesOptionalOverrides(t *testing.T) {
 	}
 	mockStore.EXPECT().GetSession(gomock.Any(), "parent-1").Return(parentSession, nil)
 
+	// Expect GetMCPServers call (even if it returns empty)
+	mockStore.EXPECT().GetMCPServers(gomock.Any(), "parent-1").Return([]store.MCPServer{}, nil)
+
 	// Test with various overrides
 	req := ContinueSessionConfig{
 		ParentSessionID:      "parent-1",
@@ -376,6 +385,9 @@ func TestContinueSession_HandlesOptionalOverrides(t *testing.T) {
 			}
 			return nil
 		})
+
+	// Expect MCP servers to be stored (if MCPConfig override is provided)
+	mockStore.EXPECT().StoreMCPServers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	// Expect status update
 	// May be called twice if Claude fails to launch in background

--- a/hld/store/sqlite.go
+++ b/hld/store/sqlite.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	claudecode "github.com/humanlayer/humanlayer/claudecode-go"
@@ -1061,8 +1062,17 @@ func (s *SQLiteStore) StoreRawEvent(ctx context.Context, sessionID string, event
 
 // Helper function to convert MCP config to store format
 func MCPServersFromConfig(sessionID string, config map[string]claudecode.MCPServer) ([]MCPServer, error) {
+	// First, collect all server names and sort them for deterministic ordering
+	names := make([]string, 0, len(config))
+	for name := range config {
+		names = append(names, name)
+	}
+	// Sort names to ensure consistent ordering
+	sort.Strings(names)
+
 	servers := make([]MCPServer, 0, len(config))
-	for name, server := range config {
+	for _, name := range names {
+		server := config[name]
 		argsJSON, err := json.Marshal(server.Args)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal args: %w", err)

--- a/hld/store/sqlite.go
+++ b/hld/store/sqlite.go
@@ -1020,6 +1020,7 @@ func (s *SQLiteStore) GetMCPServers(ctx context.Context, sessionID string) ([]MC
 		SELECT id, session_id, name, command, args_json, env_json
 		FROM mcp_servers
 		WHERE session_id = ?
+		ORDER BY id
 	`
 
 	rows, err := s.db.QueryContext(ctx, query, sessionID)

--- a/hld/store/sqlite_test.go
+++ b/hld/store/sqlite_test.go
@@ -436,10 +436,10 @@ func TestGetSessionConversationWithParentChain(t *testing.T) {
 	})
 
 	t.Run("GetSessionConversation_NonExistentSession", func(t *testing.T) {
-		// Should return empty events for non-existent session
-		events, err := store.GetSessionConversation(ctx, "does-not-exist")
-		require.NoError(t, err)
-		require.Len(t, events, 0)
+		// Should return error for non-existent session
+		_, err := store.GetSessionConversation(ctx, "does-not-exist")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "session not found: does-not-exist")
 	})
 
 	t.Run("GetSessionConversation_NoParent", func(t *testing.T) {

--- a/hld/store/store.go
+++ b/hld/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	claudecode "github.com/humanlayer/humanlayer/claudecode-go"
@@ -42,27 +43,31 @@ type ConversationStore interface {
 
 // Session represents a Claude Code session
 type Session struct {
-	ID                 string
-	RunID              string
-	ClaudeSessionID    string
-	ParentSessionID    string
-	Query              string
-	Summary            string
-	Model              string
-	WorkingDir         string
-	MaxTurns           int
-	SystemPrompt       string
-	CustomInstructions string
-	Status             string
-	CreatedAt          time.Time
-	LastActivityAt     time.Time
-	CompletedAt        *time.Time
-	CostUSD            *float64
-	TotalTokens        *int
-	DurationMS         *int
-	NumTurns           *int
-	ResultContent      string
-	ErrorMessage       string
+	ID                   string
+	RunID                string
+	ClaudeSessionID      string
+	ParentSessionID      string
+	Query                string
+	Summary              string
+	Model                string
+	WorkingDir           string
+	MaxTurns             int
+	SystemPrompt         string
+	AppendSystemPrompt   string // NEW: Append to system prompt
+	CustomInstructions   string
+	PermissionPromptTool string // NEW: MCP tool for permission prompts
+	AllowedTools         string // NEW: JSON array of allowed tools
+	DisallowedTools      string // NEW: JSON array of disallowed tools
+	Status               string
+	CreatedAt            time.Time
+	LastActivityAt       time.Time
+	CompletedAt          *time.Time
+	CostUSD              *float64
+	TotalTokens          *int
+	DurationMS           *int
+	NumTurns             *int
+	ResultContent        string
+	ErrorMessage         string
 }
 
 // SessionUpdate contains fields that can be updated
@@ -148,17 +153,25 @@ const (
 
 // NewSessionFromConfig creates a Session from Claude SessionConfig
 func NewSessionFromConfig(id, runID string, config claudecode.SessionConfig) *Session {
+	// Convert slices to JSON for storage
+	allowedToolsJSON, _ := json.Marshal(config.AllowedTools)
+	disallowedToolsJSON, _ := json.Marshal(config.DisallowedTools)
+
 	return &Session{
-		ID:                 id,
-		RunID:              runID,
-		Query:              config.Query,
-		Model:              string(config.Model),
-		WorkingDir:         config.WorkingDir,
-		MaxTurns:           config.MaxTurns,
-		SystemPrompt:       config.SystemPrompt,
-		CustomInstructions: config.CustomInstructions,
-		Status:             SessionStatusStarting,
-		CreatedAt:          time.Now(),
-		LastActivityAt:     time.Now(),
+		ID:                   id,
+		RunID:                runID,
+		Query:                config.Query,
+		Model:                string(config.Model),
+		WorkingDir:           config.WorkingDir,
+		MaxTurns:             config.MaxTurns,
+		SystemPrompt:         config.SystemPrompt,
+		AppendSystemPrompt:   config.AppendSystemPrompt,
+		CustomInstructions:   config.CustomInstructions,
+		PermissionPromptTool: config.PermissionPromptTool,
+		AllowedTools:         string(allowedToolsJSON),
+		DisallowedTools:      string(disallowedToolsJSON),
+		Status:               SessionStatusStarting,
+		CreatedAt:            time.Now(),
+		LastActivityAt:       time.Now(),
 	}
 }

--- a/humanlayer-tui/conversation.go
+++ b/humanlayer-tui/conversation.go
@@ -32,10 +32,6 @@ type conversationModel struct {
 	resumeInput      textinput.Model
 	showResumePrompt bool
 
-	// Parent session data for inheritance (stored during resume)
-	parentModel      string
-	parentWorkingDir string
-
 	// Loading states
 	loading     bool
 	error       error
@@ -85,9 +81,6 @@ func (cm *conversationModel) setSession(sessionID string) {
 	cm.clearApprovalState()
 	cm.clearResumeState()
 	cm.stopPolling() // Stop any existing polling
-	// Clear parent data when switching sessions
-	cm.parentModel = ""
-	cm.parentWorkingDir = ""
 	// Reset scroll tracking
 	cm.wasAtBottom = true
 }
@@ -216,16 +209,6 @@ func (cm *conversationModel) Update(msg tea.Msg, m *model) tea.Cmd {
 		cm.session = msg.session
 		cm.events = msg.events
 		cm.lastRefresh = time.Now()
-
-		// If this is a child session with missing data, use parent data stored during resume
-		if cm.session != nil && cm.session.ParentSessionID != "" {
-			if cm.session.Model == "" && cm.parentModel != "" {
-				cm.session.Model = cm.parentModel
-			}
-			if cm.session.WorkingDir == "" && cm.parentWorkingDir != "" {
-				cm.session.WorkingDir = cm.parentWorkingDir
-			}
-		}
 
 		// Cache the conversation for future use (if session and events are not nil)
 		if cm.session != nil && cm.events != nil {
@@ -390,9 +373,6 @@ func (cm *conversationModel) updateResumeInput(msg tea.KeyMsg, m *model) tea.Cmd
 		if cm.session != nil && cm.sessionID != "" {
 			query := cm.resumeInput.Value()
 			if query != "" {
-				// Store parent session data for inheritance
-				cm.parentModel = cm.session.Model
-				cm.parentWorkingDir = cm.session.WorkingDir
 				return continueSession(m.daemonClient, cm.sessionID, query)
 			}
 		}


### PR DESCRIPTION
## What problem(s) was I solving?

When continuing a session using the `hlyr continue` command or via the TUI, the child session was not inheriting all configuration fields from the parent session. This meant users had to manually re-specify configuration options like system prompts, tool permissions, and MCP server configurations when resuming sessions, leading to a poor user experience and potential inconsistencies.

Additionally, the codebase had several issues with test reliability, race conditions in approval handling, and database connection management that were causing CI failures.

## What user-facing changes did I ship?

- **Full configuration inheritance**: When continuing a session, all configuration fields are now automatically inherited from the parent session, including:
  - System prompts and append system prompts
  - Custom instructions
  - Permission prompt tool settings
  - Allowed and disallowed tools lists
  - MCP server configurations
- **Override capability**: Users can still override any inherited configuration by explicitly specifying new values when continuing a session
- **Improved reliability**: Fixed race conditions in approval status updates that could cause approvals to be incorrectly overwritten
- **Better error handling**: Sessions that don't exist now properly return errors instead of empty results
- **Removed manual workarounds**: Cleaned up temporary workarounds in the TUI that were manually tracking parent session configuration

## How I implemented it

1. **Database schema update**: Added missing configuration fields to the sessions table:
   - `permission_prompt_tool`
   - `append_system_prompt`
   - `allowed_tools` (JSON array)
   - `disallowed_tools` (JSON array)
   - Created migration script to update existing databases
   - Fixed migration ordering to ensure proper execution for both new and existing databases

2. **Enhanced session continuation logic** in `hld/session/manager.go`:
   - Modified `ContinueSession` to inherit ALL configuration fields from parent session
   - Added logic to deserialize JSON arrays for allowed/disallowed tools
   - Implemented MCP server inheritance from parent session with deterministic ordering
   - Preserved override capability for explicit user specifications
   - Maintained the existing behavior of NOT inheriting MaxTurns (as per design)

3. **Fixed reliability issues**:
   - Fixed race condition in approval status updates: now only updates from pending to resolved, never overwrites approved/denied status
   - Improved error handling to return proper errors for non-existent sessions
   - Fixed listener double-close issue by tracking close state
   - Proper context cancellation handling in monitorSession to prevent 'database is closed' errors during shutdown
   - Fixed CI test failures by using temporary database files instead of in-memory databases for proper connection sharing

4. **Improved test infrastructure**:
   - Added `continue_inheritance_test.go` with comprehensive tests for all inheritance scenarios
   - Enhanced integration tests to run by default with quiet mode support
   - Fixed MCP server ordering to ensure deterministic test results
   - Added config overrides to prevent loading user configuration in tests
   - Filtered approval poller events in subscription tests to reduce noise

5. **Cleanup**: Removed manual inheritance workaround from TUI that was tracking `parentModel` and `parentWorkingDir` fields, as this is now handled properly by the backend

## How to verify it

- [x] I have ensured `make check test` passes

## Description for the changelog

Fixed session continuation to properly inherit all configuration fields from parent sessions, including system prompts, tool permissions, and MCP server configurations. Also improved reliability by fixing race conditions and database connection issues.