### PR TITLE
Add kbd hint for session cycle

### DIFF
--- a/humanlayer-wui/src/components/SessionTableSearch.tsx
+++ b/humanlayer-wui/src/components/SessionTableSearch.tsx
@@ -59,36 +59,43 @@ export function SessionTableSearch({
   )
 
   return (
-    <div className={cn('relative flex items-center gap-2', className)}>
-      <div className="relative flex-1">
-        <Search className="absolute left-3 h-4 w-4 text-muted-foreground top-1/2 -translate-y-1/2" />
-        <Input
-          id={inputClassId}
-          type="text"
-          value={value}
-          onChange={e => onChange(e.target.value)}
-          placeholder={placeholder}
-          className={cn(
-            'w-full h-9 pl-10 pr-3 text-sm',
-            'font-mono',
-            'bg-background border rounded-md',
-            'transition-all duration-200',
-            'placeholder:text-muted-foreground/60',
-            'border-border hover:border-primary/50 focus:border-primary focus:ring-2 focus:ring-primary/20',
-            'focus:outline-none',
-          )}
-          spellCheck={false}
-        />
+    <div className={cn('flex flex-col gap-2', className)}>
+      <div className="relative flex items-center gap-2">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 h-4 w-4 text-muted-foreground top-1/2 -translate-y-1/2" />
+          <Input
+            id={inputClassId}
+            type="text"
+            value={value}
+            onChange={e => onChange(e.target.value)}
+            placeholder={placeholder}
+            className={cn(
+              'w-full h-9 pl-10 pr-3 text-sm',
+              'font-mono',
+              'bg-background border rounded-md',
+              'transition-all duration-200',
+              'placeholder:text-muted-foreground/60',
+              'border-border hover:border-primary/50 focus:border-primary focus:ring-2 focus:ring-primary/20',
+              'focus:outline-none',
+            )}
+            spellCheck={false}
+          />
+        </div>
+
+        {statusFilter && (
+          <span
+            className="px-2 py-1 text-xs text-accent-foreground rounded whitespace-nowrap"
+            style={{ backgroundColor: 'var(--terminal-accent)' }}
+          >
+            status: {statusFilter.toLowerCase()}
+          </span>
+        )}
       </div>
 
-      {statusFilter && (
-        <span
-          className="px-2 py-1 text-xs text-accent-foreground rounded whitespace-nowrap"
-          style={{ backgroundColor: 'var(--terminal-accent)' }}
-        >
-          status: {statusFilter.toLowerCase()}
-        </span>
-      )}
+      <div className="flex items-center gap-2 text-xs text-muted-foreground justify-end">
+        <span>cycle session status with</span>
+        <kbd className="px-1 py-0.5 text-xs bg-muted rounded">TAB</kbd>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## What problem(s) was I solving?

The session table search interface was missing a visual hint for the Tab key functionality that cycles through session status filters. Users had no way to discover this keyboard shortcut without documentation or trial and error.

## What user-facing changes did I ship?

- Added a small, unobtrusive keyboard hint below the search bar that shows "cycle session status with TAB"
- The hint uses a styled `<kbd>` element to clearly indicate it's a keyboard shortcut
- Positioned the hint at the bottom right of the search component with appropriate styling to match the UI theme

## How I implemented it

- Modified the `SessionTableSearch` component to wrap the existing content in a flex column layout
- Added a new row below the search bar containing the keyboard hint text
- Used existing Tailwind classes and component styles to ensure visual consistency
- The hint is always visible and uses muted text color to avoid being distracting

## How to verify it

- [x] I have ensured `make check test` passes
- [ ] Navigate to the sessions table view in the HumanLayer WUI
- [ ] Observe the new keyboard hint below the search bar
- [ ] Press Tab to verify it still cycles through session status filters as expected
- [ ] Verify the hint text is readable but not intrusive

## Description for the changelog

Add keyboard hint for Tab key session status cycling in WUI search interface