### PR TITLE
remove chmod restrictions from searchable thoughts directory

### DIFF
--- a/hack/create_worktree.sh
+++ b/hack/create_worktree.sh
@@ -94,6 +94,21 @@ else
     exit 1
 fi
 
+# Initialize thoughts (non-interactive mode with hardcoded directory)
+echo "🧠 Initializing thoughts..."
+cd "$WORKTREE_PATH"
+if humanlayer thoughts init --directory humanlayer > /dev/null 2>&1; then
+    echo "✅ Thoughts initialized!"
+    # Run sync to create searchable directory
+    if humanlayer thoughts sync > /dev/null 2>&1; then
+        echo "✅ Thoughts searchable index created!"
+    else
+        echo "⚠️  Could not create searchable index. Run 'humanlayer thoughts sync' manually."
+    fi
+else
+    echo "⚠️  Could not initialize thoughts automatically. Run 'humanlayer thoughts init' manually."
+fi
+
 # Return to original directory
 cd - > /dev/null
 

--- a/hlyr/src/commands/thoughts.ts
+++ b/hlyr/src/commands/thoughts.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander'
 import { thoughtsInitCommand } from './thoughts/init.js'
+import { thoughtsUninitCommand } from './thoughts/uninit.js'
 import { thoughtsSyncCommand } from './thoughts/sync.js'
 import { thoughtsStatusCommand } from './thoughts/status.js'
 import { thoughtsConfigCommand } from './thoughts/config.js'
@@ -12,7 +13,15 @@ export function thoughtsCommand(program: Command): void {
     .description('Initialize thoughts for current repository')
     .option('--force', 'Force reconfiguration even if already set up')
     .option('--config-file <path>', 'Path to config file')
+    .option('--directory <name>', 'Specify the repository directory name (skips interactive prompt)')
     .action(thoughtsInitCommand)
+
+  thoughts
+    .command('uninit')
+    .description('Remove thoughts setup from current repository')
+    .option('--force', 'Force removal even if not in configuration')
+    .option('--config-file <path>', 'Path to config file')
+    .action(thoughtsUninitCommand)
 
   thoughts
     .command('sync')

--- a/hlyr/src/commands/thoughts/init.ts
+++ b/hlyr/src/commands/thoughts/init.ts
@@ -25,6 +25,10 @@ interface InitOptions {
   directory?: string
 }
 
+function sanitizeDirectoryName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_-]/g, '_')
+}
+
 function prompt(question: string): Promise<string> {
   const rl = readline.createInterface({
     input: process.stdin,
@@ -453,19 +457,18 @@ export async function thoughtsInitCommand(options: InitOptions): Promise<void> {
     if (!mappedName) {
       if (options.directory) {
         // Non-interactive mode with --directory option
-        const sanitizedDir = options.directory.replace(/[^a-zA-Z0-9_-]/g, '_')
+        const sanitizedDir = sanitizeDirectoryName(options.directory)
 
         if (!existingRepos.includes(sanitizedDir)) {
           console.error(
-            chalk.red(`Error: Directory "${sanitizedDir}" not found in existing thoughts directories.`),
+            chalk.red(`Error: Directory "${sanitizedDir}" not found in thoughts repository.`),
           )
           console.error(
-            chalk.red(
-              'For non-interactive mode, you must use a directory that has already been mapped.',
-            ),
+            chalk.red('In non-interactive mode (--directory), you must specify a directory'),
           )
+          console.error(chalk.red('name that already exists in the thoughts repository.'))
           console.error('')
-          console.error(chalk.yellow('Existing directories:'))
+          console.error(chalk.yellow('Available directories:'))
           existingRepos.forEach(repo => console.error(chalk.gray(`  - ${repo}`)))
           process.exit(1)
         }
@@ -509,7 +512,7 @@ export async function thoughtsInitCommand(options: InitOptions): Promise<void> {
             mappedName = nameInput || defaultName
 
             // Sanitize the name
-            mappedName = mappedName.replace(/[^a-zA-Z0-9_-]/g, '_')
+            mappedName = sanitizeDirectoryName(mappedName)
             console.log(
               chalk.green(`✓ Will create: ${config.thoughtsRepo}/${config.reposDir}/${mappedName}`),
             )
@@ -535,7 +538,7 @@ export async function thoughtsInitCommand(options: InitOptions): Promise<void> {
           mappedName = nameInput || defaultName
 
           // Sanitize the name
-          mappedName = mappedName.replace(/[^a-zA-Z0-9_-]/g, '_')
+          mappedName = sanitizeDirectoryName(mappedName)
           console.log(
             chalk.green(`✓ Will create: ${config.thoughtsRepo}/${config.reposDir}/${mappedName}`),
           )

--- a/hlyr/src/commands/thoughts/sync.ts
+++ b/hlyr/src/commands/thoughts/sync.ts
@@ -164,18 +164,6 @@ function createSearchDirectory(thoughtsDir: string): void {
     }
   }
 
-  // Make .search directory read-only
-  try {
-    // First set directories to be readable and traversable
-    execSync(`find "${searchDir}" -type d -exec chmod 755 {} +`, { stdio: 'pipe' })
-    // Then set files to be read-only
-    execSync(`find "${searchDir}" -type f -exec chmod 444 {} +`, { stdio: 'pipe' })
-    // Finally make directories read-only but still traversable
-    execSync(`find "${searchDir}" -type d -exec chmod 555 {} +`, { stdio: 'pipe' })
-  } catch {
-    // Ignore chmod errors on systems that don't support it
-  }
-
   console.log(chalk.gray(`Created ${linkedCount} hard links in searchable directory`))
 }
 

--- a/hlyr/src/commands/thoughts/uninit.ts
+++ b/hlyr/src/commands/thoughts/uninit.ts
@@ -1,0 +1,84 @@
+import fs from 'fs'
+import path from 'path'
+import { execSync } from 'child_process'
+import chalk from 'chalk'
+import { loadThoughtsConfig, saveThoughtsConfig, getCurrentRepoPath } from '../../thoughtsConfig.js'
+
+interface UninitOptions {
+  force?: boolean
+  configFile?: string
+}
+
+export async function thoughtsUninitCommand(options: UninitOptions): Promise<void> {
+  try {
+    const currentRepo = getCurrentRepoPath()
+    const thoughtsDir = path.join(currentRepo, 'thoughts')
+
+    // Check if thoughts directory exists
+    if (!fs.existsSync(thoughtsDir)) {
+      console.error(chalk.red('Error: Thoughts not initialized for this repository.'))
+      process.exit(1)
+    }
+
+    // Load config
+    const config = loadThoughtsConfig(options)
+    if (!config) {
+      console.error(chalk.red('Error: Thoughts configuration not found.'))
+      process.exit(1)
+    }
+
+    const mappedName = config.repoMappings[currentRepo]
+    if (!mappedName && !options.force) {
+      console.error(chalk.red('Error: This repository is not in the thoughts configuration.'))
+      console.error(chalk.yellow('Use --force to remove the thoughts directory anyway.'))
+      process.exit(1)
+    }
+
+    console.log(chalk.blue('Removing thoughts setup from current repository...'))
+
+    // Step 1: Handle searchable directory if it exists
+    const searchableDir = path.join(thoughtsDir, 'searchable')
+    if (fs.existsSync(searchableDir)) {
+      console.log(chalk.gray('Removing searchable directory...'))
+      try {
+        // Reset permissions in case they're restricted
+        execSync(`chmod -R 755 "${searchableDir}"`, { stdio: 'pipe' })
+      } catch {
+        // Ignore chmod errors
+      }
+      fs.rmSync(searchableDir, { recursive: true, force: true })
+    }
+
+    // Step 2: Remove the entire thoughts directory
+    // IMPORTANT: This only removes the local thoughts/ directory containing symlinks
+    // The actual thoughts content in the thoughts repository remains untouched
+    console.log(chalk.gray('Removing thoughts directory (symlinks only)...'))
+    try {
+      fs.rmSync(thoughtsDir, { recursive: true, force: true })
+    } catch (error) {
+      console.error(chalk.red(`Error removing thoughts directory: ${error}`))
+      console.error(chalk.yellow('You may need to manually remove: ' + thoughtsDir))
+      process.exit(1)
+    }
+
+    // Step 3: Remove from config if mapped
+    if (mappedName) {
+      console.log(chalk.gray('Removing repository from thoughts configuration...'))
+      delete config.repoMappings[currentRepo]
+      saveThoughtsConfig(config, options)
+    }
+
+    console.log(chalk.green('✅ Thoughts removed from repository'))
+
+    // Provide info about what was done
+    if (mappedName) {
+      console.log('')
+      console.log(chalk.gray('Note: Your thoughts content remains safe in:'))
+      console.log(chalk.gray(`  ${config.thoughtsRepo}/${config.reposDir}/${mappedName}`))
+      console.log(chalk.gray('Only the local symlinks and configuration were removed.'))
+    }
+  } catch (error) {
+    console.error(chalk.red(`Error during thoughts uninit: ${error}`))
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
## What problem(s) was I solving?

The thoughts searchable directory was using chmod 444 to make hard links "read-only", but this was fundamentally flawed. Hard links share the same inode as the original file, so making them read-only also made the original files read-only. This prevented users from editing their own thoughts files, which defeats the purpose of the thoughts system.

Additionally, the worktree scripts needed improvements to better automate thoughts setup and cleanup, especially for CI/CD workflows.

## What user-facing changes did I ship?

- **Fixed editing of thoughts files**: Users can now edit their thoughts files normally, whether accessing them through the original path or the searchable directory
- **Added `thoughts uninit` command**: Cleanly removes thoughts setup from a repository, handling permissions and cleanup properly
- **Added `--directory` option to `thoughts init`**: Enables non-interactive initialization for automation workflows
- **Automatic thoughts setup in worktrees**: New worktrees automatically initialize and sync thoughts
- **Improved worktree cleanup**: Uses the new `uninit` command with fallback to manual cleanup

## How I implemented it

1. **Removed chmod restrictions**: Deleted all chmod commands that were setting files to 444/555 in the sync process
2. **Updated documentation**: Changed CLAUDE.md generation to reflect that files are editable hard links, not "read-only copies"
3. **Created uninit command**: New command that properly removes thoughts setup, including:
   - Resetting permissions on searchable directory
   - Removing all symlinks and directories
   - Cleaning up repository mapping from config
4. **Enhanced init command**: Added `--directory` option that skips interactive prompts for automation
5. **Updated worktree scripts**:
   - `create_worktree.sh`: Automatically runs `thoughts init --directory humanlayer` and sync
   - `cleanup_worktree.sh`: Uses `thoughts uninit` with manual fallback for older installations

## How to verify it

- [x] I have ensured `make check test` passes

Additional verification:
- Initialize thoughts in a repository and verify files in `thoughts/searchable/` are editable
- Test the new `thoughts uninit` command removes setup cleanly
- Test `thoughts init --directory humanlayer` works without prompts
- Create a new worktree and verify thoughts are automatically initialized

## Description for the changelog

Fixed thoughts searchable directory permissions to allow editing, added `thoughts uninit` command for clean removal, and improved worktree automation with non-interactive thoughts initialization.