### PR TITLE
implement getsessionleaves json rpc endpoint to show only

### DIFF
--- a/hld/client/client.go
+++ b/hld/client/client.go
@@ -256,6 +256,15 @@ func (c *client) ListSessions() (*rpc.ListSessionsResponse, error) {
 	return &resp, nil
 }
 
+// GetSessionLeaves gets only the leaf sessions (sessions with no children)
+func (c *client) GetSessionLeaves() (*rpc.GetSessionLeavesResponse, error) {
+	var resp rpc.GetSessionLeavesResponse
+	if err := c.call("getSessionLeaves", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // ContinueSession continues an existing completed session with a new query
 func (c *client) ContinueSession(req rpc.ContinueSessionRequest) (*rpc.ContinueSessionResponse, error) {
 	var resp rpc.ContinueSessionResponse

--- a/hld/client/types.go
+++ b/hld/client/types.go
@@ -18,6 +18,9 @@ type Client interface {
 	// ListSessions lists all active sessions
 	ListSessions() (*rpc.ListSessionsResponse, error)
 
+	// GetSessionLeaves gets only the leaf sessions (sessions with no children)
+	GetSessionLeaves() (*rpc.GetSessionLeavesResponse, error)
+
 	// InterruptSession interrupts a running session
 	InterruptSession(sessionID string) error
 

--- a/hld/internal/testutil/socket.go
+++ b/hld/internal/testutil/socket.go
@@ -30,3 +30,33 @@ func CreateTestSocket(t *testing.T) string {
 	t.Helper()
 	return SocketPath(t, "test")
 }
+
+// DatabasePath returns a temporary database path for testing.
+// It automatically sets the HUMANLAYER_DATABASE_PATH environment variable
+// and registers cleanup with t.Cleanup().
+func DatabasePath(t *testing.T, suffix string) string {
+	t.Helper()
+
+	// Create a temporary directory for the test
+	tempDir := t.TempDir()
+
+	// Create database path
+	dbPath := fmt.Sprintf("%s/test-%s.db", tempDir, suffix)
+
+	// Set environment variable
+	oldPath := os.Getenv("HUMANLAYER_DATABASE_PATH")
+	if err := os.Setenv("HUMANLAYER_DATABASE_PATH", dbPath); err != nil {
+		t.Fatalf("Failed to set HUMANLAYER_DATABASE_PATH: %v", err)
+	}
+
+	// Register cleanup to restore original environment
+	t.Cleanup(func() {
+		if oldPath != "" {
+			_ = os.Setenv("HUMANLAYER_DATABASE_PATH", oldPath)
+		} else {
+			_ = os.Unsetenv("HUMANLAYER_DATABASE_PATH")
+		}
+	})
+
+	return dbPath
+}

--- a/hld/store/sqlite_integration_test.go
+++ b/hld/store/sqlite_integration_test.go
@@ -7,19 +7,18 @@ import (
 	"context"
 	"database/sql"
 	"os"
-	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
 	claudecode "github.com/humanlayer/humanlayer/claudecode-go"
+	"github.com/humanlayer/humanlayer/hld/internal/testutil"
 )
 
 // TestSQLiteStoreIntegration tests the SQLite store with real database operations
 func TestSQLiteStoreIntegration(t *testing.T) {
 	// Create temporary database
-	tmpDir := t.TempDir()
-	dbPath := filepath.Join(tmpDir, "test.db")
+	dbPath := testutil.DatabasePath(t, "sqlite-integration")
 
 	// Create store
 	store, err := NewSQLiteStore(dbPath)
@@ -565,8 +564,7 @@ func TestSQLiteStoreIntegration(t *testing.T) {
 
 // TestSQLiteStorePersistence verifies data persists across store instances
 func TestSQLiteStorePersistence(t *testing.T) {
-	tmpDir := t.TempDir()
-	dbPath := filepath.Join(tmpDir, "persist.db")
+	dbPath := testutil.DatabasePath(t, "sqlite-persist")
 	ctx := context.Background()
 
 	// Create first store instance
@@ -641,8 +639,7 @@ func TestSQLiteStorePersistence(t *testing.T) {
 
 // TestSQLiteStoreWithMockSession tests store integration with mock claude sessions
 func TestSQLiteStoreWithMockSession(t *testing.T) {
-	tmpDir := t.TempDir()
-	dbPath := filepath.Join(tmpDir, "mock_session.db")
+	dbPath := testutil.DatabasePath(t, "sqlite-mock")
 	ctx := context.Background()
 
 	store, err := NewSQLiteStore(dbPath)

--- a/hld/store/sqlite_test.go
+++ b/hld/store/sqlite_test.go
@@ -2,22 +2,17 @@ package store
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	claudecode "github.com/humanlayer/humanlayer/claudecode-go"
+	"github.com/humanlayer/humanlayer/hld/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSQLiteStore(t *testing.T) {
 	// Create temp database
-	tmpDir, err := os.MkdirTemp("", "hld-test-*")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tmpDir) }()
-
-	dbPath := filepath.Join(tmpDir, "test.db")
+	dbPath := testutil.DatabasePath(t, "sqlite")
 	store, err := NewSQLiteStore(dbPath)
 	require.NoError(t, err)
 	defer func() { _ = store.Close() }()
@@ -265,11 +260,7 @@ func TestSQLiteStore(t *testing.T) {
 
 func TestGetSessionConversationWithParentChain(t *testing.T) {
 	// Create temp database
-	tmpDir, err := os.MkdirTemp("", "hld-test-parent-*")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tmpDir) }()
-
-	dbPath := filepath.Join(tmpDir, "test.db")
+	dbPath := testutil.DatabasePath(t, "sqlite-parent")
 	store, err := NewSQLiteStore(dbPath)
 	require.NoError(t, err)
 	defer func() { _ = store.Close() }()

--- a/humanlayer-tui/CLAUDE.md
+++ b/humanlayer-tui/CLAUDE.md
@@ -1,0 +1,28 @@
+# CLAUDE.md - HumanLayer TUI
+
+## IMPORTANT: This project is archived
+
+The HumanLayer TUI (Terminal User Interface) is **archived** and no longer actively developed. 
+
+### Key Points:
+- **No new features** will be added to the TUI
+- **No modifications** should be made unless fixing critical bugs
+- **Reference only**: The code can be used as reference when implementing features in other components
+- **Focus on WUI**: All new UI features should be implemented in the WUI (Web UI) instead
+
+### What This Means for Development:
+- When implementing new JSON-RPC endpoints or features, **do not update the TUI**
+- When creating implementation plans, **exclude TUI from the scope**
+- If you need to understand how something works, you may reference TUI code
+- The TUI binary is still built and distributed, but only for legacy support
+
+### Why Archived:
+The team has decided to focus development efforts on the WUI (Web UI) which provides a richer user experience and is easier to maintain and extend.
+
+### Current State:
+- The TUI remains functional with existing features
+- It connects to the hld daemon via JSON-RPC
+- Provides session management and approval handling
+- Built with Go and Bubble Tea framework
+
+If you have questions about this decision, please consult with the team.

--- a/humanlayer-tui/CLAUDE.md
+++ b/humanlayer-tui/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## IMPORTANT: This project is archived
 
-The HumanLayer TUI (Terminal User Interface) is **archived** and no longer actively developed. 
+The HumanLayer TUI (Terminal User Interface) is **archived** and no longer actively developed.
 
 ### Key Points:
 - **No new features** will be added to the TUI

--- a/humanlayer-wui/src-tauri/src/daemon_client/client.rs
+++ b/humanlayer-wui/src-tauri/src/daemon_client/client.rs
@@ -17,6 +17,7 @@ pub trait DaemonClientTrait: Send + Sync {
     async fn health(&self) -> Result<HealthCheckResponse>;
     async fn launch_session(&self, req: LaunchSessionRequest) -> Result<LaunchSessionResponse>;
     async fn list_sessions(&self) -> Result<ListSessionsResponse>;
+    async fn get_session_leaves(&self) -> Result<GetSessionLeavesResponse>;
     async fn continue_session(&self, req: ContinueSessionRequest) -> Result<ContinueSessionResponse>;
     async fn get_session_state(&self, session_id: &str) -> Result<GetSessionStateResponse>;
     async fn get_conversation(&self, session_id: Option<&str>, claude_session_id: Option<&str>) -> Result<GetConversationResponse>;
@@ -129,6 +130,10 @@ impl DaemonClientTrait for DaemonClient {
 
     async fn list_sessions(&self) -> Result<ListSessionsResponse> {
         self.send_rpc_request("listSessions", None::<()>).await
+    }
+
+    async fn get_session_leaves(&self) -> Result<GetSessionLeavesResponse> {
+        self.send_rpc_request("getSessionLeaves", None::<()>).await
     }
 
     async fn continue_session(&self, req: ContinueSessionRequest) -> Result<ContinueSessionResponse> {

--- a/humanlayer-wui/src-tauri/src/daemon_client/types.rs
+++ b/humanlayer-wui/src-tauri/src/daemon_client/types.rs
@@ -95,6 +95,14 @@ pub struct ListSessionsResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct GetSessionLeavesRequest {}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetSessionLeavesResponse {
+    pub sessions: Vec<SessionInfo>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SessionInfo {
     pub id: String,
     pub run_id: String,

--- a/humanlayer-wui/src-tauri/src/lib.rs
+++ b/humanlayer-wui/src-tauri/src/lib.rs
@@ -73,6 +73,21 @@ async fn list_sessions(
 }
 
 #[tauri::command]
+async fn get_session_leaves(
+    state: State<'_, AppState>,
+) -> std::result::Result<daemon_client::GetSessionLeavesResponse, String> {
+    let client_guard = state.client.lock().await;
+
+    match &*client_guard {
+        Some(client) => client
+            .get_session_leaves()
+            .await
+            .map_err(|e| e.to_string()),
+        None => Err("Not connected to daemon".to_string()),
+    }
+}
+
+#[tauri::command]
 async fn get_session_state(
     state: State<'_, AppState>,
     session_id: String,
@@ -306,6 +321,7 @@ pub fn run() {
             daemon_health,
             launch_session,
             list_sessions,
+            get_session_leaves,
             get_session_state,
             continue_session,
             get_conversation,

--- a/humanlayer-wui/src/AppStore.ts
+++ b/humanlayer-wui/src/AppStore.ts
@@ -38,7 +38,7 @@ export const useStore = create<StoreState>((set, get) => ({
     })),
   refreshSessions: async () => {
     try {
-      const response = await daemonClient.listSessions()
+      const response = await daemonClient.getSessionLeaves()
       set({ sessions: response.sessions })
     } catch (error) {
       console.error('Failed to refresh sessions:', error)

--- a/humanlayer-wui/src/hooks/useSessions.ts
+++ b/humanlayer-wui/src/hooks/useSessions.ts
@@ -22,7 +22,7 @@ export function useSessions(): UseSessionsReturn {
       setLoading(true)
       setError(null)
 
-      const response = await daemonClient.listSessions()
+      const response = await daemonClient.getSessionLeaves()
 
       // Transform to UI-friendly format
       const summaries: SessionSummary[] = response.sessions.map(session => ({

--- a/humanlayer-wui/src/lib/daemon/client.ts
+++ b/humanlayer-wui/src/lib/daemon/client.ts
@@ -5,6 +5,7 @@ import type {
   LaunchSessionRequest,
   LaunchSessionResponse,
   ListSessionsResponse,
+  GetSessionLeavesResponse,
   GetSessionStateResponse,
   ContinueSessionRequest,
   ContinueSessionResponse,
@@ -29,6 +30,10 @@ export class DaemonClient {
 
   async listSessions(): Promise<ListSessionsResponse> {
     return await invoke('list_sessions')
+  }
+
+  async getSessionLeaves(): Promise<GetSessionLeavesResponse> {
+    return await invoke('get_session_leaves')
   }
 
   async getSessionState(sessionId: string): Promise<GetSessionStateResponse> {

--- a/humanlayer-wui/src/lib/daemon/types.ts
+++ b/humanlayer-wui/src/lib/daemon/types.ts
@@ -106,6 +106,14 @@ export interface ListSessionsResponse {
   sessions: SessionInfo[]
 }
 
+export interface GetSessionLeavesRequest {
+  // Empty for now - could add filters later
+}
+
+export interface GetSessionLeavesResponse {
+  sessions: SessionInfo[]
+}
+
 // Contact channel types
 export interface SlackChannel {
   channel_or_user_id: string


### PR DESCRIPTION
## What problem(s) was I solving?

- When users have multiple Claude Code sessions with continuations (parent-child relationships), the UI displays all sessions including intermediate ones, creating visual clutter
- Users only care about the most recent/active sessions in each conversation chain, not the full history
- The existing `listSessions` endpoint returns all sessions without any filtering

## What user-facing changes did I ship?

- The WUI now only displays leaf sessions (sessions with no children), significantly reducing clutter when users have multiple session continuations
- Sessions are sorted by last activity with the newest first, making it easier to find recent work
- The session display remains functionally the same but with fewer, more relevant entries

## How I implemented it

- **Backend (hld daemon)**:
  - Added new `getSessionLeaves` JSON-RPC endpoint that filters sessions to return only leaf nodes
  - Built a parent-to-children map to identify which sessions have children
  - Added database migration 5 to create an index on `parent_session_id` for efficient tree queries
  - Included comprehensive unit tests covering various tree structures (linear chains, forks, deep trees)
  - Added integration test for the new endpoint

- **Client libraries**:
  - Extended Go client interface and implementation with `GetSessionLeaves` method
  - Added TypeScript types and method to DaemonClient
  - Added Rust types, trait method, and Tauri command for WUI integration

- **Frontend (WUI)**:
  - Updated `AppStore` and `useSessions` hook to call `getSessionLeaves` instead of `listSessions`
  - No UI component changes needed - the filtered data works seamlessly with existing components

- **Testing improvements**:
  - Created `DatabasePath` test utility for proper SQLite test isolation
  - Fixed integration tests that were using the user's actual database instead of test databases
  - Refactored existing SQLite tests to use the new utility

- **Documentation**:
  - Added CLAUDE.md to the TUI project marking it as archived (per ENG-1507)

## How to verify it

- [x] I have ensured `make check test` passes

## Description for the changelog

Add `getSessionLeaves` endpoint to show only active session branches in UI, reducing clutter from session continuations