### PR TITLE
Track parent-child relationships for Claude sub-tasks

### DIFF
--- a/claudecode-go/types.go
+++ b/claudecode-go/types.go
@@ -67,6 +67,9 @@ type StreamEvent struct {
 	Tools      []string    `json:"tools,omitempty"`
 	MCPServers []MCPStatus `json:"mcp_servers,omitempty"`
 
+	// Parent tracking for sub-tasks
+	ParentToolUseID string `json:"parent_tool_use_id,omitempty"`
+
 	// System event fields (when type="system" and subtype="init")
 	CWD            string `json:"cwd,omitempty"`
 	Model          string `json:"model,omitempty"`

--- a/hld/rpc/handlers.go
+++ b/hld/rpc/handlers.go
@@ -223,6 +223,7 @@ func (h *SessionHandlers) HandleGetConversation(ctx context.Context, params json
 			ToolID:            event.ToolID,
 			ToolName:          event.ToolName,
 			ToolInputJSON:     event.ToolInputJSON,
+			ParentToolUseID:   event.ParentToolUseID,
 			ToolResultForID:   event.ToolResultForID,
 			ToolResultContent: event.ToolResultContent,
 			IsCompleted:       event.IsCompleted,

--- a/hld/rpc/types.go
+++ b/hld/rpc/types.go
@@ -29,9 +29,10 @@ type ConversationEvent struct {
 	Content string `json:"content,omitempty"`
 
 	// Tool call fields
-	ToolID        string `json:"tool_id,omitempty"`
-	ToolName      string `json:"tool_name,omitempty"`
-	ToolInputJSON string `json:"tool_input_json,omitempty"`
+	ToolID          string `json:"tool_id,omitempty"`
+	ToolName        string `json:"tool_name,omitempty"`
+	ToolInputJSON   string `json:"tool_input_json,omitempty"`
+	ParentToolUseID string `json:"parent_tool_use_id,omitempty"`
 
 	// Tool result fields
 	ToolResultForID   string `json:"tool_result_for_id,omitempty"`

--- a/hld/session/manager.go
+++ b/hld/session/manager.go
@@ -605,6 +605,7 @@ func (m *Manager) processStreamEvent(ctx context.Context, sessionID string, clau
 						ToolID:          content.ID,
 						ToolName:        content.Name,
 						ToolInputJSON:   string(inputJSON),
+						ParentToolUseID: event.ParentToolUseID, // Capture from event level
 						// We don't know yet if this needs approval - that comes from HumanLayer API
 					}
 					if err := m.store.AddConversationEvent(ctx, convEvent); err != nil {
@@ -625,13 +626,14 @@ func (m *Manager) processStreamEvent(ctx context.Context, sessionID string, clau
 						m.eventBus.Publish(bus.Event{
 							Type: bus.EventConversationUpdated,
 							Data: map[string]interface{}{
-								"session_id":        sessionID,
-								"claude_session_id": claudeSessionID,
-								"event_type":        "tool_call",
-								"tool_id":           content.ID,
-								"tool_name":         content.Name,
-								"tool_input":        toolInput,
-								"content_type":      "tool_use",
+								"session_id":         sessionID,
+								"claude_session_id":  claudeSessionID,
+								"event_type":         "tool_call",
+								"tool_id":            content.ID,
+								"tool_name":          content.Name,
+								"tool_input":         toolInput,
+								"parent_tool_use_id": event.ParentToolUseID,
+								"content_type":       "tool_use",
 							},
 						})
 					}

--- a/hld/store/store.go
+++ b/hld/store/store.go
@@ -106,9 +106,10 @@ type ConversationEvent struct {
 	Content string
 
 	// Tool call fields
-	ToolID        string
-	ToolName      string
-	ToolInputJSON string
+	ToolID          string
+	ToolName        string
+	ToolInputJSON   string
+	ParentToolUseID string
 
 	// Tool result fields
 	ToolResultForID   string


### PR DESCRIPTION
## What problem(s) was I solving?

When Claude Code spawns sub-tasks (using the Task tool), there was no way to track the parent-child relationships between the main task and its sub-tasks. This made it difficult to understand the task hierarchy and relationships in the HumanLayer UI and for debugging purposes.

## What user-facing changes did I ship?

No direct user-facing changes - this is an infrastructure improvement that will enable future UI enhancements. The parent-child relationships are now:
- Captured from Claude's streaming JSON events
- Stored in the database with proper indexing
- Exposed through the RPC API for future UI consumption

## How I implemented it

1. **Added ParentToolUseID field to StreamEvent** in `claudecode-go/types.go` to parse the parent_tool_use_id from Claude's streaming JSON
2. **Database migration** (migration 6) in `hld/store/sqlite.go`:
   - Added `parent_tool_use_id` column to conversation_events table
   - Created index for efficient parent-child queries
   - Included safety check to avoid duplicate column errors
3. **Updated data flow** throughout the system:
   - Modified ConversationEvent structs to include ParentToolUseID
   - Updated all SQL queries to handle the new field
   - Passed parent ID through event processing pipeline
   - Exposed parent_tool_use_id in RPC getConversation responses
4. **Event bus integration**: Include parent_tool_use_id in published events for future extensibility

## How to verify it

- [x] I have ensured `make check test` passes
- [x] Manually verified that sub-tasks have correct parent_tool_use_id (user confirmed this was tested)
- [x] Manually verified that regular tool calls have NULL parent_tool_use_id (user confirmed this was tested)

## Description for the changelog

Add support for tracking parent-child relationships between Claude tasks and sub-tasks, enabling future UI improvements for visualizing task hierarchies.