### PR TITLE
Add automatic git pull to thoughts synchronization

### DIFF
--- a/hlyr/src/commands/thoughts/init.ts
+++ b/hlyr/src/commands/thoughts/init.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
-import { execSync } from 'child_process'
+import { execSync, execFileSync } from 'child_process'
 import chalk from 'chalk'
 import readline from 'readline'
 import {
@@ -604,6 +604,23 @@ export async function thoughtsInitCommand(options: InitOptions): Promise<void> {
 
     if (otherUsers.length > 0) {
       console.log(chalk.green(`✓ Added symlinks for other users: ${otherUsers.join(', ')}`))
+    }
+
+    // Pull latest thoughts if remote exists
+    try {
+      execSync('git remote get-url origin', { cwd: expandedRepo, stdio: 'pipe' })
+      // Remote exists, try to pull
+      try {
+        execFileSync('git', ['pull', '--rebase'], {
+          stdio: 'pipe',
+          cwd: expandedRepo,
+        })
+        console.log(chalk.green('✓ Pulled latest thoughts from remote'))
+      } catch (error) {
+        console.warn(chalk.yellow('Warning: Could not pull latest thoughts:'), error.message)
+      }
+    } catch {
+      // No remote configured, skip pull
     }
 
     // Generate CLAUDE.md

--- a/hlyr/src/commands/thoughts/init.ts
+++ b/hlyr/src/commands/thoughts/init.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
-import { execSync, execFileSync } from 'child_process'
+import { execSync } from 'child_process'
 import chalk from 'chalk'
 import readline from 'readline'
 import {
@@ -611,7 +611,7 @@ export async function thoughtsInitCommand(options: InitOptions): Promise<void> {
       execSync('git remote get-url origin', { cwd: expandedRepo, stdio: 'pipe' })
       // Remote exists, try to pull
       try {
-        execFileSync('git', ['pull', '--rebase'], {
+        execSync('git pull --rebase', {
           stdio: 'pipe',
           cwd: expandedRepo,
         })

--- a/hlyr/src/commands/thoughts/sync.ts
+++ b/hlyr/src/commands/thoughts/sync.ts
@@ -34,7 +34,20 @@ function syncThoughts(thoughtsRepo: string, message: string): void {
     // Stage all changes
     execSync('git add -A', { cwd: expandedRepo, stdio: 'pipe' })
 
-    // Pull latest changes before committing
+    // Check if there are changes to commit
+    const hasChanges = checkGitStatus(expandedRepo)
+
+    if (hasChanges) {
+      // Commit changes
+      const commitMessage = message || `Sync thoughts - ${new Date().toISOString()}`
+      execFileSync('git', ['commit', '-m', commitMessage], { cwd: expandedRepo, stdio: 'pipe' })
+
+      console.log(chalk.green('✅ Thoughts synchronized'))
+    } else {
+      console.log(chalk.gray('No changes to commit'))
+    }
+
+    // Pull latest changes after committing (to avoid conflicts with staged changes)
     try {
       execFileSync('git', ['pull', '--rebase'], {
         stdio: 'pipe',
@@ -54,19 +67,6 @@ function syncThoughts(thoughtsRepo: string, message: string): void {
         // This handles cases like no upstream, network issues, etc.
         console.warn(chalk.yellow('Warning: Could not pull latest changes:'), error.message)
       }
-    }
-
-    // Check if there are changes to commit
-    const hasChanges = checkGitStatus(expandedRepo)
-
-    if (hasChanges) {
-      // Commit changes
-      const commitMessage = message || `Sync thoughts - ${new Date().toISOString()}`
-      execFileSync('git', ['commit', '-m', commitMessage], { cwd: expandedRepo, stdio: 'pipe' })
-
-      console.log(chalk.green('✅ Thoughts synchronized'))
-    } else {
-      console.log(chalk.gray('No changes to commit'))
     }
 
     // Check if remote exists and push any unpushed commits

--- a/hlyr/src/commands/thoughts/sync.ts
+++ b/hlyr/src/commands/thoughts/sync.ts
@@ -49,7 +49,7 @@ function syncThoughts(thoughtsRepo: string, message: string): void {
 
     // Pull latest changes after committing (to avoid conflicts with staged changes)
     try {
-      execFileSync('git', ['pull', '--rebase'], {
+      execSync('git pull --rebase', {
         stdio: 'pipe',
         cwd: expandedRepo,
       })


### PR DESCRIPTION
## What problem(s) was I solving?

The thoughts synchronization system was missing automatic pull functionality, which led to several issues:
- Team members could push changes that would overwrite others' work without pulling first
- Users had to manually run `git pull` in their thoughts repository to get updates
- Merge conflicts were discovered late in the process, after attempting to push
- New repository setups wouldn't automatically get the latest thoughts from the team

## What user-facing changes did I ship?

- **Auto-pull on sync**: The `humanlayer thoughts sync` command now automatically pulls latest changes before committing, ensuring users stay in sync with the team
- **Merge conflict detection**: Clear error messages when conflicts occur, with instructions on how to resolve them
- **Auto-pull on init**: When initializing thoughts in a new repository, automatically pulls latest thoughts if a remote exists
- **Auto-pull on status**: When `humanlayer thoughts status` detects the repository is behind remote, it automatically pulls updates
- **Improved sync behavior**: Fixed sync to always push any unpushed commits, not just newly created ones

## How I implemented it

### 1. Modified `thoughts/sync.ts`:
   - Added `git pull --rebase` after committing changes (to avoid conflicts with staged changes)
   - Added merge conflict detection with clear error messages
   - Changed logic to always push unpushed commits, even if no new changes were made
   - Fixed false merge conflict errors by reordering operations: commit first, then pull

### 2. Modified `thoughts/init.ts`:
   - Added automatic pull after setting up symlinks if a remote exists
   - Gracefully handles cases where no remote is configured

### 3. Modified `thoughts/status.ts`:
   - When detecting repository is behind remote, automatically attempts to pull
   - Re-checks status after pull to show updated state
   - Fails silently if pull fails (since status is meant to be read-only)

## How to verify it

- [x] I have ensured `make check test` passes

## Description for the changelog

Improved thoughts synchronization with automatic git pull functionality to keep team members in sync and prevent merge conflicts