### PR TITLE
fix: refresh session list after continuing session

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail.tsx
@@ -950,6 +950,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
   const [focusSource, setFocusSource] = useState<'mouse' | 'keyboard' | null>(null)
   const [isSplitView, setIsSplitView] = useState(true)
   const interruptSession = useStore(state => state.interruptSession)
+  const refreshSessions = useStore(state => state.refreshSessions)
   const navigate = useNavigate()
   const isRunning = session.status === 'running'
 
@@ -1014,6 +1015,9 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
 
       // Always navigate to the new session - the backend handles queuing
       navigate(`/sessions/${response.session_id}`)
+
+      // Refresh the session list to ensure UI reflects current state
+      await refreshSessions()
 
       // Reset form state only after success
       setResponseInput('')


### PR DESCRIPTION
When continuing a session, the parent session remained visible in the session list until the next refresh. Now we call refreshSessions() after navigation to immediately update the UI to show only leaf sessions.

🤖 Generated with [Claude Code](https://claude.ai/code)

## What problem(s) was I solving?

## What user-facing changes did I ship?

## How I implemented it

## How to verify it

- [ ] I have ensured `make check test` passes

## Description for the changelog

## A picture of a cute animal (not mandatory but encouraged)
