### PR TITLE
feat: implement toast notification system for WUI error handling

### DIFF
--- a/humanlayer-wui/src/App.css
+++ b/humanlayer-wui/src/App.css
@@ -185,4 +185,21 @@
   button {
     font-family: inherit;
   }
+
+  /* Pulsing animation for incomplete events */
+  @keyframes pulse-warning {
+    0%,
+    100% {
+      opacity: 1;
+      color: var(--terminal-accent);
+    }
+    50% {
+      opacity: 0.5;
+      color: var(--terminal-warning);
+    }
+  }
+
+  .pulse-warning {
+    animation: pulse-warning 2s ease-in-out infinite;
+  }
 }

--- a/humanlayer-wui/src/components/ApprovalsPanel.tsx
+++ b/humanlayer-wui/src/components/ApprovalsPanel.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Loader2, AlertCircle, CheckCircle2, XCircle, MessageSquare } from 'lucide-react'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { notificationService } from '@/services/NotificationService'
 
 /**
  * Example approvals panel component similar to the TUI
@@ -57,8 +58,7 @@ export function ApprovalsPanel() {
     try {
       await approve(approval.callId)
     } catch (err) {
-      console.error('Failed to approve:', err)
-      alert(err instanceof Error ? err.message : 'Failed to approve')
+      notificationService.notifyError(err, 'Failed to approve')
     } finally {
       setProcessingId(null)
     }
@@ -72,8 +72,7 @@ export function ApprovalsPanel() {
     try {
       await deny(approval.callId, reason)
     } catch (err) {
-      console.error('Failed to deny:', err)
-      alert(err instanceof Error ? err.message : 'Failed to deny')
+      notificationService.notifyError(err, 'Failed to deny')
     } finally {
       setProcessingId(null)
     }
@@ -87,8 +86,7 @@ export function ApprovalsPanel() {
     try {
       await respond(approval.callId, response)
     } catch (err) {
-      console.error('Failed to respond:', err)
-      alert(err instanceof Error ? err.message : 'Failed to respond')
+      notificationService.notifyError(err, 'Failed to respond')
     } finally {
       setProcessingId(null)
     }

--- a/humanlayer-wui/src/components/Layout.tsx
+++ b/humanlayer-wui/src/components/Layout.tsx
@@ -9,6 +9,7 @@ import { useSessionLauncher, useSessionLauncherHotkeys } from '@/hooks/useSessio
 import { useStore } from '@/AppStore'
 import { useSessionEventsWithNotifications } from '@/hooks/useSessionEventsWithNotifications'
 import { Toaster } from 'sonner'
+import { notificationService } from '@/services/NotificationService'
 import '@/App.css'
 
 export function Layout() {
@@ -114,7 +115,7 @@ export function Layout() {
         setApprovals(response.approvals)
       }
     } catch (error) {
-      alert(`Failed to handle approval: ${error}`)
+      notificationService.notifyError(error, 'Failed to handle approval')
     }
   }
 

--- a/humanlayer-wui/src/components/internal/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail.tsx
@@ -439,7 +439,7 @@ function eventToDisplayObject(
 
   if (subject === null) {
     // console.warn('Unknown subject for event', event)
-    subject = <span>Uknown Subject</span>
+    subject = <span>Unknown Subject</span>
   }
 
   return {


### PR DESCRIPTION
## What problem(s) was I solving?

The WUI (Web UI) had poor error handling UX where RPC errors and other failures were either shown using browser `alert()` dialogs or silently logged to the console. Users had no visibility when actions failed, leading to confusion about whether their interactions succeeded or not. This was particularly problematic for approval actions (approve/deny) and session continuation where failures would occur silently.

## What user-facing changes did I ship?

- **Toast notifications for all errors**: Replaced browser alerts with modern toast notifications that appear in the bottom-right corner
- **Visibility for silent failures**: Added error notifications for previously silent failures in approve/deny/continue session operations
- **Enhanced visual feedback**: Added pulse animation for incomplete tool calls to better indicate pending operations
- **WebSearch tool display**: Added proper display formatting for WebSearch tool calls with a globe icon
- **Consistent error messages**: All errors now go through `formatError()` utility for user-friendly messages

## How I implemented it

1. **Extended NotificationService** with a new `notifyError()` method that:
   - Logs errors to console for debugging
   - Formats errors using the existing `formatError` utility to strip technical details
   - Shows red toast notifications with 8-second duration for better visibility
   - Added 'error' type to the notification system enum

2. **Replaced all `alert()` calls** throughout the codebase:
   - `ApprovalsPanel.tsx`: Updated approve/deny/respond error handlers
   - `Layout.tsx`: Updated legacy approval handler
   - `SessionDetail.tsx`: Updated approve/deny/continue session error handlers

3. **Added visual enhancements**:
   - Pulse animation CSS for incomplete tool calls (warning state)
   - WebSearch tool display with globe icon and formatted query
   - Fixed subject fallback handling to prevent undefined subjects

The implementation leverages the existing Sonner toast infrastructure (added in PR #250) to maintain consistency across the application.

## How to verify it

- [x] I have ensured `make check test` passes

**Manual testing required:**
- [ ] Disconnect the daemon (`hld`) and try to approve/deny an approval - should show red toast with "Cannot connect to daemon" message
- [ ] Try to continue a session with the daemon disconnected - should show error toast and preserve user input
- [ ] Verify error toasts appear in bottom-right with 8-second duration
- [ ] Check that console still logs errors for debugging
- [ ] Verify WebSearch tool calls display with globe icon and query text
- [ ] Confirm incomplete tool calls show pulse animation

## Description for the changelog

Improve error handling UX in WUI by replacing browser alerts with toast notifications and adding visibility for previously silent failures in approval and session operations.