### PR TITLE
Adjust row padding; fix scroll bug in sessiontable

### DIFF
--- a/humanlayer-wui/src/components/Layout.tsx
+++ b/humanlayer-wui/src/components/Layout.tsx
@@ -129,7 +129,7 @@ export function Layout() {
         {connected && (
           <>
             <Breadcrumbs />
-            <div className="flex-1 overflow-hidden">
+            <div className="flex-1 overflow-y-auto">
               <Outlet />
             </div>
 

--- a/humanlayer-wui/src/components/internal/SessionDetail/formatToolResult.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/formatToolResult.tsx
@@ -86,9 +86,14 @@ export function formatToolResult(toolName: string, toolResult: ConversationEvent
 
     case 'MultiEdit': {
       // Check for specific MultiEdit errors
-      if (content.includes('Found') && content.includes('matches of the string to replace, but replace_all is false')) {
+      if (
+        content.includes('Found') &&
+        content.includes('matches of the string to replace, but replace_all is false')
+      ) {
         const matchCount = content.match(/Found (\d+) matches/)
-        abbreviated = matchCount ? `Found ${matchCount[1]} matches - replace_all needed` : 'Multiple matches found'
+        abbreviated = matchCount
+          ? `Found ${matchCount[1]} matches - replace_all needed`
+          : 'Multiple matches found'
       } else if (isError) {
         // Extract specific error message if available
         if (content.toLowerCase().includes('file has not been read yet')) {
@@ -241,7 +246,7 @@ export function formatToolResult(toolName: string, toolResult: ConversationEvent
   if (isError && toolName !== 'Read') {
     return <span className="text-destructive">{abbreviated}</span>
   }
-  
+
   // Also apply error styling for specific MultiEdit errors
   if (toolName === 'MultiEdit' && abbreviated.includes('replace_all needed')) {
     return <span className="text-destructive">{abbreviated}</span>

--- a/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
@@ -365,9 +365,7 @@ export function ConversationContent({
                     )}
                   </div>
 
-                  {expandedEventId === displayObject.id && (
-                    <EventMetaInfo event={event} />
-                  )}
+                  {expandedEventId === displayObject.id && <EventMetaInfo event={event} />}
                 </div>
               )
             }

--- a/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
@@ -60,7 +60,6 @@ export function ConversationContent({
   // expandedToolResult is used by parent to control hotkey availability
   void expandedToolResult
   const [expandedEventId, setExpandedEventId] = useState<number | null>(null)
-  const [isWideView] = useState(false) // This can be controlled from parent if needed
   const { events, loading, error, isInitialLoad } = useConversation(sessionId, undefined, 1000)
   const toolResults = events.filter(event => event.event_type === ConversationEventType.ToolResult)
   const toolResultsByKey = keyBy(toolResults, 'tool_result_for_id')
@@ -218,17 +217,18 @@ export function ConversationContent({
                 onClick={() =>
                   setExpandedEventId(expandedEventId === displayObject.id ? null : displayObject.id)
                 }
-                className={`pt-1 pb-3 px-2 cursor-pointer ${
+                className={`relative p-4 cursor-pointer NoSubTasksConversationContent ${
                   index !== nonEmptyDisplayObjects.length - 1 ? 'border-b' : ''
-                } ${focusedEventId === displayObject.id ? '!bg-accent/20 -mx-2 px-4 rounded' : ''}`}
+                } ${focusedEventId === displayObject.id ? '!bg-accent/20' : ''}`}
               >
-                {/* Timestamp at top */}
-                <div className="flex justify-end mb-1">
-                  <span className="text-xs text-muted-foreground/60">
+                {/* Timestamp */}
+                <span className="absolute top-2 right-4">
+                  <span className="text-xs text-muted-foreground/60 uppercase tracking-wider">
                     {formatAbsoluteTimestamp(displayObject.created_at)}
                   </span>
-                </div>
+                </span>
 
+                {/* Icon */}
                 <div className="flex items-baseline gap-2">
                   {displayObject.iconComponent && (
                     <span className="text-sm text-accent align-middle relative top-[1px]">
@@ -239,18 +239,21 @@ export function ConversationContent({
                     {displayObject.subject}
                   </span>
                 </div>
+
+                {/* Tool Result Content */}
                 {displayObject.toolResultContent && (
                   <p className="whitespace-pre-wrap text-foreground">
                     {displayObject.toolResultContent}
                   </p>
                 )}
+
+                {/* Body */}
                 {displayObject.body && (
                   <p className="whitespace-pre-wrap text-foreground">{displayObject.body}</p>
                 )}
               </div>
 
-              {/* Expanded content for slim view */}
-              {!isWideView && expandedEventId === displayObject.id && (
+              {expandedEventId === displayObject.id && (
                 <EventMetaInfo event={events.find(e => e.id === displayObject.id)!} />
               )}
             </div>
@@ -327,7 +330,7 @@ export function ConversationContent({
                     onClick={() =>
                       setExpandedEventId(expandedEventId === displayObject.id ? null : displayObject.id)
                     }
-                    className={`pt-1 pb-3 px-2 cursor-pointer ${
+                    className={`relative p-4 cursor-pointer ${
                       index !==
                       rootEvents.filter(e => e.event_type !== ConversationEventType.ToolResult).length -
                         1
@@ -336,7 +339,7 @@ export function ConversationContent({
                     } ${focusedEventId === displayObject.id ? '!bg-accent/20 -mx-2 px-4 rounded' : ''}`}
                   >
                     {/* Timestamp at top */}
-                    <div className="flex justify-end mb-1">
+                    <div className="absolute top-2 right-4">
                       <span className="text-xs text-muted-foreground/60">
                         {formatAbsoluteTimestamp(displayObject.created_at)}
                       </span>
@@ -362,8 +365,7 @@ export function ConversationContent({
                     )}
                   </div>
 
-                  {/* Expanded content for slim view */}
-                  {!isWideView && expandedEventId === displayObject.id && (
+                  {expandedEventId === displayObject.id && (
                     <EventMetaInfo event={event} />
                   )}
                 </div>

--- a/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
@@ -113,7 +113,8 @@ export function ConversationContent({
         })
 
       // Auto-scroll if we have new display events or events have changed
-      if (hasNewEvents || eventsChanged) {
+      // _and_ we're not focused on a row
+      if ((hasNewEvents || eventsChanged) && !focusedEventId) {
         setTimeout(() => {
           if (containerRef.current) {
             containerRef.current.scrollTop = containerRef.current.scrollHeight
@@ -336,7 +337,7 @@ export function ConversationContent({
                         1
                         ? 'border-b'
                         : ''
-                    } ${focusedEventId === displayObject.id ? '!bg-accent/20 -mx-2 px-4 rounded' : ''}`}
+                    } ${focusedEventId === displayObject.id ? '!bg-accent/20 rounded' : ''}`}
                   >
                     {/* Timestamp at top */}
                     <div className="absolute top-2 right-4">

--- a/humanlayer-wui/src/components/internal/SessionDetail/views/TaskGroup.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/TaskGroup.tsx
@@ -54,7 +54,6 @@ export function TaskGroup({
 
   return (
     <div className="p-4 TaskGroup">
-
       {/* Task Header with Preview */}
       <div
         data-event-id={parentTask.id}

--- a/humanlayer-wui/src/components/internal/SessionDetail/views/TaskGroup.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/TaskGroup.tsx
@@ -53,11 +53,12 @@ export function TaskGroup({
   const isCompleted = parentTask.is_completed
 
   return (
-    <div className="mb-4">
+    <div className="p-4 TaskGroup">
+
       {/* Task Header with Preview */}
       <div
         data-event-id={parentTask.id}
-        className={`flex items-start gap-2 py-2 px-3 rounded-md cursor-pointer hover:bg-muted/10 transition-colors ${
+        className={`flex items-start gap-2 rounded-md cursor-pointer hover:bg-muted/10 transition-colors ${
           focusedEventId === parentTask.id ? '!bg-accent/20' : ''
         }`}
         onClick={onToggle}
@@ -157,7 +158,7 @@ export function TaskGroup({
 
       {/* Expanded Sub-task Events */}
       {isExpanded && (
-        <div className="ml-6 mt-2 pl-4 border-l-2 border-border/50">
+        <div className="ml-6 mt-2 pl-4 border-l-2 border-border/50 TaskGroupExpanded">
           {group.subTaskEvents.map(subEvent => {
             const displayObject = eventToDisplayObject(
               subEvent,
@@ -177,7 +178,7 @@ export function TaskGroup({
             if (!displayObject) return null
 
             return (
-              <div key={subEvent.id} className="mb-2">
+              <div key={subEvent.id} className="relative mb-2">
                 <div
                   data-event-id={displayObject.id}
                   onMouseEnter={() => {
@@ -195,7 +196,7 @@ export function TaskGroup({
                     focusedEventId === displayObject.id ? '!bg-accent/20 -mx-2 px-4 rounded' : ''
                   }`}
                 >
-                  <div className="flex justify-end mb-2">
+                  <div className="absolute top-2 right-4">
                     <span className="text-xs text-muted-foreground/60">
                       {formatAbsoluteTimestamp(displayObject.created_at)}
                     </span>


### PR DESCRIPTION
## What problem(s) was I solving?

- Fixed a scrolling issue in the SessionTable page where the table content would overflow and become inaccessible
- Addressed inconsistent padding in conversation events that made the UI feel cramped and harder to scan
- Improved the visual hierarchy of timestamps in the conversation view

## What user-facing changes did I ship?

- **Fixed scroll behavior**: The main content area now properly scrolls, allowing users to access all sessions in the SessionTable
- **Improved spacing**: Conversation events now have consistent 16px padding (p-4) instead of inconsistent top/bottom padding
- **Better timestamp positioning**: Timestamps are now absolutely positioned in the top-right corner of each event, reducing visual clutter
- **Cleaner layout**: Removed unused `isWideView` state variable and simplified the event layout structure

## How I implemented it

### Layout.tsx
- Changed the main content container from `overflow-hidden` to `overflow-y-auto` to enable vertical scrolling
- This fixes the issue where content would be cut off without a way to scroll

### ConversationContent.tsx  
- Replaced inconsistent padding (`pt-1 pb-3 px-2`) with uniform padding (`p-4`) for all conversation events
- Made timestamps absolutely positioned (`absolute top-2 right-4`) to maintain consistent spacing
- Added CSS class names (`NoSubTasksConversationContent`) for easier debugging/styling
- Removed the unused `isWideView` state variable and its associated logic

### TaskGroup.tsx
- Applied the same padding standardization (`p-4`) to task groups for consistency
- Made timestamps absolutely positioned to match the ConversationContent styling
- Added CSS class names (`TaskGroup`, `TaskGroupExpanded`) for component identification

## How to verify it

- [x] I have ensured `make check test` passes

### Manual testing steps:
1. Open the HumanLayer WUI
2. Navigate to the Sessions page
3. Verify that you can scroll through all sessions if there are more than fit on screen
4. Click into a session to view the conversation
5. Verify that conversation events have consistent spacing and timestamps are properly positioned
6. Expand/collapse task groups and verify the layout remains consistent

## Description for the changelog

Fixed scroll behavior in SessionTable and improved conversation event spacing with consistent padding and better timestamp positioning