### PR TITLE
Add default project and auto-tagging to Linear command

### DIFF
--- a/.claude/commands/linear.md
+++ b/.claude/commands/linear.md
@@ -53,12 +53,21 @@ When referencing thoughts documents, always provide GitHub links using the `link
 
 ### Default Values
 - **Status**: Always create new tickets in "Triage" status
+- **Project**: For new tickets, default to "M U L T I C L A U D E" (ID: f11c8d63-9120-4393-bfae-553da0b04fd8) unless told otherwise
 - **Priority**: Default to Medium (3) for most tasks, use best judgment or ask user
   - Urgent (1): Critical blockers, security issues
   - High (2): Important features with deadlines, major bugs
   - Medium (3): Standard implementation tasks (default)
   - Low (4): Nice-to-haves, minor improvements
 - **Links**: Use the `links` parameter to attach URLs (not just markdown links in description)
+
+### Automatic Label Assignment
+Automatically apply labels based on the ticket content:
+- **hld**: For tickets about the `hld/` directory (the daemon)
+- **wui**: For tickets about `humanlayer-wui/`
+- **meta**: For tickets about `hlyr` commands, thoughts tool, or `thoughts/` directory
+
+Note: meta is mutually exclusive with hld/wui. Tickets can have both hld and wui, but not meta with either.
 
 ## Action-Specific Instructions
 
@@ -133,10 +142,11 @@ When referencing thoughts documents, always provide GitHub links using the `link
    - title: [refined title]
    - description: [final description in markdown]
    - teamId: [selected team]
-   - projectId: [if selected]
+   - projectId: [use default project from above unless user specifies]
    - priority: [selected priority number, default 3]
    - stateId: [Triage status ID]
    - assigneeId: [if requested]
+   - labelIds: [apply automatic label assignment from above]
    - links: [{url: "GitHub URL", title: "Document Title"}]
    ```
 


### PR DESCRIPTION
## What problem(s) was I solving?

- Linear tickets were being created without a default project, requiring manual selection each time
- There was no automatic labeling system to categorize tickets based on their content, making it harder to filter and organize tickets

## What user-facing changes did I ship?

- Linear tickets now default to the "M U L T I C L A U D E" project (ID: f11c8d63-9120-4393-bfae-553da0b04fd8) when creating new tickets
- Tickets are automatically labeled based on their content:
  - `hld` label for tickets about the daemon (`hld/` directory)
  - `wui` label for tickets about the web UI (`humanlayer-wui/`)
  - `meta` label for tickets about `hlyr` commands, thoughts tool, or `thoughts/` directory
  - Note: `meta` is mutually exclusive with `hld`/`wui` labels

## How I implemented it

Updated the `.claude/commands/linear.md` documentation to include:
1. A default project ID in the "Default Values" section that gets used unless the user explicitly specifies a different project
2. An "Automatic Label Assignment" section that describes the labeling rules
3. Updated the ticket creation steps to use the default project and apply automatic labels based on the ticket content

## How to verify it

- [x] I have ensured `make check test` passes (Note: There's an unrelated TypeScript error in humanlayer-wui that was pre-existing)

## Description for the changelog

Improved Linear ticket creation workflow with automatic project assignment to MULTICLAUDE and content-based labeling (hld, wui, meta)