### PR TITLE
feat: add working directory column to session table

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -139,7 +139,9 @@ export default function SessionTable({
                     </span>
                   </TooltipTrigger>
                   <TooltipContent className="max-w-[600px]">
-                    <span className="font-mono text-sm">{session.working_dir || 'No working directory'}</span>
+                    <span className="font-mono text-sm">
+                      {session.working_dir || 'No working directory'}
+                    </span>
                   </TooltipContent>
                 </Tooltip>
               </TableCell>

--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -13,7 +13,7 @@ import { useHotkeys, useHotkeysContext } from 'react-hotkeys-hook'
 import { useEffect, useRef } from 'react'
 import { CircleOff } from 'lucide-react'
 import { getStatusTextClass } from '@/utils/component-utils'
-import { formatTimestamp, formatAbsoluteTimestamp } from '@/utils/formatting'
+import { formatTimestamp, formatAbsoluteTimestamp, truncatePath } from '@/utils/formatting'
 import { highlightMatches } from '@/lib/fuzzy-search'
 import { useSessionLauncher } from '@/hooks/useSessionLauncher'
 import { cn } from '@/lib/utils'
@@ -113,6 +113,7 @@ export default function SessionTable({
         <TableHeader>
           <TableRow>
             <TableHead>Status</TableHead>
+            <TableHead>Working Directory</TableHead>
             <TableHead>Summary</TableHead>
             <TableHead>Model</TableHead>
             <TableHead>Started</TableHead>
@@ -130,6 +131,18 @@ export default function SessionTable({
               className={`cursor-pointer ${focusedSession?.id === session.id ? '!bg-accent/20' : ''}`}
             >
               <TableCell className={getStatusTextClass(session.status)}>{session.status}</TableCell>
+              <TableCell className="max-w-[200px]">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="block truncate cursor-help text-sm">
+                      {truncatePath(session.working_dir)}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-[600px]">
+                    <span className="font-mono text-sm">{session.working_dir || 'No working directory'}</span>
+                  </TooltipContent>
+                </Tooltip>
+              </TableCell>
               <TableCell>
                 <span>{renderHighlightedText(session.summary, session.id)}</span>
               </TableCell>

--- a/humanlayer-wui/src/utils/formatting.ts
+++ b/humanlayer-wui/src/utils/formatting.ts
@@ -87,7 +87,7 @@ export function truncatePath(path: string | undefined, maxLength: number = 40): 
   if (path.length <= maxLength) return path
 
   // Handle home directory replacement
-  const homePath = path.replace(/^\/Users\/[^/]+/, '~')
+  const homePath = path.replace(/^(\/Users|\/home)\/[^/]+/, '~')
 
   // If home-replaced path fits, use it
   if (homePath.length <= maxLength) return homePath

--- a/humanlayer-wui/src/utils/formatting.ts
+++ b/humanlayer-wui/src/utils/formatting.ts
@@ -82,34 +82,35 @@ export function formatParameters(params: Record<string, any>, maxLength: number 
 
 export function truncatePath(path: string | undefined, maxLength: number = 40): string {
   if (!path) return '-'
-  
+
   // If path fits, return as-is
   if (path.length <= maxLength) return path
-  
+
   // Handle home directory replacement
   const homePath = path.replace(/^\/Users\/[^/]+/, '~')
-  
+
   // If home-replaced path fits, use it
   if (homePath.length <= maxLength) return homePath
-  
+
   // Smart truncation: preserve the end of the path
   const parts = homePath.split('/')
-  
+
   // If we have path segments, try to preserve the last few
   if (parts.length > 2) {
     // Keep trying to add parts from the end until we exceed maxLength
     let result = parts[parts.length - 1]
     for (let i = parts.length - 2; i >= 0; i--) {
       const testResult = parts[i] + '/' + result
-      if (testResult.length + 3 > maxLength) { // +3 for "..."
+      if (testResult.length + 3 > maxLength) {
+        // +3 for "..."
         return '.../' + result
       }
       result = testResult
     }
     return result
   }
-  
+
   // Fallback: simple end truncation ensuring at least 30 chars visible
   const minEndChars = Math.min(30, maxLength - 3)
-  return '...' + homePath.slice(-(minEndChars))
+  return '...' + homePath.slice(-minEndChars)
 }

--- a/humanlayer-wui/src/utils/formatting.ts
+++ b/humanlayer-wui/src/utils/formatting.ts
@@ -79,3 +79,37 @@ export function formatParameters(params: Record<string, any>, maxLength: number 
 
   return parts.join(', ')
 }
+
+export function truncatePath(path: string | undefined, maxLength: number = 40): string {
+  if (!path) return '-'
+  
+  // If path fits, return as-is
+  if (path.length <= maxLength) return path
+  
+  // Handle home directory replacement
+  const homePath = path.replace(/^\/Users\/[^/]+/, '~')
+  
+  // If home-replaced path fits, use it
+  if (homePath.length <= maxLength) return homePath
+  
+  // Smart truncation: preserve the end of the path
+  const parts = homePath.split('/')
+  
+  // If we have path segments, try to preserve the last few
+  if (parts.length > 2) {
+    // Keep trying to add parts from the end until we exceed maxLength
+    let result = parts[parts.length - 1]
+    for (let i = parts.length - 2; i >= 0; i--) {
+      const testResult = parts[i] + '/' + result
+      if (testResult.length + 3 > maxLength) { // +3 for "..."
+        return '.../' + result
+      }
+      result = testResult
+    }
+    return result
+  }
+  
+  // Fallback: simple end truncation ensuring at least 30 chars visible
+  const minEndChars = Math.min(30, maxLength - 3)
+  return '...' + homePath.slice(-(minEndChars))
+}


### PR DESCRIPTION
## What problem(s) was I solving?

When viewing multiple Claude Code sessions in the HumanLayer WUI, it's not immediately clear which directory each session is operating in. Users need to click into each session to see its working directory, making it difficult to quickly identify and navigate to the session they want when multiple sessions are running across different projects.

## What user-facing changes did I ship?

- Added a new "Working Directory" column to the session table, positioned as the second column after Status
- Implemented smart path truncation that preserves the most relevant part of the path (end segments)
- Added tooltip functionality showing the full path on hover for truncated paths
- Automatically replaces user home directories with `~` for cleaner display

## How I implemented it

1. Modified `SessionTable.tsx` to add the new column header and cell for working directory
2. Created a new `truncatePath` utility function in `formatting.ts` that:
   - Returns the full path if it fits within the max length
   - Replaces `/Users/[username]` with `~` for more concise display
   - Intelligently truncates long paths by preserving the end segments (most relevant part)
   - Falls back to simple end truncation for edge cases
3. Applied consistent styling with a max-width constraint and truncation for the cell
4. Added a tooltip component that displays the full path on hover for better UX

## How to verify it

- [x] I have ensured `make check test` passes

Manual testing steps:
1. Launch the HumanLayer WUI
2. Create multiple Claude Code sessions in different directories
3. Verify the Working Directory column appears between Status and Summary columns
4. Test with various path lengths to ensure truncation works correctly
5. Hover over truncated paths to verify the tooltip shows the full path
6. Verify that home directories are properly replaced with `~`

## Description for the changelog

Add working directory column to session table in HumanLayer WUI for better session context visibility