### PR TITLE
[ENG-1612] Improve bulk action handling; add unit tests; adjust checkbox handling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,6 +116,14 @@ jobs:
       - name: Generate Go mocks
         run: make -C hld mocks
 
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install wui deps
+        run: bun install --cwd=humanlayer-wui
+
       - name: Test
         run: make test
 

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,12 @@ test-header:
 	@sh -n ./hack/run_silent.sh || (echo "❌ Shell script syntax error in hack/run_silent.sh" && exit 1)
 	@. ./hack/run_silent.sh && print_main_header "Running Tests"
 
+.PHONY: test-wui
+test-wui: ## Test humanlayer-wui
+	@$(MAKE) -C humanlayer-wui test VERBOSE=$(VERBOSE)
+
 .PHONY: test
-test: test-header test-py test-ts test-hlyr test-hld test-claudecode-go
+test: test-header test-py test-ts test-hlyr test-wui test-hld test-claudecode-go
 
 .PHONY: check-test
 check-test: ## Run all checks and tests

--- a/humanlayer-wui/CLAUDE.md
+++ b/humanlayer-wui/CLAUDE.md
@@ -15,3 +15,30 @@ For UI development, we use Radix UI components styled with Tailwind CSS. State m
 - DO use `zustand` for managing global state. In a number of cases we've used internal React state management, but as the application scales we'll want to push more of that state into `zustand`.
 - DO verify your changes with `bun run lint` and `bun run typecheck`.
 - DO provide a manual list of steps for a human to test new UI changes.
+
+## Testing
+
+We use Bun's built-in test runner for unit tests. Run tests with `bun test`.
+
+- Store tests are located in `src/AppStore.test.ts`
+- Tests are critical for complex state management logic like keyboard shortcuts and selection behavior
+- When modifying store methods, write tests FIRST to verify the expected behavior
+- Use test-driven development (TDD) for store changes: write failing tests, then implement the fix
+
+## Keyboard Shortcuts & Selection Management
+
+The WUI implements vim-style keyboard navigation with complex selection behavior:
+
+- `j/k` - Navigate down/up through sessions
+- `shift+j/shift+k` - Bulk selection with anchor-based range selection
+- `x` - Toggle individual selection
+- `e` - Archive/unarchive sessions
+
+Selection behavior is managed through the AppStore with these key methods:
+
+- `bulkSelect(sessionId, direction)` - Main entry point for shift+j/k shortcuts
+- `selectRange()` - Creates new selection ranges
+- `addRangeToSelection()` - Adds ranges to existing selections
+- `updateCurrentRange()` - Modifies existing ranges (pivot behavior)
+
+The selection system uses "stateless anchor management" - anchors are calculated dynamically based on the current position within a selection range, not stored in state. This prevents synchronization issues.

--- a/humanlayer-wui/Makefile
+++ b/humanlayer-wui/Makefile
@@ -37,7 +37,7 @@ check-quiet: ## Run all quality checks with quiet output
 
 test-quiet: ## Run tests with quiet output
 	@. ../hack/run_silent.sh && print_header "humanlayer-wui" "Web UI tests"
-	@echo "  No tests configured yet"
+	@. ../hack/run_silent.sh && run_silent_with_test_count "Tests passed" "bun test" "bun"
 
 check: ## Run all quality checks (format + lint + typecheck)
 	@if [ -n "$$VERBOSE" ]; then \
@@ -48,7 +48,7 @@ check: ## Run all quality checks (format + lint + typecheck)
 
 test: ## Run tests
 	@if [ -n "$$VERBOSE" ]; then \
-		echo "No tests configured yet"; \
+		bun test; \
 	else \
 		$(MAKE) test-quiet; \
 	fi

--- a/humanlayer-wui/package.json
+++ b/humanlayer-wui/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit",
-    "check": "bun run format:check && bun run lint && bun run typecheck"
+    "check": "bun run format:check && bun run lint && bun run typecheck",
+    "test": "bun test"
   },
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.1.11",

--- a/humanlayer-wui/src/AppStore.test.ts
+++ b/humanlayer-wui/src/AppStore.test.ts
@@ -1,0 +1,131 @@
+import { describe, test, expect, beforeEach } from 'bun:test'
+import { useStore } from './AppStore'
+import type { SessionInfo } from '@/lib/daemon/types'
+import { createMockSessions } from './test-utils'
+
+// Mock sessions for testing
+const mockSessions: SessionInfo[] = createMockSessions(4)
+
+describe('AppStore - Range Selection', () => {
+  beforeEach(() => {
+    // Reset store state before each test
+    const store = useStore.getState()
+    store.initSessions(mockSessions)
+    store.clearSelection()
+    store.setFocusedSession(null)
+    store.setSelectionAnchor(null)
+  })
+
+  test('should select range from anchor to current position when moving down', () => {
+    const store = useStore.getState()
+
+    // Start at session-1
+    store.setFocusedSession(mockSessions[0])
+
+    // First shift+j should set anchor and select sessions 0 and 1
+    store.setSelectionAnchor(mockSessions[0].id)
+    store.selectRange(mockSessions[0].id, mockSessions[1].id)
+
+    // Get fresh state after updates
+    const updatedState = useStore.getState()
+    expect(updatedState.selectedSessions.size).toBe(2)
+    expect(updatedState.selectedSessions.has('session-1')).toBe(true)
+    expect(updatedState.selectedSessions.has('session-2')).toBe(true)
+
+    // Second shift+j should extend range to include session-3
+    store.selectRange(mockSessions[0].id, mockSessions[2].id)
+
+    const finalState = useStore.getState()
+    expect(finalState.selectedSessions.size).toBe(3)
+    expect(finalState.selectedSessions.has('session-1')).toBe(true)
+    expect(finalState.selectedSessions.has('session-2')).toBe(true)
+    expect(finalState.selectedSessions.has('session-3')).toBe(true)
+  })
+
+  test('should shrink range when moving back up with shift+k', () => {
+    const store = useStore.getState()
+
+    // Start with range selected from session-1 to session-3
+    store.setSelectionAnchor(mockSessions[0].id)
+    store.selectRange(mockSessions[0].id, mockSessions[2].id)
+
+    let state = useStore.getState()
+    expect(state.selectedSessions.size).toBe(3)
+
+    // shift+k should shrink range to sessions 1 and 2
+    store.selectRange(mockSessions[0].id, mockSessions[1].id)
+
+    state = useStore.getState()
+    expect(state.selectedSessions.size).toBe(2)
+    expect(state.selectedSessions.has('session-1')).toBe(true)
+    expect(state.selectedSessions.has('session-2')).toBe(true)
+    expect(state.selectedSessions.has('session-3')).toBe(false)
+  })
+
+  test('should handle range selection in reverse direction', () => {
+    const store = useStore.getState()
+
+    // Start at session-3 and select upward
+    store.setFocusedSession(mockSessions[2])
+    store.setSelectionAnchor(mockSessions[2].id)
+
+    // Select from session-3 to session-2 (upward)
+    store.selectRange(mockSessions[2].id, mockSessions[1].id)
+
+    let state = useStore.getState()
+    expect(state.selectedSessions.size).toBe(2)
+    expect(state.selectedSessions.has('session-2')).toBe(true)
+    expect(state.selectedSessions.has('session-3')).toBe(true)
+
+    // Extend to session-1
+    store.selectRange(mockSessions[2].id, mockSessions[0].id)
+
+    state = useStore.getState()
+    expect(state.selectedSessions.size).toBe(3)
+    expect(state.selectedSessions.has('session-1')).toBe(true)
+    expect(state.selectedSessions.has('session-2')).toBe(true)
+    expect(state.selectedSessions.has('session-3')).toBe(true)
+  })
+
+  test('should clear anchor when regular navigation occurs', () => {
+    const store = useStore.getState()
+
+    // Set up range selection
+    store.setSelectionAnchor(mockSessions[0].id)
+    let state = useStore.getState()
+    expect(state.selectionAnchor).toBe('session-1')
+
+    // Regular navigation should clear anchor
+    store.clearSelectionAnchor()
+    state = useStore.getState()
+    expect(state.selectionAnchor).toBe(null)
+  })
+
+  test('should handle edge cases with empty sessions', () => {
+    const store = useStore.getState()
+    store.initSessions([])
+
+    // Should not crash when selecting range with no sessions
+    store.selectRange('non-existent-1', 'non-existent-2')
+    const state = useStore.getState()
+    expect(state.selectedSessions.size).toBe(0)
+  })
+
+  test('should select current and next on first shift+j', () => {
+    const store = useStore.getState()
+
+    // Start at session-1 with no selection
+    store.setFocusedSession(mockSessions[0])
+    expect(store.selectedSessions.size).toBe(0)
+
+    // First shift+j should set anchor at current position and select current + next
+    store.setSelectionAnchor(mockSessions[0].id)
+    store.selectRange(mockSessions[0].id, mockSessions[1].id)
+
+    const state = useStore.getState()
+    expect(state.selectionAnchor).toBe('session-1')
+    expect(state.selectedSessions.size).toBe(2)
+    expect(state.selectedSessions.has('session-1')).toBe(true)
+    expect(state.selectedSessions.has('session-2')).toBe(true)
+  })
+})

--- a/humanlayer-wui/src/AppStore.test.ts
+++ b/humanlayer-wui/src/AppStore.test.ts
@@ -314,7 +314,6 @@ describe('AppStore - bulkSelect behavior', () => {
 
     // Press shift+j from session 1
     // Should select sessions 1-2 with focus on session 2
-    console.log('TEST: Pressing shift+j from session 1')
     store.bulkSelect(mockSessions[0].id, 'desc')
 
     let state = useStore.getState()
@@ -326,15 +325,9 @@ describe('AppStore - bulkSelect behavior', () => {
     // Now press shift+k from session 2
     // Should deselect session 2, keeping only session 1 selected
     // The anchor should be at session 1 (the start of the original range)
-    console.log('TEST: Pressing shift+k from session 2')
     store.bulkSelect(mockSessions[1].id, 'asc')
 
     state = useStore.getState()
-    console.log('TEST: Final state after first shift+k:', {
-      selectedSize: state.selectedSessions.size,
-      selectedIds: Array.from(state.selectedSessions),
-      focusedId: state.focusedSession?.id,
-    })
     expect(state.selectedSessions.size).toBe(1)
     expect(state.selectedSessions.has('session-1')).toBe(true)
     expect(state.selectedSessions.has('session-2')).toBe(false)
@@ -351,7 +344,6 @@ describe('AppStore - bulkSelect behavior', () => {
 
     // First shift+k from session 3
     // Should deselect session 3, keeping only session 2
-    console.log('TEST: First shift+k from session 3')
     store.bulkSelect(mockSessions[2].id, 'asc')
 
     let state = useStore.getState()
@@ -362,15 +354,9 @@ describe('AppStore - bulkSelect behavior', () => {
 
     // Second shift+k from session 2
     // Should add session 1 to selection (extending backwards)
-    console.log('TEST: Second shift+k from session 2')
     store.bulkSelect(mockSessions[1].id, 'asc')
 
     state = useStore.getState()
-    console.log('TEST: Final state after second shift+k:', {
-      selectedSize: state.selectedSessions.size,
-      selectedIds: Array.from(state.selectedSessions),
-      focusedId: state.focusedSession?.id,
-    })
     expect(state.selectedSessions.size).toBe(2)
     expect(state.selectedSessions.has('session-1')).toBe(true)
     expect(state.selectedSessions.has('session-2')).toBe(true)

--- a/humanlayer-wui/src/AppStore.ts
+++ b/humanlayer-wui/src/AppStore.ts
@@ -263,21 +263,21 @@ export const useStore = create<StoreState>((set, get) => ({
         const startIndex = Math.min(anchorIndex, targetIndex)
         const endIndex = Math.max(anchorIndex, targetIndex)
         const newSelection = new Set<string>()
-        
+
         for (let i = startIndex; i <= endIndex; i++) {
           newSelection.add(sessions[i].id)
         }
-        
+
         return { selectedSessions: newSelection }
       }
 
       // In adding mode: we need to find which sessions belong to the "current" range
       // (the range being modified by the current shift+j/k sequence) and update only those
-      
+
       // Find the extent of the current range by looking for contiguous selections around the anchor
       let rangeStart = anchorIndex
       let rangeEnd = anchorIndex
-      
+
       // Find the boundaries of the current selection range that includes the anchor
       for (let i = anchorIndex - 1; i >= 0; i--) {
         if (selectedSessions.has(sessions[i].id)) {
@@ -286,7 +286,7 @@ export const useStore = create<StoreState>((set, get) => ({
           break
         }
       }
-      
+
       for (let i = anchorIndex + 1; i < sessions.length; i++) {
         if (selectedSessions.has(sessions[i].id)) {
           rangeEnd = i
@@ -297,7 +297,7 @@ export const useStore = create<StoreState>((set, get) => ({
 
       // Create new selection preserving everything outside the current range
       const newSelection = new Set<string>()
-      
+
       // Add all selections outside the current range
       selectedSessions.forEach(id => {
         const index = sessions.findIndex(s => s.id === id)
@@ -305,11 +305,11 @@ export const useStore = create<StoreState>((set, get) => ({
           newSelection.add(id)
         }
       })
-      
+
       // Add the new range from anchor to target
       const newRangeStart = Math.min(anchorIndex, targetIndex)
       const newRangeEnd = Math.max(anchorIndex, targetIndex)
-      
+
       for (let i = newRangeStart; i <= newRangeEnd; i++) {
         newSelection.add(sessions[i].id)
       }

--- a/humanlayer-wui/src/components/SessionTableSearch.tsx
+++ b/humanlayer-wui/src/components/SessionTableSearch.tsx
@@ -5,6 +5,7 @@ import { useHotkeys } from 'react-hotkeys-hook'
 import { SessionTableHotkeysScope } from './internal/SessionTable'
 import { Badge } from './ui/badge'
 import { useStore } from '@/AppStore'
+import { ViewMode } from '@/lib/daemon/types'
 
 interface SessionTableSearchProps {
   value: string
@@ -97,7 +98,7 @@ export function SessionTableSearch({
           </Badge>
         )}
 
-        {viewMode === 'archived' && (
+        {viewMode === ViewMode.Archived && (
           <Badge
             variant="secondary"
             className="text-xs animate-in fade-in slide-in-from-right-1 duration-200"

--- a/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionActions.ts
+++ b/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionActions.ts
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useNavigate } from 'react-router-dom'
-import { SessionInfo, ConversationEvent } from '@/lib/daemon/types'
+import { SessionInfo, ConversationEvent, ViewMode } from '@/lib/daemon/types'
 import { daemonClient } from '@/lib/daemon/client'
 import { notificationService } from '@/services/NotificationService'
 import { useStore } from '@/AppStore'
@@ -25,6 +25,7 @@ export function useSessionActions({
   const interruptSession = useStore(state => state.interruptSession)
   const refreshSessions = useStore(state => state.refreshSessions)
   const archiveSession = useStore(state => state.archiveSession)
+  const setViewMode = useStore(state => state.setViewMode)
   const navigate = useNavigate()
 
   // Update response input when fork message is selected
@@ -50,6 +51,8 @@ export function useSessionActions({
       // Unarchive the session if it's archived
       if (session.archived) {
         await archiveSession(session.id, false)
+        // Switch to normal view mode when resuming an archived session
+        setViewMode(ViewMode.Normal)
       }
 
       const response = await daemonClient.continueSession({

--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -61,6 +61,8 @@ export default function SessionTable({
     setSelectionAnchor,
     clearSelectionAnchor,
     selectRange,
+    addRangeToSelection,
+    isAddingToSelection,
   } = useStore()
 
   // Helper to render highlighted text
@@ -106,6 +108,10 @@ export default function SessionTable({
   useHotkeys(
     'j',
     () => {
+      console.log('[j] Clearing anchor, current selections:', {
+        selectedSessionsSize: selectedSessions.size,
+        selectedSessionIds: Array.from(selectedSessions),
+      })
       clearSelectionAnchor() // Clear anchor on regular navigation
       handleFocusNextSession?.()
     },
@@ -113,7 +119,7 @@ export default function SessionTable({
       scopes: SessionTableHotkeysScope,
       enabled: !isSessionLauncherOpen,
     },
-    [clearSelectionAnchor, handleFocusNextSession],
+    [clearSelectionAnchor, handleFocusNextSession, selectedSessions],
   )
 
   useHotkeys(
@@ -136,8 +142,21 @@ export default function SessionTable({
       if (focusedSession) {
         const currentIndex = sessions.findIndex(s => s.id === focusedSession.id)
 
+        console.log('[shift+j] Current state:', {
+          focusedSessionId: focusedSession.id,
+          currentIndex,
+          selectionAnchor,
+          selectedSessionsSize: selectedSessions.size,
+          selectedSessionIds: Array.from(selectedSessions),
+          isAddingToSelection,
+        })
+
+        // Check if we should be adding to selection BEFORE setting anchor
+        const shouldAddToSelection = !selectionAnchor && selectedSessions.size > 0
+
         // If no anchor is set, set it to current position
         if (!selectionAnchor) {
+          console.log('[shift+j] Setting anchor to:', focusedSession.id)
           setSelectionAnchor(focusedSession.id)
         }
 
@@ -146,8 +165,24 @@ export default function SessionTable({
           const nextSession = sessions[currentIndex + 1]
           handleFocusSession?.(nextSession)
 
-          // Select range from anchor to new position
-          selectRange(selectionAnchor || focusedSession.id, nextSession.id)
+          // Use the pre-calculated flag for new sequences, or check isAddingToSelection for continuing sequences
+          const shouldAdd = shouldAddToSelection || isAddingToSelection
+          
+          if (shouldAdd) {
+            console.log('[shift+j] Adding to selection:', {
+              anchor: selectionAnchor || focusedSession.id,
+              target: nextSession.id,
+            })
+            // Continue adding to existing selections
+            addRangeToSelection(selectionAnchor || focusedSession.id, nextSession.id)
+          } else {
+            console.log('[shift+j] Replacing selection:', {
+              anchor: selectionAnchor || focusedSession.id,
+              target: nextSession.id,
+            })
+            // Replace selections with new range
+            selectRange(selectionAnchor || focusedSession.id, nextSession.id)
+          }
         }
       }
     },
@@ -156,7 +191,16 @@ export default function SessionTable({
       enabled: !isSessionLauncherOpen,
       preventDefault: true,
     },
-    [focusedSession, sessions, selectionAnchor, setSelectionAnchor, selectRange, handleFocusSession],
+    [
+      focusedSession,
+      sessions,
+      selectionAnchor,
+      setSelectionAnchor,
+      selectRange,
+      addRangeToSelection,
+      isAddingToSelection,
+      handleFocusSession,
+    ],
   )
 
   useHotkeys(
@@ -165,8 +209,21 @@ export default function SessionTable({
       if (focusedSession) {
         const currentIndex = sessions.findIndex(s => s.id === focusedSession.id)
 
+        console.log('[shift+k] Current state:', {
+          focusedSessionId: focusedSession.id,
+          currentIndex,
+          selectionAnchor,
+          selectedSessionsSize: selectedSessions.size,
+          selectedSessionIds: Array.from(selectedSessions),
+          isAddingToSelection,
+        })
+
+        // Check if we should be adding to selection BEFORE setting anchor
+        const shouldAddToSelection = !selectionAnchor && selectedSessions.size > 0
+
         // If no anchor is set, set it to current position
         if (!selectionAnchor) {
+          console.log('[shift+k] Setting anchor to:', focusedSession.id)
           setSelectionAnchor(focusedSession.id)
         }
 
@@ -175,8 +232,24 @@ export default function SessionTable({
           const prevSession = sessions[currentIndex - 1]
           handleFocusSession?.(prevSession)
 
-          // Select range from anchor to new position
-          selectRange(selectionAnchor || focusedSession.id, prevSession.id)
+          // Use the pre-calculated flag for new sequences, or check isAddingToSelection for continuing sequences
+          const shouldAdd = shouldAddToSelection || isAddingToSelection
+          
+          if (shouldAdd) {
+            console.log('[shift+k] Adding to selection:', {
+              anchor: selectionAnchor || focusedSession.id,
+              target: prevSession.id,
+            })
+            // Continue adding to existing selections
+            addRangeToSelection(selectionAnchor || focusedSession.id, prevSession.id)
+          } else {
+            console.log('[shift+k] Replacing selection:', {
+              anchor: selectionAnchor || focusedSession.id,
+              target: prevSession.id,
+            })
+            // Replace selections with new range
+            selectRange(selectionAnchor || focusedSession.id, prevSession.id)
+          }
         }
       }
     },
@@ -185,7 +258,16 @@ export default function SessionTable({
       enabled: !isSessionLauncherOpen,
       preventDefault: true,
     },
-    [focusedSession, sessions, selectionAnchor, setSelectionAnchor, selectRange, handleFocusSession],
+    [
+      focusedSession,
+      sessions,
+      selectionAnchor,
+      setSelectionAnchor,
+      selectRange,
+      addRangeToSelection,
+      isAddingToSelection,
+      handleFocusSession,
+    ],
   )
 
   // Select all with meta+a (Cmd+A on Mac, Ctrl+A on Windows/Linux)

--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -328,11 +328,20 @@ export default function SessionTable({
                     }}
                   >
                     <div className="flex items-center justify-center">
-                      {selectedSessions.has(session.id) ? (
-                        <CheckSquare className="w-4 h-4 text-primary" />
-                      ) : (
-                        <Square className="w-4 h-4 text-muted-foreground" />
-                      )}
+                      <div
+                        className={cn(
+                          "transition-all duration-200 ease-in-out",
+                          (focusedSession?.id === session.id || selectedSessions.size > 0)
+                            ? "opacity-100 scale-100"
+                            : "opacity-0 scale-75"
+                        )}
+                      >
+                        {selectedSessions.has(session.id) ? (
+                          <CheckSquare className="w-4 h-4 text-primary" />
+                        ) : (
+                          <Square className="w-4 h-4 text-muted-foreground" />
+                        )}
+                      </div>
                     </div>
                   </TableCell>
                   <TableCell className={getStatusTextClass(session.status)}>{session.status}</TableCell>

--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -155,11 +155,17 @@ export default function SessionTable({
         // Check if we should be adding to selection BEFORE setting anchor
         // If we're starting within an existing selection, we're modifying that range, not adding
         const isStartingInSelection = selectedSessions.has(focusedSession.id)
-        const shouldAddToSelection = !selectionAnchor && selectedSessions.size > 0 && !isStartingInSelection
+        const shouldAddToSelection =
+          !selectionAnchor && selectedSessions.size > 0 && !isStartingInSelection
 
         // If no anchor is set, set it to current position
         if (!selectionAnchor) {
-          console.log('[shift+j] Setting anchor to:', focusedSession.id, 'isStartingInSelection:', isStartingInSelection)
+          console.log(
+            '[shift+j] Setting anchor to:',
+            focusedSession.id,
+            'isStartingInSelection:',
+            isStartingInSelection,
+          )
           setSelectionAnchor(focusedSession.id)
         }
 
@@ -170,7 +176,7 @@ export default function SessionTable({
 
           // Use the pre-calculated flag for new sequences, or check isAddingToSelection for continuing sequences
           const shouldAdd = shouldAddToSelection || (isAddingToSelection && !isStartingInSelection)
-          
+
           if (shouldAdd) {
             console.log('[shift+j] Adding to selection:', {
               anchor: selectionAnchor || focusedSession.id,
@@ -233,11 +239,17 @@ export default function SessionTable({
         // Check if we should be adding to selection BEFORE setting anchor
         // If we're starting within an existing selection, we're modifying that range, not adding
         const isStartingInSelection = selectedSessions.has(focusedSession.id)
-        const shouldAddToSelection = !selectionAnchor && selectedSessions.size > 0 && !isStartingInSelection
+        const shouldAddToSelection =
+          !selectionAnchor && selectedSessions.size > 0 && !isStartingInSelection
 
         // If no anchor is set, set it to current position
         if (!selectionAnchor) {
-          console.log('[shift+k] Setting anchor to:', focusedSession.id, 'isStartingInSelection:', isStartingInSelection)
+          console.log(
+            '[shift+k] Setting anchor to:',
+            focusedSession.id,
+            'isStartingInSelection:',
+            isStartingInSelection,
+          )
           setSelectionAnchor(focusedSession.id)
         }
 
@@ -246,7 +258,7 @@ export default function SessionTable({
           const prevSession = sessions[currentIndex - 1]
           const anchorId = selectionAnchor || focusedSession.id
           const anchorIndex = sessions.findIndex(s => s.id === anchorId)
-          
+
           handleFocusSession?.(prevSession)
 
           // When in adding mode AND not starting in an existing selection, we need special handling
@@ -254,18 +266,20 @@ export default function SessionTable({
             // Check if the new target would shrink the current range
             // This happens when we're moving back towards the anchor
             const prevIndex = currentIndex - 1
-            
+
             // Check if we're shrinking the selection by checking if the new range
             // would be smaller than what's currently selected in this range
             const currentRangeStart = Math.min(anchorIndex, currentIndex)
             const currentRangeEnd = Math.max(anchorIndex, currentIndex)
             const newRangeStart = Math.min(anchorIndex, prevIndex)
             const newRangeEnd = Math.max(anchorIndex, prevIndex)
-            
+
             // We're shrinking if the new range is contained within the current range
             // and is smaller
-            const isShrinking = newRangeEnd - newRangeStart < currentRangeEnd - currentRangeStart &&
-                                newRangeStart >= currentRangeStart && newRangeEnd <= currentRangeEnd
+            const isShrinking =
+              newRangeEnd - newRangeStart < currentRangeEnd - currentRangeStart &&
+              newRangeStart >= currentRangeStart &&
+              newRangeEnd <= currentRangeEnd
 
             if (isShrinking) {
               console.log('[shift+k] Updating current range (shrinking):', {
@@ -287,7 +301,7 @@ export default function SessionTable({
           } else {
             // Not in adding mode - check what to do
             const shouldAdd = shouldAddToSelection
-            
+
             if (shouldAdd) {
               console.log('[shift+k] Adding to selection (new range):', {
                 anchor: anchorId,

--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -52,16 +52,8 @@ export default function SessionTable({
   const { isOpen: isSessionLauncherOpen } = useSessionLauncher()
   const { enableScope, disableScope } = useHotkeysContext()
   const tableRef = useRef<HTMLTableElement>(null)
-  const {
-    archiveSession,
-    selectedSessions,
-    toggleSessionSelection,
-    bulkArchiveSessions,
-    selectRange,
-    addRangeToSelection,
-    updateCurrentRange,
-    bulkSelect,
-  } = useStore()
+  const { archiveSession, selectedSessions, toggleSessionSelection, bulkArchiveSessions, bulkSelect } =
+    useStore()
 
   // Helper to render highlighted text
   const renderHighlightedText = (text: string, sessionId: string) => {
@@ -132,67 +124,7 @@ export default function SessionTable({
     'shift+j',
     () => {
       if (focusedSession && sessions.length > 0) {
-        console.log('shift+j')
-
         bulkSelect(focusedSession.id, 'desc')
-        /*
-        const currentIndex = sessions.findIndex(s => s.id === focusedSession.id)
-        if (currentIndex === -1 || currentIndex >= sessions.length - 1) return
-
-        const nextSession = sessions[currentIndex + 1]
-        handleFocusSession?.(nextSession)
-
-        // Determine the anchor based on current state
-        let anchorId = focusedSession.id
-        
-        // Check if we're starting within an existing selection
-        const isStartingInSelection = selectedSessions.has(focusedSession.id)
-        
-        if (isStartingInSelection && selectedSessions.size > 0) {
-          // Find the contiguous range that includes current position
-          let rangeStart = currentIndex
-          let rangeEnd = currentIndex
-          
-          // Look backwards for contiguous selections
-          for (let i = currentIndex - 1; i >= 0; i--) {
-            if (selectedSessions.has(sessions[i].id)) {
-              rangeStart = i
-            } else {
-              break
-            }
-          }
-          
-          // Look forwards for contiguous selections
-          for (let i = currentIndex + 1; i < sessions.length; i++) {
-            if (selectedSessions.has(sessions[i].id)) {
-              rangeEnd = i
-            } else {
-              break
-            }
-          }
-          
-          // For shift+j (moving down), anchor at the top of the range
-          anchorId = sessions[rangeStart].id
-          
-          console.log('[shift+j] Starting in selection, found range:', {
-            rangeStart,
-            rangeEnd,
-            anchorIndex: rangeStart,
-            targetIndex: currentIndex + 1,
-          })
-          
-          // Use updateCurrentRange to modify the existing range
-          updateCurrentRange(anchorId, nextSession.id)
-        } else if (selectedSessions.size > 0 && !isStartingInSelection) {
-          // We have selections but starting fresh - add to existing
-          console.log('[shift+j] Adding new range to existing selections')
-          addRangeToSelection(anchorId, nextSession.id)
-        } else {
-          // No selections or replacing - create new range
-          console.log('[shift+j] Creating new selection range')
-          selectRange(anchorId, nextSession.id)
-        }
-      */
       }
     },
     {
@@ -200,82 +132,14 @@ export default function SessionTable({
       enabled: !isSessionLauncherOpen,
       preventDefault: true,
     },
-    [
-      focusedSession,
-      sessions,
-      selectedSessions,
-      selectRange,
-      addRangeToSelection,
-      updateCurrentRange,
-      handleFocusSession,
-      bulkSelect,
-    ],
+    [focusedSession, sessions, bulkSelect],
   )
 
   useHotkeys(
     'shift+k',
     () => {
       if (focusedSession && sessions.length > 0) {
-        console.log('shift+k')
         bulkSelect(focusedSession.id, 'asc')
-        /*
-        const currentIndex = sessions.findIndex(s => s.id === focusedSession.id)
-        if (currentIndex === -1 || currentIndex === 0) return
-
-        const prevSession = sessions[currentIndex - 1]
-        handleFocusSession?.(prevSession)
-
-        // Determine the anchor based on current state
-        let anchorId = focusedSession.id
-        
-        // Check if we're starting within an existing selection
-        const isStartingInSelection = selectedSessions.has(focusedSession.id)
-        
-        if (isStartingInSelection && selectedSessions.size > 0) {
-          // Find the contiguous range that includes current position
-          let rangeStart = currentIndex
-          let rangeEnd = currentIndex
-          
-          // Look backwards for contiguous selections
-          for (let i = currentIndex - 1; i >= 0; i--) {
-            if (selectedSessions.has(sessions[i].id)) {
-              rangeStart = i
-            } else {
-              break
-            }
-          }
-          
-          // Look forwards for contiguous selections
-          for (let i = currentIndex + 1; i < sessions.length; i++) {
-            if (selectedSessions.has(sessions[i].id)) {
-              rangeEnd = i
-            } else {
-              break
-            }
-          }
-          
-          // For shift+k (moving up), anchor at the bottom of the range
-          anchorId = sessions[rangeEnd].id
-          
-          console.log('[shift+k] Starting in selection, found range:', {
-            rangeStart,
-            rangeEnd,
-            anchorIndex: rangeEnd,
-            targetIndex: currentIndex - 1,
-          })
-          
-          // Use updateCurrentRange to modify the existing range
-          updateCurrentRange(anchorId, prevSession.id)
-        } else if (selectedSessions.size > 0 && !isStartingInSelection) {
-          // We have selections but starting fresh - add to existing
-          console.log('[shift+k] Adding new range to existing selections')
-          addRangeToSelection(anchorId, prevSession.id)
-        } else {
-          // No selections or replacing - create new range
-          console.log('[shift+k] Creating new selection range')
-          selectRange(anchorId, prevSession.id)
-        }
-        */
       }
     },
     {
@@ -283,16 +147,7 @@ export default function SessionTable({
       enabled: !isSessionLauncherOpen,
       preventDefault: true,
     },
-    [
-      focusedSession,
-      sessions,
-      selectedSessions,
-      selectRange,
-      addRangeToSelection,
-      updateCurrentRange,
-      handleFocusSession,
-      bulkSelect,
-    ],
+    [focusedSession, sessions, bulkSelect],
   )
 
   // Select all with meta+a (Cmd+A on Mac, Ctrl+A on Windows/Linux)

--- a/humanlayer-wui/src/lib/daemon/types.ts
+++ b/humanlayer-wui/src/lib/daemon/types.ts
@@ -40,6 +40,11 @@ export enum ApprovalStatus {
   Resolved = 'resolved',
 }
 
+export enum ViewMode {
+  Normal = 'normal',
+  Archived = 'archived',
+}
+
 // Type definitions matching the Rust types
 export interface HealthCheckResponse {
   status: string

--- a/humanlayer-wui/src/pages/SessionTablePage.tsx
+++ b/humanlayer-wui/src/pages/SessionTablePage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useStore } from '@/AppStore'
+import { ViewMode } from '@/lib/daemon/types'
 import SessionTable, { SessionTableHotkeysScope } from '@/components/internal/SessionTable'
 import { SessionTableSearch } from '@/components/SessionTableSearch'
 import { useSessionFilter } from '@/hooks/useSessionFilter'
@@ -81,7 +82,7 @@ export function SessionTablePage() {
     'tab',
     e => {
       e.preventDefault()
-      setViewMode(viewMode === 'normal' ? 'archived' : 'normal')
+      setViewMode(viewMode === ViewMode.Normal ? ViewMode.Archived : ViewMode.Normal)
       // Clear search when switching views
       setSearchQuery('')
     },
@@ -93,7 +94,7 @@ export function SessionTablePage() {
     'shift+tab',
     e => {
       e.preventDefault()
-      setViewMode(viewMode === 'normal' ? 'archived' : 'normal')
+      setViewMode(viewMode === ViewMode.Normal ? ViewMode.Archived : ViewMode.Normal)
       // Clear search when switching views
       setSearchQuery('')
     },
@@ -136,14 +137,14 @@ export function SessionTablePage() {
   useHotkeys(
     'escape',
     () => {
-      if (viewMode === 'archived') {
-        setViewMode('normal')
+      if (viewMode === ViewMode.Archived) {
+        setViewMode(ViewMode.Normal)
       }
     },
     {
       enableOnFormTags: false,
       scopes: SessionTableHotkeysScope,
-      enabled: !isSessionLauncherOpen && viewMode === 'archived',
+      enabled: !isSessionLauncherOpen && viewMode === ViewMode.Archived,
       preventDefault: true,
     },
   )
@@ -171,7 +172,7 @@ export function SessionTablePage() {
           searchText={searchText}
           matchedSessions={matchedSessions}
           emptyState={
-            viewMode === 'archived'
+            viewMode === ViewMode.Archived
               ? {
                   icon: Archive,
                   title: 'No archived sessions',
@@ -179,7 +180,7 @@ export function SessionTablePage() {
                     'Sessions you archive will appear here. Press ESC or click below to go back.',
                   action: {
                     label: 'View all sessions',
-                    onClick: () => setViewMode('normal'),
+                    onClick: () => setViewMode(ViewMode.Normal),
                   },
                 }
               : {

--- a/humanlayer-wui/src/test-utils.ts
+++ b/humanlayer-wui/src/test-utils.ts
@@ -1,0 +1,46 @@
+import type { SessionInfo } from '@/lib/daemon/types'
+import { SessionStatus } from '@/lib/daemon/types'
+
+export function createMockSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  const id = overrides.id || `session-${Math.random().toString(36).substring(7)}`
+  const timestamp = new Date().toISOString()
+
+  return {
+    id,
+    run_id: `run-${id}`,
+    summary: 'Test session',
+    query: 'Test query',
+    status: SessionStatus.Running,
+    working_dir: '/home/user/project',
+    model: 'claude-3',
+    start_time: timestamp,
+    last_activity_at: timestamp,
+    archived: false,
+    auto_accept_edits: false,
+    ...overrides,
+  }
+}
+
+export function createMockSessions(
+  count: number,
+  overrides: Partial<SessionInfo>[] = [],
+): SessionInfo[] {
+  return Array.from({ length: count }, (_, index) => {
+    const baseTime = new Date('2024-01-01T00:00:00Z')
+    baseTime.setMinutes(index * 2)
+    const startTime = baseTime.toISOString()
+    baseTime.setMinutes(index * 2 + 1)
+    const lastActivityTime = baseTime.toISOString()
+
+    return createMockSession({
+      id: `session-${index + 1}`,
+      summary: `Session ${index + 1}`,
+      query: `Test query ${index + 1}`,
+      status: index < 2 ? SessionStatus.Running : SessionStatus.Completed,
+      working_dir: `/home/user/project${index + 1}`,
+      start_time: startTime,
+      last_activity_at: lastActivityTime,
+      ...overrides[index],
+    })
+  })
+}

--- a/humanlayer-wui/src/types/bun-test.d.ts
+++ b/humanlayer-wui/src/types/bun-test.d.ts
@@ -1,0 +1,31 @@
+declare module 'bun:test' {
+  export function describe(name: string, fn: () => void): void
+  export function test(name: string, fn: () => void | Promise<void>): void
+  export function expect<T>(value: T): {
+    toBe(expected: T): void
+    toEqual(expected: T): void
+    toBeTruthy(): void
+    toBeFalsy(): void
+    toBeNull(): void
+    toBeUndefined(): void
+    toBeGreaterThan(expected: number): void
+    toBeGreaterThanOrEqual(expected: number): void
+    toBeLessThan(expected: number): void
+    toBeLessThanOrEqual(expected: number): void
+    toContain(expected: string | T): void
+    toHaveLength(expected: number): void
+    toThrow(expected?: string | RegExp | Error): void
+    not: {
+      toBe(expected: T): void
+      toEqual(expected: T): void
+      toBeTruthy(): void
+      toBeFalsy(): void
+      toBeNull(): void
+      toBeUndefined(): void
+    }
+  }
+  export function beforeEach(fn: () => void | Promise<void>): void
+  export function afterEach(fn: () => void | Promise<void>): void
+  export function beforeAll(fn: () => void | Promise<void>): void
+  export function afterAll(fn: () => void | Promise<void>): void
+}


### PR DESCRIPTION
## What problem(s) was I solving?

The Web UI's keyboard navigation for bulk selection had several usability issues:
1. Shift+j/k toggled individual items instead of selecting contiguous ranges like standard keyboard shortcuts (e.g., shift+arrow keys)
2. Users couldn't build multiple non-contiguous selection ranges efficiently
3. Checkboxes were always visible, creating visual clutter when not needed for selection
4. The archived icon was redundant since the view mode already indicated archived status
5. No automated tests existed for the WUI project, making it risky to modify keyboard navigation behavior

## What user-facing changes did I ship?

- **Enhanced keyboard shortcuts**: Shift+j/k now properly selects contiguous ranges instead of toggling individual items
  - First shift+j sets an anchor and selects from current position to next
  - Subsequent shift+j/k extends or shrinks the selection range
  - Users can create multiple selection ranges by navigating with j/k and using shift+j/k again
- **Cleaner UI**: Checkboxes only appear when needed (row focused or in bulk selection mode) with smooth 200ms fade/scale animations
- **Better archive handling**: Removed redundant archive icon and automatically switch to normal view when resuming archived sessions
- **Added test infrastructure**: Set up Bun test runner for the WUI project with comprehensive unit tests

## How I implemented it

1. **Range selection state management**:
   - Added `selectionAnchor`, `isAddingToSelection` to AppStore to track range selection state
   - Created `selectRange()` for replacing selection with a new range
   - Created `addRangeToSelection()` for adding a new range to existing selections
   - Created `updateCurrentRange()` for modifying the current range during shift+j/k navigation

2. **Keyboard handler improvements**:
   - Modified shift+j/k handlers in SessionTable to use range selection instead of toggle
   - Pre-calculate selection behavior to avoid React state batching issues
   - Clear anchor on regular navigation (j/k) and individual toggles (x/click)

3. **UI enhancements**:
   - Added conditional rendering for checkboxes based on focus/selection state
   - Implemented CSS transitions for smooth checkbox appearance/disappearance
   - Replaced string literals with ViewMode enum for type safety
   - Auto-switch view modes when resuming archived sessions

4. **Testing infrastructure**:
   - Configured Bun test runner in package.json and Makefile
   - Created test utilities for mock session generation
   - Added comprehensive unit tests for all range selection scenarios

## How to verify it

- [x] I have ensured `make check test` passes

**Manual testing steps for keyboard navigation:**
1. Open the WUI and navigate to the sessions table
2. Press `j/k` to navigate between sessions (no selection)
3. Press `shift+j` to start range selection (selects current + next)
4. Continue pressing `shift+j` to extend selection downward
5. Press `shift+k` to shrink selection upward
6. Press `j` to move down without selecting, then `shift+j` to add a new range
7. Verify checkboxes only appear when row is focused or items are selected
8. Archive some sessions with `Shift+Delete` and verify the archived icon doesn't appear
9. Switch to archived view with `v` and resume a session - verify it switches back to normal view

## Description for the changelog

Fixed WUI keyboard navigation to support proper range selection with shift+j/k, added conditional checkbox visibility with animations, and established test infrastructure for the WUI project.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improved keyboard navigation and selection handling in the Web UI, added test infrastructure with Bun, and refined UI elements for better usability.
> 
>   - **Behavior**:
>     - `shift+j/k` now selects contiguous ranges in `SessionTable`, allowing multiple non-contiguous selections.
>     - Checkboxes only appear when needed, with animations, in `SessionTable`.
>     - Removed archive icon; auto-switch to normal view when resuming archived sessions.
>   - **State Management**:
>     - Added `selectionAnchor`, `isAddingToSelection` to `AppStore` for range selection.
>     - New methods `selectRange()`, `addRangeToSelection()`, `updateCurrentRange()` in `AppStore`.
>   - **Testing**:
>     - Configured Bun test runner in `package.json` and `Makefile`.
>     - Added `AppStore.test.ts` for unit tests covering range selection scenarios.
>   - **Misc**:
>     - Introduced `ViewMode` enum in `types.ts` for type safety.
>     - Updated `SessionTable` and `SessionTablePage` to use new selection logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for d83401a560e3555fdd85380b6de8916445cef09e. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->