### PR TITLE
Add browser-like zoom functionality to WUI

### DIFF
--- a/humanlayer-wui/src/components/Layout.tsx
+++ b/humanlayer-wui/src/components/Layout.tsx
@@ -10,6 +10,7 @@ import { useStore } from '@/AppStore'
 import { useSessionEventsWithNotifications } from '@/hooks/useSessionEventsWithNotifications'
 import { Toaster } from 'sonner'
 import { notificationService } from '@/services/NotificationService'
+import { useZoom } from '@/contexts/ZoomContext'
 import '@/App.css'
 
 export function Layout() {
@@ -21,6 +22,9 @@ export function Layout() {
   // Session launcher state
   const { isOpen, close } = useSessionLauncher()
   const { handleKeyDown } = useSessionLauncherHotkeys()
+
+  // Zoom functionality
+  const { increaseZoom, decreaseZoom, resetZoom } = useZoom()
 
   // Set up real-time subscriptions with notification handling
   useSessionEventsWithNotifications(connected)
@@ -63,9 +67,31 @@ export function Layout() {
 
   // Global hotkey handler
   useEffect(() => {
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [handleKeyDown])
+    const handleGlobalKeyDown = (e: KeyboardEvent) => {
+      // Handle zoom shortcuts
+      if (e.metaKey || e.ctrlKey) {
+        if (e.key === '=' || e.key === '+') {
+          e.preventDefault()
+          increaseZoom()
+          return
+        } else if (e.key === '-' || e.key === '_') {
+          e.preventDefault()
+          decreaseZoom()
+          return
+        } else if (e.key === '0') {
+          e.preventDefault()
+          resetZoom()
+          return
+        }
+      }
+
+      // Handle other shortcuts
+      handleKeyDown(e)
+    }
+
+    document.addEventListener('keydown', handleGlobalKeyDown)
+    return () => document.removeEventListener('keydown', handleGlobalKeyDown)
+  }, [handleKeyDown, increaseZoom, decreaseZoom, resetZoom])
 
   const connectToDaemon = async () => {
     try {

--- a/humanlayer-wui/src/contexts/ZoomContext.tsx
+++ b/humanlayer-wui/src/contexts/ZoomContext.tsx
@@ -1,0 +1,54 @@
+import React, { createContext, useContext, useState, useEffect } from 'react'
+
+interface ZoomContextType {
+  zoomLevel: number
+  setZoomLevel: (level: number) => void
+  increaseZoom: () => void
+  decreaseZoom: () => void
+  resetZoom: () => void
+}
+
+const ZoomContext = createContext<ZoomContextType | undefined>(undefined)
+
+const MIN_ZOOM = 0.5
+const MAX_ZOOM = 2.0
+const ZOOM_STEP = 0.1
+const DEFAULT_ZOOM = 1.0
+
+export function ZoomProvider({ children }: { children: React.ReactNode }) {
+  const [zoomLevel, setZoomLevel] = useState<number>(() => {
+    const stored = localStorage.getItem('wui-zoom-level')
+    return stored ? parseFloat(stored) : DEFAULT_ZOOM
+  })
+
+  useEffect(() => {
+    localStorage.setItem('wui-zoom-level', zoomLevel.toString())
+    document.body.style.zoom = zoomLevel.toString()
+  }, [zoomLevel])
+
+  const increaseZoom = () => {
+    setZoomLevel(prev => Math.min(MAX_ZOOM, Math.round((prev + ZOOM_STEP) * 10) / 10))
+  }
+
+  const decreaseZoom = () => {
+    setZoomLevel(prev => Math.max(MIN_ZOOM, Math.round((prev - ZOOM_STEP) * 10) / 10))
+  }
+
+  const resetZoom = () => {
+    setZoomLevel(DEFAULT_ZOOM)
+  }
+
+  return (
+    <ZoomContext.Provider value={{ zoomLevel, setZoomLevel, increaseZoom, decreaseZoom, resetZoom }}>
+      {children}
+    </ZoomContext.Provider>
+  )
+}
+
+export function useZoom() {
+  const context = useContext(ZoomContext)
+  if (context === undefined) {
+    throw new Error('useZoom must be used within a ZoomProvider')
+  }
+  return context
+}

--- a/humanlayer-wui/src/main.tsx
+++ b/humanlayer-wui/src/main.tsx
@@ -3,14 +3,17 @@ import ReactDOM from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
 import { router } from './router'
 import { ThemeProvider } from './contexts/ThemeContext'
+import { ZoomProvider } from './contexts/ZoomContext'
 import { HotkeysProvider } from 'react-hotkeys-hook'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <ThemeProvider>
-      <HotkeysProvider initiallyActiveScopes={['none']}>
-        <RouterProvider router={router} />
-      </HotkeysProvider>
+      <ZoomProvider>
+        <HotkeysProvider initiallyActiveScopes={['none']}>
+          <RouterProvider router={router} />
+        </HotkeysProvider>
+      </ZoomProvider>
     </ThemeProvider>
   </React.StrictMode>,
 )


### PR DESCRIPTION
Implement zoom controls with keyboard shortcuts:
- Cmd/Ctrl + Plus: Increase zoom (10% increments)
- Cmd/Ctrl + Minus: Decrease zoom (10% decrements)
- Cmd/Ctrl + 0: Reset zoom to 100%

Zoom level persists across sessions using localStorage.
Range: 50% to 200% with 10% steps.
