### PR TITLE
some commands and workflow hacks

### DIFF
--- a/.claude/commands/founder_mode.md
+++ b/.claude/commands/founder_mode.md
@@ -1,0 +1,15 @@
+you're working on an experimental feature that didn't get the proper ticketing and pr stuff set up.
+
+assuming you just made a commit, here are the next steps:
+
+
+1. get the sha of the commit you just made (if you didn't make one, read `.claude/commands/commit.md` and make one)
+
+2. read `.claude/commands/linear.md` - create a linear ticket about what you just did, and put it in 'in dev' state - it should have ### headers for "problem to solve" and "proposed solution"
+3. fetch the ticket to get the recommended git branch name
+4. git checkout main
+5. git checkout -b 'BRANCHNAME'
+6. git cherry-pick 'COMMITHASH'
+7. git push -u origin 'BRANCHNAME'
+8. gh pr create --fill
+9. read '.claude/commands/pull_request.md' and follow the instructions

--- a/hack/dex/flow-tmux.sh
+++ b/hack/dex/flow-tmux.sh
@@ -1,0 +1,61 @@
+number=$1
+if [ -z "$number" ]; then
+  detected_number="$(tmux display-message -p '\#W' 2>/dev/null | cut -d'-' -f2 | grep -E '^[0-9]+$')"
+  if [ -n "$detected_number" ]; then
+    echo "Detected ticket number from tmux pane title: $detected_number"
+    read -p "Is this correct? (y/n) " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      number=$detected_number
+    else
+      echo "Usage: $0 <number>"
+      exit 1
+    fi
+  fi
+fi
+
+if [ -z "$number" ]; then
+  echo "Usage: $0 <number>"
+  exit 1
+fi
+
+if [ -z "$LINEAR_API_KEY" ]; then
+  echo "LINEAR_API_KEY is not set"
+  exit 1
+fi
+
+set -euo pipefail
+set -x
+
+skip_research=false
+skip_plan=false
+
+if [ "$2" = "plan" ]; then
+  skip_research=true
+elif [ "$2" = "ticket" ]; then
+  skip_research=true
+  skip_plan=true
+fi
+
+if [ "$skip_research" = "false" ]; then
+  # research
+  tmux rename-window "ENG-${number}-research"
+  # fetch the ticket for the number
+  linear get-issue ENG-$number > thoughts/shared/tickets/eng-$number.md
+  claude --allowedTools="Write,Edit,MultiEdit" "/research_codebase find all places in the code related to thoughts/shared/tickets/eng-${number}.md, ensure your final output filename includes 'eng-${number}'"
+  sleep 5
+  humanlayer thoughts sync || echo "thoughts sync failed"
+fi
+
+if [ "$skip_plan" = "false" ]; then
+  # plan
+  tmux rename-window "eng-${number}-plan"
+  claude --allowedTools="Write,Edit,MultiEdit" "/create_plan make the plan for thoughts/shared/tickets/eng-${number}.md - ensure eng-${number} is in the final plan file name"
+  sleep 5
+  humanlayer thoughts sync || echo "thoughts sync failed"
+fi
+
+# linear
+tmux rename-window "eng-${number}-linear"
+claude "/linear review all the files in thoughts/ (research, plans) related to eng-${number} and attach to the ticket links, then put the ticket in 'spec in review' state"
+sleep 5


### PR DESCRIPTION
## What problem(s) was I solving?

Developers sometimes hack out small experimental features without creating tickets first. When they reach a good place with the implementation, they need to retroactively create proper tickets and PRs to follow the standard workflow. This manual process was time-consuming and error-prone.

## What user-facing changes did I ship?

Added a new `/founder_mode` command that automates the process of retroactively creating Linear tickets and PRs for experimental work. Also added a personal workflow helper script for tmux-based development workflows.

## How I implemented it

- Created `.claude/commands/founder_mode.md` with step-by-step instructions for the retroactive ticket/PR creation workflow
- Added `hack/dex/flow-tmux.sh` - a personal workflow automation script for Linear ticket research and planning with tmux integration
- The founder_mode command guides through: getting commit SHA → creating Linear ticket → fetching branch name → creating branch → cherry-picking → pushing → creating PR

## How to verify it

- [ ] I have ensured `make check test` passes (Note: Integration test failure in hld/daemon unrelated to these changes)

## Description for the changelog

Add founder_mode command for retroactive ticket creation and PR setup