### PR TITLE
Fix scanner buffer overflow for large file content responses

### DIFF
--- a/hld/rpc/server.go
+++ b/hld/rpc/server.go
@@ -69,7 +69,7 @@ func (s *Server) SetSubscriptionHandlers(mgr *SubscriptionHandlers) {
 func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 	// Use a scanner to read line-delimited JSON
 	scanner := bufio.NewScanner(conn)
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024) // 1MB buffer
+	scanner.Buffer(make([]byte, 0), 10*1024*1024) // 10MB buffer to match claudecode-go
 
 	for scanner.Scan() {
 		select {


### PR DESCRIPTION

## What problem(s) was I solving?

## What user-facing changes did I ship?

## How I implemented it

## How to verify it

- [ ] I have ensured `make check test` passes

## Description for the changelog

## A picture of a cute animal (not mandatory but encouraged)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase buffer size to 10MB in `claudecode-go/client.go` and `server.go` to prevent buffer overflow for large JSON data.
> 
>   - **Buffer Configuration**:
>     - In `claudecode-go/client.go`, `parseStreamingJSON()` now configures `bufio.Scanner` to handle JSON lines up to 10MB, preventing buffer overflow for large file contents.
>     - In `server.go`, `ServeConn()` updates `bufio.Scanner` buffer to 10MB to match `claudecode-go`.
>   - **Error Handling**:
>     - In `claudecode-go/client.go`, `parseStreamingJSON()` checks for `bufio.ErrTooLong` and sets an error if JSON lines exceed 10MB.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for ce0f48f571172ddd82f63fc0a5c39d9380444d6d. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->