### PR TITLE
Fix scanner buffer overflow for large file content responses

### DIFF
--- a/hld/rpc/server.go
+++ b/hld/rpc/server.go
@@ -69,7 +69,7 @@ func (s *Server) SetSubscriptionHandlers(mgr *SubscriptionHandlers) {
 func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 	// Use a scanner to read line-delimited JSON
 	scanner := bufio.NewScanner(conn)
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024) // 1MB buffer
+	scanner.Buffer(make([]byte, 0), 10*1024*1024) // 10MB buffer to match claudecode-go
 
 	for scanner.Scan() {
 		select {


### PR DESCRIPTION
## What problem(s) was I solving?

## What user-facing changes did I ship?

## How I implemented it

## How to verify it

- [ ] I have ensured `make check test` passes

## Description for the changelog

## A picture of a cute animal (not mandatory but encouraged)
