### PR TITLE
[ENG-1597] Less weird colors and initial "thinking" messages

### DIFF
--- a/claudecode-go/types.go
+++ b/claudecode-go/types.go
@@ -107,6 +107,7 @@ type Message struct {
 type Content struct {
 	Type      string                 `json:"type"`
 	Text      string                 `json:"text,omitempty"`
+	Thinking  string                 `json:"thinking,omitempty"`
 	ID        string                 `json:"id,omitempty"`
 	Name      string                 `json:"name,omitempty"`
 	Input     map[string]interface{} `json:"input,omitempty"`

--- a/hld/store/store.go
+++ b/hld/store/store.go
@@ -197,6 +197,7 @@ const (
 	EventTypeToolCall   = "tool_call"
 	EventTypeToolResult = "tool_result"
 	EventTypeSystem     = "system"
+	EventTypeThinking   = "thinking"
 )
 
 // RecentPath represents a recently used working directory

--- a/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
@@ -9,6 +9,7 @@ import { ConversationEvent, ConversationEventType, ApprovalStatus } from '@/lib/
 import { Button } from '@/components/ui/button'
 import {
   Bot,
+  Brain,
   FilePenLine,
   UserCheck,
   User,
@@ -64,6 +65,11 @@ export function eventToDisplayObject(
   let body = null
   let iconComponent = null
   let toolResultContent = null
+  
+  // console.log('event', event)
+  // Check if this is a thinking message
+  const isThinking = event.event_type === ConversationEventType.Thinking ||
+    (event.role === 'assistant' && event.content?.startsWith('<thinking>'))
 
   const iconClasses = `w-4 h-4 align-middle relative top-[1px] ${event.event_type === ConversationEventType.ToolCall && !event.is_completed ? 'pulse-warning' : ''}`
 
@@ -445,6 +451,21 @@ export function eventToDisplayObject(
     }
   }
 
+  if (event.event_type === ConversationEventType.Thinking) {
+    // Thinking messages are always from assistant
+    const fullContent = event.content || ''
+    const contentTree = starryNight?.highlight(fullContent, 'text.md')
+    
+    subject = contentTree ? (
+      <span className="text-muted-foreground italic">
+        {toJsxRuntime(contentTree, { Fragment, jsx, jsxs })}
+      </span>
+    ) : (
+      <span className="text-muted-foreground italic">{fullContent}</span>
+    )
+    body = null // Everything is in subject for thinking messages
+  }
+
   if (event.event_type === ConversationEventType.Message) {
     // For assistant messages, show full content without truncation
     if (event.role === 'assistant') {
@@ -452,9 +473,11 @@ export function eventToDisplayObject(
       const contentTree = starryNight?.highlight(fullContent, 'text.md')
 
       subject = contentTree ? (
-        <span>{toJsxRuntime(contentTree, { Fragment, jsx, jsxs })}</span>
+        <span className={isThinking ? 'text-muted-foreground' : ''}>
+          {toJsxRuntime(contentTree, { Fragment, jsx, jsxs })}
+        </span>
       ) : (
-        <span>{fullContent}</span>
+        <span className={isThinking ? 'text-muted-foreground' : ''}>{fullContent}</span>
       )
       body = null // Everything is in subject for assistant messages
     } else {
@@ -478,7 +501,9 @@ export function eventToDisplayObject(
     }
   }
 
-  if (event.role === 'assistant') {
+  if (event.event_type === ConversationEventType.Thinking) {
+    iconComponent = <Brain className={iconClasses} />
+  } else if (event.role === 'assistant') {
     iconComponent = <Bot className={iconClasses} />
   }
 
@@ -549,6 +574,7 @@ export function eventToDisplayObject(
     body,
     created_at: event.created_at,
     toolResultContent,
+    isThinking,
   }
 }
 

--- a/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
@@ -65,10 +65,11 @@ export function eventToDisplayObject(
   let body = null
   let iconComponent = null
   let toolResultContent = null
-  
+
   // console.log('event', event)
   // Check if this is a thinking message
-  const isThinking = event.event_type === ConversationEventType.Thinking ||
+  const isThinking =
+    event.event_type === ConversationEventType.Thinking ||
     (event.role === 'assistant' && event.content?.startsWith('<thinking>'))
 
   const iconClasses = `w-4 h-4 align-middle relative top-[1px] ${event.event_type === ConversationEventType.ToolCall && !event.is_completed ? 'pulse-warning' : ''}`
@@ -455,7 +456,7 @@ export function eventToDisplayObject(
     // Thinking messages are always from assistant
     const fullContent = event.content || ''
     const contentTree = starryNight?.highlight(fullContent, 'text.md')
-    
+
     subject = contentTree ? (
       <span className="text-muted-foreground italic">
         {toJsxRuntime(contentTree, { Fragment, jsx, jsxs })}

--- a/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
@@ -255,7 +255,9 @@ export function ConversationContent({
                 {/* Icon */}
                 <div className="flex items-baseline gap-2">
                   {displayObject.iconComponent && (
-                    <span className={`text-sm ${displayObject.isThinking ? 'text-muted-foreground' : 'text-accent'} align-middle relative top-[1px]`}>
+                    <span
+                      className={`text-sm ${displayObject.isThinking ? 'text-muted-foreground' : 'text-accent'} align-middle relative top-[1px]`}
+                    >
                       {displayObject.iconComponent}
                     </span>
                   )}
@@ -380,7 +382,9 @@ export function ConversationContent({
 
                     <div className="flex items-baseline gap-2">
                       {displayObject.iconComponent && (
-                        <span className={`text-sm ${displayObject.isThinking ? 'text-muted-foreground' : 'text-accent'} align-middle relative top-[1px]`}>
+                        <span
+                          className={`text-sm ${displayObject.isThinking ? 'text-muted-foreground' : 'text-accent'} align-middle relative top-[1px]`}
+                        >
                           {displayObject.iconComponent}
                         </span>
                       )}

--- a/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
@@ -255,11 +255,11 @@ export function ConversationContent({
                 {/* Icon */}
                 <div className="flex items-baseline gap-2">
                   {displayObject.iconComponent && (
-                    <span className="text-sm text-accent align-middle relative top-[1px]">
+                    <span className={`text-sm ${displayObject.isThinking ? 'text-muted-foreground' : 'text-accent'} align-middle relative top-[1px]`}>
                       {displayObject.iconComponent}
                     </span>
                   )}
-                  <span className="whitespace-pre-wrap text-accent max-w-[90%]">
+                  <span className="whitespace-pre-wrap text-foreground max-w-[80%]">
                     {displayObject.subject}
                   </span>
                 </div>
@@ -380,11 +380,11 @@ export function ConversationContent({
 
                     <div className="flex items-baseline gap-2">
                       {displayObject.iconComponent && (
-                        <span className="text-sm text-accent align-middle relative top-[1px]">
+                        <span className={`text-sm ${displayObject.isThinking ? 'text-muted-foreground' : 'text-accent'} align-middle relative top-[1px]`}>
                           {displayObject.iconComponent}
                         </span>
                       )}
-                      <span className="whitespace-pre-wrap text-accent max-w-[90%]">
+                      <span className="whitespace-pre-wrap text-foreground max-w-[90%]">
                         {displayObject.subject}
                       </span>
                     </div>

--- a/humanlayer-wui/src/lib/daemon/types.ts
+++ b/humanlayer-wui/src/lib/daemon/types.ts
@@ -25,6 +25,7 @@ export enum ConversationEventType {
   ToolCall = 'tool_call',
   ToolResult = 'tool_result',
   System = 'system',
+  Thinking = 'thinking',
 }
 
 export enum ConversationRole {


### PR DESCRIPTION
## What problem(s) was I solving?

1. **Color inconsistency in the WUI**: The UI was using accent colors (`text-accent`) for all message text, making it visually noisy and harder to scan conversations. Claude Code uses a more restrained approach with regular text in foreground color.

2. **Missing thinking messages**: When Claude enters "thinking mode" (triggered by prompts containing "THINK"), these thinking messages were being dropped during event processing and never shown in the UI. The daemon was only processing "text", "tool_use", and "tool_result" content types.

## What user-facing changes did I ship?

1. **Improved text colors**: Regular message text now uses foreground color instead of accent color, making conversations more readable and less visually overwhelming.

2. **Thinking messages are now visible**: Users can see Claude's thinking process when using prompts that trigger thinking mode. These messages appear with:
   - A Brain icon (🧠) instead of the regular Bot icon
   - Muted/grey text color
   - Italic styling for visual distinction

## How I implemented it

### Backend changes:
- Added new `EventTypeThinking = "thinking"` constant to the event type definitions
- Added handler for "thinking" content type in `processStreamEvent` to capture these messages
- Updated `claudecode-go` Content struct to include the `Thinking` field
- Thinking messages are stored as a separate event type in `conversation_events`

### Frontend changes:
- Added `Thinking = 'thinking'` to the TypeScript ConversationEventType enum
- Updated `eventToDisplayObject` to handle thinking events with appropriate styling
- Applied muted foreground color and italic text to thinking messages
- Used Brain icon from lucide-react for visual distinction

The implementation preserves the full thinking content while ignoring the cryptographic signature field that comes with thinking messages.

## How to verify it

- [x] I have ensured `make check test` passes (Note: Prettier formatted files after commit, tests pass but format check needs update)

**Manual testing steps:**
1. Rebuild the daemon: `cd hld && go build ./cmd/hld`
2. Restart the daemon to pick up changes
3. Launch a Claude session with thinking: `claude -p "THINK about why the sky is blue"`
4. Open the WUI and observe:
   - Thinking messages appear with Brain icon
   - Text is grey/muted and italic
   - Regular messages use foreground color (not accent)
5. Test color improvements across different themes (Ctrl+T to switch themes)

## Description for the changelog

- Improve WUI color scheme: use foreground colors for message text instead of accent colors for better readability
- Add support for displaying Claude's thinking messages with distinct visual styling (Brain icon, muted italic text)