### PR TITLE
Allow zoom in tauri webviews

### DIFF
--- a/humanlayer-wui/src-tauri/capabilities/default.json
+++ b/humanlayer-wui/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "opener:default",
     "notification:default",
+    "core:webview:allow-set-webview-zoom",
     "fs:default",
     {
       "identifier": "fs:scope",

--- a/humanlayer-wui/src-tauri/tauri.conf.json
+++ b/humanlayer-wui/src-tauri/tauri.conf.json
@@ -14,7 +14,8 @@
       {
         "title": "humanlayer-wui",
         "width": 800,
-        "height": 600
+        "height": 600,
+        "zoomHotkeysEnabled": true
       }
     ],
     "security": {


### PR DESCRIPTION
## What problem(s) was I solving?

Users couldn't zoom in or out in the HumanLayer Web UI (WUI) using standard browser zoom keyboard shortcuts (Cmd/Ctrl + Plus/Minus). This made it difficult for users to adjust the interface size according to their preferences or accessibility needs, especially when dealing with dense information in the approval management interface.

## What user-facing changes did I ship?

- Enabled standard zoom keyboard shortcuts in the WUI:
  - `Cmd/Ctrl + Plus` to zoom in
  - `Cmd/Ctrl + Minus` to zoom out
  - `Cmd/Ctrl + 0` to reset zoom to 100%
- Users can now adjust the interface scale to their preference, improving accessibility and usability

## How I implemented it

The implementation involved two simple configuration changes to the Tauri application:

1. Added the `core:webview:allow-set-webview-zoom` permission to the default capabilities file (`humanlayer-wui/src-tauri/capabilities/default.json`). This permission allows the webview to programmatically set zoom levels.

2. Enabled the `zoomHotkeysEnabled` flag in the window configuration (`humanlayer-wui/src-tauri/tauri.conf.json`). This flag tells Tauri to handle the standard zoom keyboard shortcuts automatically.

These minimal changes leverage Tauri's built-in zoom functionality without requiring any custom JavaScript or event handling code.

## How to verify it

- [x] I have ensured `make check test` passes

Manual verification steps:
1. Build and run the WUI application
2. Test zoom shortcuts:
   - Press `Cmd+Plus` (Mac) or `Ctrl+Plus` (Windows/Linux) to zoom in
   - Press `Cmd+Minus` (Mac) or `Ctrl+Minus` (Windows/Linux) to zoom out
   - Press `Cmd+0` (Mac) or `Ctrl+0` (Windows/Linux) to reset zoom to 100%
3. Verify the zoom level persists within the session
4. Verify all UI elements scale appropriately without breaking layout

## Description for the changelog

Added browser-like zoom functionality to the HumanLayer Web UI, allowing users to zoom in/out using standard keyboard shortcuts (Cmd/Ctrl +/-/0)