### PR TITLE
Add 'e' keyboard shortcut to archive sessions from detail

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -328,6 +328,9 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
   useHotkeys(
     'e',
     async () => {
+      // TODO(3): The timeout clearing logic (using confirmingArchiveTimeoutRef) is duplicated in multiple places.
+      // Consider refactoring this into a helper function to reduce repetition.
+
       // Clear any existing timeout
       if (confirmingArchiveTimeoutRef.current) {
         clearTimeout(confirmingArchiveTimeoutRef.current)

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -363,16 +363,16 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
       // Either second press for active session or immediate archive for completed/failed
       try {
         await useStore.getState().archiveSession(session.id, isArchiving)
-        
+
         // Clear confirmation state
         setConfirmingArchive(false)
-        
+
         // Show success notification matching list view behavior
         toast.success(isArchiving ? 'Session archived' : 'Session unarchived', {
           description: session.summary || 'Untitled session',
           duration: 3000,
         })
-        
+
         // Navigate back to session list
         onClose()
       } catch (error) {
@@ -386,7 +386,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
       scopes: [SessionDetailHotkeysScope],
       preventDefault: true,
     },
-    [session.id, session.archived, session.summary, session.status, onClose, confirmingArchive]
+    [session.id, session.archived, session.summary, session.status, onClose, confirmingArchive],
   )
 
   // Add hotkey to open fork view (Meta+Y)

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
+import { toast } from 'sonner'
 
 import { ConversationEvent, SessionInfo, ApprovalStatus, SessionStatus } from '@/lib/daemon/types'
 import { Card, CardContent } from '@/components/ui/card'
@@ -89,9 +90,11 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
   const [forkViewOpen, setForkViewOpen] = useState(false)
   const [previewEventIndex, setPreviewEventIndex] = useState<number | null>(null)
   const [pendingForkMessage, setPendingForkMessage] = useState<ConversationEvent | null>(null)
+  const [confirmingArchive, setConfirmingArchive] = useState(false)
 
   const isActivelyProcessing = ['starting', 'running', 'completing'].includes(session.status)
   const responseInputRef = useRef<HTMLTextAreaElement>(null)
+  const confirmingArchiveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Get session from store to access auto_accept_edits
   const sessionFromStore = useStore(state => state.sessions.find(s => s.id === session.id))
@@ -239,6 +242,16 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
     }
   }, [session.id]) // Re-run when session changes
 
+  // Cleanup confirmation timeout on unmount or session change
+  useEffect(() => {
+    return () => {
+      if (confirmingArchiveTimeoutRef.current) {
+        clearTimeout(confirmingArchiveTimeoutRef.current)
+        confirmingArchiveTimeoutRef.current = null
+      }
+    }
+  }, [session.id])
+
   // Check if there are pending approvals out of view
   const [hasPendingApprovalsOutOfView, setHasPendingApprovalsOutOfView] = useState(false)
 
@@ -268,7 +281,14 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
         return
       }
 
-      if (approvals.confirmingApprovalId) {
+      if (confirmingArchive) {
+        setConfirmingArchive(false)
+        // Clear timeout if exists
+        if (confirmingArchiveTimeoutRef.current) {
+          clearTimeout(confirmingArchiveTimeoutRef.current)
+          confirmingArchiveTimeoutRef.current = null
+        }
+      } else if (approvals.confirmingApprovalId) {
         approvals.setConfirmingApprovalId(null)
       } else if (navigation.focusedEventId) {
         navigation.setFocusedEventId(null)
@@ -302,6 +322,71 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
       preventDefault: true,
     },
     [session.id, autoAcceptEdits], // Dependencies
+  )
+
+  // Add hotkey to archive session ('e' key)
+  useHotkeys(
+    'e',
+    async () => {
+      // Clear any existing timeout
+      if (confirmingArchiveTimeoutRef.current) {
+        clearTimeout(confirmingArchiveTimeoutRef.current)
+        confirmingArchiveTimeoutRef.current = null
+      }
+
+      // Check if session is active (requires confirmation)
+      const isActiveSession = [
+        SessionStatus.Starting,
+        SessionStatus.Running,
+        SessionStatus.Completing,
+        SessionStatus.WaitingInput,
+      ].includes(session.status)
+
+      const isArchiving = !session.archived
+
+      if (isActiveSession && !confirmingArchive) {
+        // First press - show warning
+        setConfirmingArchive(true)
+        toast.warning('Press e again to archive active session', {
+          description: 'This session is still active. Press e again within 3 seconds to confirm.',
+          duration: 3000,
+        })
+
+        // Set timeout to reset confirmation state
+        confirmingArchiveTimeoutRef.current = setTimeout(() => {
+          setConfirmingArchive(false)
+          confirmingArchiveTimeoutRef.current = null
+        }, 3000)
+        return
+      }
+
+      // Either second press for active session or immediate archive for completed/failed
+      try {
+        await useStore.getState().archiveSession(session.id, isArchiving)
+        
+        // Clear confirmation state
+        setConfirmingArchive(false)
+        
+        // Show success notification matching list view behavior
+        toast.success(isArchiving ? 'Session archived' : 'Session unarchived', {
+          description: session.summary || 'Untitled session',
+          duration: 3000,
+        })
+        
+        // Navigate back to session list
+        onClose()
+      } catch (error) {
+        toast.error('Failed to archive session', {
+          description: error instanceof Error ? error.message : 'Unknown error',
+        })
+        setConfirmingArchive(false)
+      }
+    },
+    {
+      scopes: [SessionDetailHotkeysScope],
+      preventDefault: true,
+    },
+    [session.id, session.archived, session.summary, session.status, onClose, confirmingArchive]
   )
 
   // Add hotkey to open fork view (Meta+Y)

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -350,6 +350,10 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
       if (isActiveSession && !confirmingArchive) {
         // First press - show warning
         setConfirmingArchive(true)
+        // TODO(3): Consider using a Dialog instead of toast for archive confirmation.
+        // This would improve accessibility (mouse users can click buttons) and avoid
+        // complexity around timeout management. The current toast approach works but
+        // isn't ideal for all users.
         toast.warning('Press e again to archive active session', {
           description: 'This session is still active. Press e again within 3 seconds to confirm.',
           duration: 3000,


### PR DESCRIPTION
## What problem(s) was I solving?

Users couldn't quickly archive sessions from the detail view using keyboard shortcuts. They had to navigate back to the session list to use the 'e' shortcut, which interrupted their workflow. This was especially inconvenient when reviewing multiple sessions in detail.

## What user-facing changes did I ship?

- Added 'e' keyboard shortcut to archive/unarchive sessions directly from the detail view
- Implemented a safety confirmation for active sessions:
  - Active sessions (Starting, Running, Completing, WaitingInput) require pressing 'e' twice within 3 seconds
  - Shows warning toast: "Press e again to archive active session" with explanation
  - Completed/Failed sessions archive immediately without confirmation
- Toast notifications show archive status ("Session archived" or "Session unarchived") with session summary
- After archiving, automatically navigates back to the session list
- Escape key cancels the confirmation state for active sessions

## How I implemented it

1. **Added confirmation state management**: Created `confirmingArchive` state and timeout ref to track double-press requirement for active sessions
2. **Enhanced the 'e' hotkey handler**: 
   - Checks session status to determine if confirmation is needed
   - Shows warning toast for active sessions on first press
   - Archives immediately for completed/failed sessions
   - Clears confirmation state after 3 seconds automatically
3. **Integrated with escape key handler**: Added logic to cancel archive confirmation when escape is pressed
4. **Added cleanup effect**: Ensures timeout is cleared when component unmounts or session changes
5. **Reused existing infrastructure**: Leveraged the `archiveSession` store method and toast library already in use

## How to verify it

- [x] I have ensured `make check test` passes

Manual testing steps:
1. **Test immediate archive (completed/failed sessions)**:
   - Navigate to a completed or failed session
   - Press 'e' once
   - Verify session archives immediately with success toast
   - Verify navigation back to session list

2. **Test confirmation flow (active sessions)**:
   - Navigate to a running/active session
   - Press 'e' once - verify warning toast appears
   - Press 'e' again within 3 seconds - verify archive succeeds
   - Test timeout: Press 'e' once, wait >3 seconds, press 'e' again - should show warning again

3. **Test escape cancellation**:
   - Navigate to active session
   - Press 'e' once to trigger confirmation
   - Press Escape - verify confirmation is cancelled
   - Press 'e' again - should show warning (not archive)

4. **Test archive status toggle**:
   - Archive a session, then navigate to it in archived view
   - Press 'e' to unarchive
   - Verify "Session unarchived" toast appears

## Description for the changelog

Added keyboard shortcut 'e' to archive/unarchive sessions from the detail view, with double-press confirmation for active sessions to prevent accidental archiving