### PR TITLE
Fix daemon integration test timing issues

### DIFF
--- a/humanlayer-ts/src/approval_resolve_backend.test.ts
+++ b/humanlayer-ts/src/approval_resolve_backend.test.ts
@@ -1,5 +1,5 @@
 import { ApprovalMethod, humanlayer, HumanLayer } from './approval'
-import { with_env_var } from '../src/testing/index'
+import { with_env_var, without_env_var } from '../src/testing/index'
 import { CloudHumanLayerBackend } from './cloud'
 
 test('no args', () => {
@@ -21,13 +21,15 @@ test('HumanLayer.cloud()', () => {
 })
 
 test('HumanLayer.cloud() with apiKey', () => {
-  const hl = HumanLayer.cloud({ apiKey: 'abc' })
-  expect(hl.approvalMethod).toBe(ApprovalMethod.backend)
-  expect(hl.backend).toBeDefined()
-  expect(hl.backend).toBeInstanceOf(CloudHumanLayerBackend)
-  const cloudBackend = <CloudHumanLayerBackend>hl.backend
-  expect(cloudBackend.connection.apiKey).toBe('abc')
-  expect(cloudBackend.connection.apiBaseURL).toBe('https://api.humanlayer.dev/humanlayer/v1')
+  without_env_var('HUMANLAYER_API_BASE', () => {
+    const hl = HumanLayer.cloud({ apiKey: 'abc' })
+    expect(hl.approvalMethod).toBe(ApprovalMethod.backend)
+    expect(hl.backend).toBeDefined()
+    expect(hl.backend).toBeInstanceOf(CloudHumanLayerBackend)
+    const cloudBackend = <CloudHumanLayerBackend>hl.backend
+    expect(cloudBackend.connection.apiKey).toBe('abc')
+    expect(cloudBackend.connection.apiBaseURL).toBe('https://api.humanlayer.dev/humanlayer/v1')
+  })
 })
 
 test('Humanlayer with api key and endpoint', () => {
@@ -41,13 +43,15 @@ test('Humanlayer with api key and endpoint', () => {
 })
 
 test('HumanLayer() with env var', () => {
-  with_env_var('HUMANLAYER_API_KEY', 'abc', () => {
-    const hl = new HumanLayer()
-    expect(hl.approvalMethod).toBe(ApprovalMethod.backend)
-    expect(hl.backend).toBeDefined()
-    expect(hl.backend).toBeInstanceOf(CloudHumanLayerBackend)
-    const cloudBackend = <CloudHumanLayerBackend>hl.backend
-    expect(cloudBackend.connection.apiKey).toBe('abc')
-    expect(cloudBackend.connection.apiBaseURL).toBe('https://api.humanlayer.dev/humanlayer/v1')
+  without_env_var('HUMANLAYER_API_BASE', () => {
+    with_env_var('HUMANLAYER_API_KEY', 'abc', () => {
+      const hl = new HumanLayer()
+      expect(hl.approvalMethod).toBe(ApprovalMethod.backend)
+      expect(hl.backend).toBeDefined()
+      expect(hl.backend).toBeInstanceOf(CloudHumanLayerBackend)
+      const cloudBackend = <CloudHumanLayerBackend>hl.backend
+      expect(cloudBackend.connection.apiKey).toBe('abc')
+      expect(cloudBackend.connection.apiBaseURL).toBe('https://api.humanlayer.dev/humanlayer/v1')
+    })
   })
 })

--- a/humanlayer-ts/src/testing/index.ts
+++ b/humanlayer-ts/src/testing/index.ts
@@ -11,3 +11,15 @@ export function with_env_var(key: string, value: string, callback: () => any) {
     }
   }
 }
+
+export function without_env_var(key: string, callback: () => any) {
+  const prevValue = process.env[key]
+  delete process.env[key]
+  try {
+    callback()
+  } finally {
+    if (typeof prevValue !== 'undefined') {
+      process.env[key] = prevValue
+    }
+  }
+}

--- a/humanlayer/core/approval_resolve_backend_test.py
+++ b/humanlayer/core/approval_resolve_backend_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from humanlayer import ApprovalMethod, CloudHumanLayerBackend, HumanLayer
-from humanlayer.testing import env_var
+from humanlayer.testing import env_var, unset_env_var
 
 
 def test_no_args() -> None:
@@ -23,12 +23,13 @@ def test_cloud() -> None:
 
 
 def test_cloud_endpoint_kwarg_default() -> None:
-    hl = HumanLayer(api_key="foo")
-    assert hl.approval_method == ApprovalMethod.BACKEND
-    assert hl.backend is not None
-    assert isinstance(hl.backend, CloudHumanLayerBackend)
-    assert hl.backend.connection.api_key == "foo"
-    assert hl.backend.connection.api_base_url == "https://api.humanlayer.dev/humanlayer/v1"
+    with unset_env_var("HUMANLAYER_API_BASE"):
+        hl = HumanLayer(api_key="foo")
+        assert hl.approval_method == ApprovalMethod.BACKEND
+        assert hl.backend is not None
+        assert isinstance(hl.backend, CloudHumanLayerBackend)
+        assert hl.backend.connection.api_key == "foo"
+        assert hl.backend.connection.api_base_url == "https://api.humanlayer.dev/humanlayer/v1"
 
 
 def test_cloud_endpoint_kwarg() -> None:
@@ -40,7 +41,7 @@ def test_cloud_endpoint_kwarg() -> None:
 
 
 def test_env_var_cloud() -> None:
-    with env_var("HUMANLAYER_API_KEY", "foo"):
+    with env_var("HUMANLAYER_API_KEY", "foo"), unset_env_var("HUMANLAYER_API_BASE"):
         hl = HumanLayer()
         assert hl.approval_method == ApprovalMethod.BACKEND
         assert hl.backend is not None

--- a/humanlayer/core/async_resolve_backend_test.py
+++ b/humanlayer/core/async_resolve_backend_test.py
@@ -3,7 +3,7 @@ import pytest
 from humanlayer.core.async_approval import AsyncHumanLayer
 from humanlayer.core.async_cloud import AsyncCloudHumanLayerBackend
 from humanlayer.core.protocol import HumanLayerException
-from humanlayer.testing import env_var
+from humanlayer.testing import env_var, unset_env_var
 
 
 def test_no_args() -> None:
@@ -18,11 +18,12 @@ def test_no_args() -> None:
 
 def test_cloud_endpoint_kwarg_default() -> None:
     """Test cloud mode with default endpoint"""
-    hl = AsyncHumanLayer(api_key="foo")
-    assert hl.backend is not None
-    assert isinstance(hl.backend, AsyncCloudHumanLayerBackend)
-    assert hl.backend.connection.api_key == "foo"
-    assert hl.backend.connection.api_base_url == "https://api.humanlayer.dev/humanlayer/v1"
+    with unset_env_var("HUMANLAYER_API_BASE"):
+        hl = AsyncHumanLayer(api_key="foo")
+        assert hl.backend is not None
+        assert isinstance(hl.backend, AsyncCloudHumanLayerBackend)
+        assert hl.backend.connection.api_key == "foo"
+        assert hl.backend.connection.api_base_url == "https://api.humanlayer.dev/humanlayer/v1"
 
 
 def test_cloud_endpoint_kwarg() -> None:
@@ -35,7 +36,7 @@ def test_cloud_endpoint_kwarg() -> None:
 
 def test_env_var_cloud() -> None:
     """Test cloud mode from environment variable"""
-    with env_var("HUMANLAYER_API_KEY", "foo"):
+    with env_var("HUMANLAYER_API_KEY", "foo"), unset_env_var("HUMANLAYER_API_BASE"):
         hl = AsyncHumanLayer()
         assert hl.backend is not None
         assert isinstance(hl.backend, AsyncCloudHumanLayerBackend)

--- a/humanlayer/testing/__init__.py
+++ b/humanlayer/testing/__init__.py
@@ -14,3 +14,15 @@ def env_var(var_name: str, var_value: str) -> Generator[None, None, None]:
             os.environ[var_name] = prev_value
         else:
             del os.environ[var_name]
+
+
+@contextlib.contextmanager
+def unset_env_var(var_name: str) -> Generator[None, None, None]:
+    prev_value = os.environ.get(var_name)
+    if var_name in os.environ:
+        del os.environ[var_name]
+    try:
+        yield
+    finally:
+        if prev_value is not None:
+            os.environ[var_name] = prev_value


### PR DESCRIPTION
## What problem(s) was I solving?

The HLD daemon integration tests were consistently failing on my system (as reported in ENG-1625). The root cause was that the `TestDaemonBinaryIntegration` test was only waiting 200ms for the daemon to start up and create its socket file, but the daemon initialization process (including SQLite database setup) was taking longer than that, especially on slower systems or under test load.

Additionally, when running the tests in environments with the `HUMANLAYER_API_BASE` environment variable set (e.g., for local development), the Python and TypeScript SDK tests were failing because they expected the default API base URL but were picking up the environment variable instead.

## What user-facing changes did I ship?

None. This PR only fixes test reliability issues and doesn't change any user-facing functionality.

## How I implemented it

1. **HLD Daemon Test Fixes:**
   - Increased daemon startup wait time from 200ms to 1 second in all three test cases (`daemon_starts`, `refuses_double_start`, `graceful_shutdown`)
   - Added stderr capture to the failing test to help debug future issues
   - Increased the context timeout from 2 seconds to 5 seconds for better reliability under load

2. **SDK Test Environment Isolation:**
   - Added `unset_env_var` helper functions to both Python and TypeScript test utilities
   - Updated tests that verify default API base URL behavior to explicitly unset the `HUMANLAYER_API_BASE` environment variable
   - This ensures tests pass regardless of the developer's local environment configuration

## How to verify it

- [x] I have ensured `make check test` passes

All tests now pass consistently, including:
- 220 HLD tests (182 unit + 38 integration)
- All Python SDK tests
- All TypeScript SDK tests

## Description for the changelog

Fix flaky HLD daemon integration tests and SDK test environment isolation