### PR TITLE
Update SessionDetail focus and keyboard shortcuts

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -236,13 +236,8 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
     return () => window.removeEventListener('resize', checkScreenSize)
   }, [])
 
-  // Auto-focus text input and scroll to bottom when session opens
+  // Scroll to bottom when session opens
   useEffect(() => {
-    // Focus the text input
-    if (responseInputRef.current && session.status !== SessionStatus.Failed) {
-      responseInputRef.current.focus()
-    }
-
     // Scroll to bottom of conversation
     const container = document.querySelector('[data-conversation-container]')
     if (container) {
@@ -456,6 +451,21 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
       preventDefault: true,
     },
     [events, navigation.setFocusedEventId, navigation.setFocusSource],
+  )
+
+  // Add Enter key to focus text input
+  useHotkeys(
+    'enter',
+    () => {
+      if (responseInputRef.current && session.status !== SessionStatus.Failed) {
+        responseInputRef.current.focus()
+      }
+    },
+    {
+      scopes: SessionDetailHotkeysScope,
+      enableOnFormTags: false,
+      preventDefault: true,
+    },
   )
 
   useStealHotkeyScope(SessionDetailHotkeysScope)

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -157,6 +157,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
     setExpandedToolResult,
     setExpandedToolCall,
     disabled: forkViewOpen, // Disable navigation when fork view is open
+    startKeyboardNavigation,
   })
 
   // Use approvals hook
@@ -622,6 +623,8 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
               setExpandedToolCall={setExpandedToolCall}
               maxEventIndex={previewEventIndex ?? undefined}
               shouldIgnoreMouseEvent={shouldIgnoreMouseEvent}
+              expandedTasks={expandedTasks}
+              toggleTaskGroup={toggleTaskGroup}
             />
             {isActivelyProcessing &&
               (() => {

--- a/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
@@ -548,7 +548,7 @@ export function eventToDisplayObject(
                 <span>
                   {resultDisplay}
                   {isFocused && (
-                    <span className="text-xs text-muted-foreground/50 ml-2">[i] expand</span>
+                    <span className="text-xs text-muted-foreground/50 ml-2"><kbd className="px-1 py-0.5 text-xs bg-muted/50 rounded">i</kbd> expand</span>
                   )}
                 </span>
               </div>
@@ -561,7 +561,7 @@ export function eventToDisplayObject(
       subject = (
         <>
           {subject}
-          <span className="text-xs text-muted-foreground/50 ml-2">[i] expand</span>
+          <span className="text-xs text-muted-foreground/50 ml-2"><kbd className="px-1 py-0.5 text-xs bg-muted/50 rounded">i</kbd> expand</span>
         </>
       )
     }

--- a/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
@@ -548,7 +548,9 @@ export function eventToDisplayObject(
                 <span>
                   {resultDisplay}
                   {isFocused && (
-                    <span className="text-xs text-muted-foreground/50 ml-2"><kbd className="px-1 py-0.5 text-xs bg-muted/50 rounded">i</kbd> expand</span>
+                    <span className="text-xs text-muted-foreground/50 ml-2">
+                      <kbd className="px-1 py-0.5 text-xs bg-muted/50 rounded">i</kbd> expand
+                    </span>
                   )}
                 </span>
               </div>
@@ -561,7 +563,9 @@ export function eventToDisplayObject(
       subject = (
         <>
           {subject}
-          <span className="text-xs text-muted-foreground/50 ml-2"><kbd className="px-1 py-0.5 text-xs bg-muted/50 rounded">i</kbd> expand</span>
+          <span className="text-xs text-muted-foreground/50 ml-2">
+            <kbd className="px-1 py-0.5 text-xs bg-muted/50 rounded">i</kbd> expand
+          </span>
         </>
       )
     }

--- a/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
@@ -40,6 +40,8 @@ export function ConversationContent({
   setExpandedToolCall,
   maxEventIndex,
   shouldIgnoreMouseEvent,
+  expandedTasks,
+  toggleTaskGroup,
 }: {
   sessionId: string
   focusedEventId: number | null
@@ -61,6 +63,8 @@ export function ConversationContent({
   setExpandedToolCall?: (event: ConversationEvent | null) => void
   maxEventIndex?: number
   shouldIgnoreMouseEvent?: () => boolean
+  expandedTasks?: Set<string>
+  toggleTaskGroup?: (taskId: string) => void
 }) {
   // expandedToolResult is used by parent to control hotkey availability
   void expandedToolResult
@@ -75,9 +79,11 @@ export function ConversationContent({
   )
   const toolResultsByKey = keyBy(toolResults, 'tool_result_for_id')
 
-  // Use task grouping hook
-  const { taskGroups, rootEvents, hasSubTasks, expandedTasks, toggleTaskGroup } =
-    useTaskGrouping(filteredEvents)
+  // Use task grouping hook - use props if provided, otherwise use local hook
+  const localTaskGrouping = useTaskGrouping(filteredEvents)
+  const { taskGroups, rootEvents, hasSubTasks } = localTaskGrouping
+  const actualExpandedTasks = expandedTasks ?? localTaskGrouping.expandedTasks
+  const actualToggleTaskGroup = toggleTaskGroup ?? localTaskGrouping.toggleTaskGroup
 
   // Watch for new Read tool results and refetch snapshots
   useEffect(() => {
@@ -334,8 +340,8 @@ export function ConversationContent({
                 <TaskGroup
                   key={event.id}
                   group={taskGroup}
-                  isExpanded={expandedTasks.has(event.tool_id!)}
-                  onToggle={() => toggleTaskGroup(event.tool_id!)}
+                  isExpanded={actualExpandedTasks.has(event.tool_id!)}
+                  onToggle={() => actualToggleTaskGroup(event.tool_id!)}
                   focusedEventId={focusedEventId}
                   setFocusedEventId={setFocusedEventId}
                   onApprove={onApprove}


### PR DESCRIPTION
## What problem(s) was I solving?

The SessionDetail keyboard navigation had several issues that disrupted the user workflow:
- Auto-focus on text input when entering SessionDetail interrupted keyboard navigation flow
- No keyboard shortcut to focus the text input when needed
- The 'i' key behavior was inconsistent - it only worked for tool inspection, not task expansion
- Duplicate state management for task grouping caused the 'i' key to fail on TaskGroups
- Mouse events would fire shortly after keyboard navigation, causing focus issues

## What user-facing changes did I ship?

- **Removed auto-focus behavior**: Text input no longer steals focus when entering SessionDetail
- **Added Enter key handler**: Press Enter to focus the text input when needed
- **Unified 'i' key behavior**: The 'i' key now works context-aware for both:
  - Expanding/collapsing TaskGroups when focused on a Task tool call
  - Inspecting tool results when focused on other tool calls
- **Fixed keyboard navigation**: j/k navigation now works reliably with TaskGroups
- **Improved visual hints**: Keyboard shortcuts now use styled `<kbd>` elements for better visibility

## How I implemented it

1. **Removed auto-focus logic** from SessionDetail.tsx mount effect
2. **Added Enter hotkey handler** with preventDefault to avoid inserting newlines
3. **Consolidated 'i' key handler** in useSessionNavigation to be context-aware:
   - Checks if focused event is a Task with sub-events → toggles expansion
   - Otherwise opens tool result inspection modal
4. **Fixed state synchronization** by passing expandedTasks and toggleTaskGroup from SessionDetail to ConversationContent as props
5. **Added keyboard navigation protection** by calling startKeyboardNavigation in j/k/i handlers
6. **Updated visual styling** for keyboard hints using `<kbd>` elements

## How to verify it

- [x] I have ensured `make check test` passes

### Manual verification:
1. Open a SessionDetail with TaskGroups
2. Press 'k' to start navigation from bottom
3. Navigate to a TaskGroup and press 'i' - it should expand/collapse
4. Navigate to other tool calls and press 'i' - it should open inspection modal
5. Press Enter at any time - focus should move to text input without inserting newlines
6. Verify mouse events don't interfere with keyboard navigation

## Description for the changelog

Fixed keyboard navigation in SessionDetail: removed auto-focus, added Enter to focus input, made 'i' key context-aware for both task expansion and tool inspection, and resolved state synchronization issues with TaskGroups