### PR TITLE
Replace WUI selection highlighting with ultra-thin inset shadow

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
@@ -258,9 +258,13 @@ export function ConversationContent({
                     }
                   }
                 }}
-                className={`group relative p-4 cursor-pointer NoSubTasksConversationContent ${
+                className={`group relative p-4 cursor-pointer NoSubTasksConversationContent transition-shadow duration-200 ${
                   index !== nonEmptyDisplayObjects.length - 1 ? 'border-b' : ''
-                } ${focusedEventId === displayObject.id ? '!bg-accent/20' : ''}`}
+                } ${
+                  focusedEventId === displayObject.id
+                    ? 'shadow-[inset_2px_0_0_0_var(--terminal-accent)]'
+                    : ''
+                }`}
               >
                 {/* Main content container with flexbox */}
                 <div className="flex gap-4">
@@ -411,13 +415,17 @@ export function ConversationContent({
                         }
                       }
                     }}
-                    className={`group relative p-4 cursor-pointer ${
+                    className={`group relative p-4 cursor-pointer transition-shadow duration-200 ${
                       index !==
                       rootEvents.filter(e => e.event_type !== ConversationEventType.ToolResult).length -
                         1
                         ? 'border-b'
                         : ''
-                    } ${focusedEventId === displayObject.id ? '!bg-accent/20 rounded' : ''}`}
+                    } ${
+                      focusedEventId === displayObject.id
+                        ? 'shadow-[inset_2px_0_0_0_var(--terminal-accent)]'
+                        : ''
+                    }`}
                   >
                     {/* Main content container with flexbox */}
                     <div className="flex gap-4">

--- a/humanlayer-wui/src/components/internal/SessionDetail/views/TaskGroup.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/TaskGroup.tsx
@@ -61,8 +61,8 @@ export function TaskGroup({
       {/* Task Header with Preview */}
       <div
         data-event-id={parentTask.id}
-        className={`flex items-start gap-2 rounded-md cursor-pointer hover:bg-muted/10 transition-colors ${
-          focusedEventId === parentTask.id ? '!bg-accent/20' : ''
+        className={`flex items-start gap-2 rounded-md cursor-pointer hover:bg-muted/10 transition-all duration-200 ${
+          focusedEventId === parentTask.id ? 'shadow-[inset_2px_0_0_0_var(--terminal-accent)]' : ''
         }`}
         onClick={onToggle}
         onMouseEnter={() => {
@@ -207,8 +207,10 @@ export function TaskGroup({
                       }
                     }
                   }}
-                  className={`group py-2 px-2 cursor-pointer ${
-                    focusedEventId === displayObject.id ? '!bg-accent/20 -mx-2 px-4 rounded' : ''
+                  className={`group py-2 px-2 cursor-pointer transition-shadow duration-200 ${
+                    focusedEventId === displayObject.id
+                      ? 'shadow-[inset_2px_0_0_0_var(--terminal-accent)]'
+                      : ''
                   }`}
                 >
                   {/* Main content container with flexbox */}

--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -327,8 +327,9 @@ export default function SessionTable({
                   }}
                   onClick={() => handleActivateSession?.(session)}
                   className={cn(
-                    'cursor-pointer',
-                    focusedSession?.id === session.id && '!bg-accent/20',
+                    'cursor-pointer transition-shadow duration-200',
+                    focusedSession?.id === session.id &&
+                      'shadow-[inset_2px_0_0_0_var(--terminal-accent)]',
                     session.archived && 'opacity-60',
                   )}
                 >


### PR DESCRIPTION
## What problem(s) was I solving?

The current message selection highlighting in the WUI uses a 20% opacity accent color background (`!bg-accent/20`) which "washes out the content" and makes selected messages difficult to read. This creates a poor user experience when navigating through messages with keyboard shortcuts (j/k), as users need to clearly see the content they're selecting while also knowing which message is currently focused.

## What user-facing changes did I ship?

- **Replaced background highlighting with ultra-minimal inset shadow**: Selected messages now display a 2px left-edge inset shadow instead of a full background color, preserving text readability while providing clear visual feedback
- **Added smooth transitions**: Selection changes now animate smoothly (200ms duration) when navigating with keyboard shortcuts, creating a more polished experience
- **Improved visual consistency**: The new selection indicator works consistently across all 9 terminal themes and maintains visibility without interfering with content

## How I implemented it

Following the implementation plan in `thoughts/shared/plans/wui_selection_highlighting_inset_shadow.md`, I made targeted changes to the selection rendering across three components:

1. **ConversationContent.tsx** - Updated both non-sub-task and sub-task conversation items to use `shadow-[inset_2px_0_0_0_var(--terminal-accent)]` instead of `!bg-accent/20`
2. **TaskGroup.tsx** - Modified task group headers and nested task items with the same inset shadow approach
3. **SessionTable.tsx** - Applied consistent selection styling to session rows for uniformity across the application

Key technical details:
- Used Tailwind's arbitrary value syntax to create the custom inset shadow
- Leveraged the existing `--terminal-accent` CSS variable for theme consistency
- Added `transition-shadow duration-200` to all selectable elements for smooth animations
- Removed unnecessary `rounded` classes that were paired with the old background highlighting

## How to verify it

- [x] I have ensured `make check test` passes

### Manual Testing Steps:

1. **Keyboard Navigation**:
   - Open the WUI and navigate to a session with multiple messages
   - Use `j` and `k` keys to navigate up and down through messages
   - Verify the 2px left-edge shadow appears on the focused message
   - Confirm text remains fully readable when selected
   - Check that transitions are smooth between selections

2. **Theme Testing**:
   - Switch between different terminal themes in the settings
   - Verify the selection indicator is visible in all themes (especially dark themes like Solarized Dark, Tokyo Night, and Dracula)
   - Ensure the accent color shadow adapts correctly to each theme

3. **Different Content Types**:
   - Test with messages containing code blocks
   - Test with nested task groups (expanded and collapsed)
   - Test with very long messages
   - Verify the indicator appears consistently on the left edge regardless of content

4. **Session Table**:
   - Navigate the session list with keyboard shortcuts
   - Confirm the same inset shadow selection appears on session rows

## Description for the changelog

Replace message selection highlighting with minimal inset shadow for improved readability while maintaining clear keyboard navigation feedback