### PR TITLE
Allison/eng 1650 a hld session failed but its still running

### DIFF
--- a/hld/CLAUDE.md
+++ b/hld/CLAUDE.md
@@ -15,3 +15,5 @@ You can test RPC calls with nc:
 ```bash
 echo '{"jsonrpc":"2.0","method":"getSessionLeaves","params":{},"id":1}' | nc -U ~/.humanlayer/daemon.sock | jq '.'
 ```
+
+For testing guidelines and database isolation requirements, see TESTING.md

--- a/hld/TESTING.md
+++ b/hld/TESTING.md
@@ -1,3 +1,45 @@
+# Testing Guidelines for HLD
+
+## Database Isolation
+
+All tests MUST use isolated databases to prevent corruption of user data.
+
+### Required for Integration Tests
+
+Every integration test that spawns a daemon MUST set database isolation:
+
+```go
+// Option 1: In-memory database (fastest, no persistence)
+t.Setenv("HUMANLAYER_DATABASE_PATH", ":memory:")
+
+// Option 2: testutil helper (allows persistence testing)
+_ = testutil.DatabasePath(t, "descriptive-name")
+
+// Option 3: Manual temp file (for special cases)
+dbPath := filepath.Join(t.TempDir(), "test.db")
+t.Setenv("HUMANLAYER_DATABASE_PATH", dbPath)
+```
+
+### Never Do This
+
+```go
+// BAD: No database path set - uses production!
+t.Setenv("HUMANLAYER_DAEMON_SOCKET", socketPath)
+// Missing: t.Setenv("HUMANLAYER_DATABASE_PATH", ...)
+```
+
+## Running Integration Tests
+
+```bash
+# Run all integration tests
+cd hld && go test -tags=integration ./...
+
+# Run specific integration test
+cd hld && go test -tags=integration ./daemon/daemon_integration_test.go -v
+```
+
+---
+
 # Testing HumanLayer Daemon + TUI Integration
 
 This guide covers testing the Phase 4 integration where the TUI communicates with the daemon instead of directly with the HumanLayer API.

--- a/hld/daemon/daemon_integration_test.go
+++ b/hld/daemon/daemon_integration_test.go
@@ -30,6 +30,7 @@ func TestDaemonBinaryIntegration(t *testing.T) {
 	t.Run("daemon_starts", func(t *testing.T) {
 		socketPath := testutil.SocketPath(t, "starts")
 		t.Setenv("HUMANLAYER_DAEMON_SOCKET", socketPath)
+		_ = testutil.DatabasePath(t, "daemon-starts")
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -77,6 +78,7 @@ func TestDaemonBinaryIntegration(t *testing.T) {
 	t.Run("refuses_double_start", func(t *testing.T) {
 		socketPath := testutil.SocketPath(t, "starts")
 		t.Setenv("HUMANLAYER_DAEMON_SOCKET", socketPath)
+		_ = testutil.DatabasePath(t, "double-start")
 
 		// Start first daemon
 		ctx1, cancel1 := context.WithTimeout(context.Background(), 2*time.Second)
@@ -113,6 +115,7 @@ func TestDaemonBinaryIntegration(t *testing.T) {
 			t.Run(sig.String(), func(t *testing.T) {
 				socketPath := testutil.SocketPath(t, sig.String())
 				t.Setenv("HUMANLAYER_DAEMON_SOCKET", socketPath)
+				_ = testutil.DatabasePath(t, "graceful-"+sig.String())
 
 				cmd := exec.Command(binPath)
 				if err := cmd.Start(); err != nil {

--- a/hld/daemon/daemon_test.go
+++ b/hld/daemon/daemon_test.go
@@ -111,6 +111,7 @@ func TestDaemonRefusesDoubleStart(t *testing.T) {
 
 	// Override config loading for test
 	t.Setenv("HUMANLAYER_DAEMON_SOCKET", socketPath)
+	t.Setenv("HUMANLAYER_DATABASE_PATH", ":memory:")
 
 	// Start first daemon
 	d1, err := New()


### PR DESCRIPTION
## What problem(s) was I solving?

Sessions were being incorrectly marked as "failed" with the error message "daemon restarted while session was active" even when the production daemon never restarted. Investigation revealed that integration tests in `hld/daemon/daemon_integration_test.go` were spawning test daemons that used the PRODUCTION database (`~/.humanlayer/daemon.db`) instead of a test database. This caused the orphan detection logic to mark all active production sessions as failed whenever tests ran (e.g., via `make test`).

## What user-facing changes did I ship?

- **Fixed phantom session failures**: Users will no longer see their active sessions mysteriously marked as failed when tests run
- **Added safeguard**: Test processes now fail fast with a clear error if they attempt to use the production database
- **Improved documentation**: Added comprehensive testing guidelines to prevent similar issues

## How I implemented it

1. **Database isolation for integration tests**: Modified all test functions in `daemon_integration_test.go` to use `testutil.DatabasePath()` which creates temporary test databases
2. **Runtime safeguard**: Added detection in `daemon.New()` to prevent test binaries from accidentally using the production database unless explicitly allowed via `HUMANLAYER_ALLOW_TEST_PROD_DB=true`
3. **Documentation**: Created comprehensive database isolation guidelines in `TESTING.md` with examples of correct and incorrect usage
4. **Fixed affected unit test**: Updated `daemon_test.go` to set database path since the new safeguard requires it

The safeguard works by checking if the binary path contains "/T/" (Go's temp test directory) or "test" in the name, and if the database path matches the default production path. This catches both `go test` runs and compiled test binaries.

## How to verify it

- [x] I have ensured `make check test` passes

Additional verification:
- Integration tests now use isolated databases (verified by examining test output)
- The safeguard prevents test processes from corrupting production data
- All existing tests continue to pass with proper database isolation

## Description for the changelog

Fixed integration tests corrupting production database and causing phantom session failures