### PR TITLE
Fix WUI launch failure for worktrees

### DIFF
--- a/humanlayer-wui/src-tauri/capabilities/default.json
+++ b/humanlayer-wui/src-tauri/capabilities/default.json
@@ -13,10 +13,7 @@
       "identifier": "fs:scope",
       "allow": [
         {
-          "path": "/"
-        },
-        {
-          "path": "/**/*"
+          "path": "**/*"
         }
       ]
     },

--- a/humanlayer-wui/src-tauri/tauri.conf.json
+++ b/humanlayer-wui/src-tauri/tauri.conf.json
@@ -32,5 +32,10 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ]
+  },
+  "plugins": {
+    "fs": {
+      "requireLiteralLeadingDot": false
+    }
   }
 }


### PR DESCRIPTION
## What problem(s) was I solving?

The WUI was failing to launch Claude Code sessions when the current working directory was a git worktree. The Tauri filesystem configuration was too restrictive with path validation, causing immediate failures when attempting to launch from worktrees. This was blocking users who work primarily with git worktrees from using the WUI to manage their Claude Code sessions.

## What user-facing changes did I ship?

Users can now successfully launch Claude Code sessions from the WUI when their current working directory is a git worktree. This restores full functionality for users who organize their development workflow around git worktrees.

## How I implemented it

I updated the Tauri filesystem configuration to be less restrictive:

1. **Simplified fs:scope permissions**: Changed from multiple specific path patterns (`"/"` and `"/**/*"`) to a single glob pattern (`"**/*"`) in the capabilities configuration
2. **Disabled requireLiteralLeadingDot**: Added `"requireLiteralLeadingDot": false` to the fs plugin configuration in `tauri.conf.json`

These changes remove unnecessary local filesystem validation from Tauri, allowing the daemon and claudecode-go to handle their own directory validation. The Tauri layer was being overly restrictive about path formats, which was incompatible with how worktree paths are structured.

## How to verify it

- [x] I have ensured `make check test` passes
- [x] Launch the WUI from a git worktree directory and verify Claude Code launches successfully
- [x] Launch the WUI from a regular git repository and verify it still works
- [x] Launch the WUI from a non-git directory and verify it still works

## Description for the changelog

Fix WUI launch failure when working in git worktrees by relaxing Tauri filesystem path validation