### PR TITLE
thoughts to makefile

### DIFF
--- a/.claude/commands/founder_mode.md
+++ b/.claude/commands/founder_mode.md
@@ -12,4 +12,4 @@ assuming you just made a commit, here are the next steps:
 6. git cherry-pick 'COMMITHASH'
 7. git push -u origin 'BRANCHNAME'
 8. gh pr create --fill
-9. read '.claude/commands/pull_request.md' and follow the instructions
+9. read '.claude/commands/describe_pr.md' and follow the instructions

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: setup
 setup: ## Set up the repository with all dependencies and builds
 	hack/setup_repo.sh
+thoughts:
+	humanlayer thoughts init --directory humanlayer
 
 .PHONY: worktree
 worktree: ## Create a new worktree for development work (use hack/create_worktree.sh branch_name for specific names)

--- a/humanlayer-wui/src/components/internal/SessionDetail/MarkdownRenderer.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/MarkdownRenderer.tsx
@@ -1,10 +1,12 @@
-import React, { memo } from 'react'
+import React, { memo, useCallback } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter'
 import DOMPurify from 'dompurify'
 import { Copy, Check } from 'lucide-react'
 import type { Components } from 'react-markdown'
+import { Button } from '@/components/ui/button'
+import { copyToClipboard } from '@/utils/clipboard'
 
 // Import only needed languages for smaller bundle
 import json from 'react-syntax-highlighter/dist/cjs/languages/prism/json'
@@ -89,96 +91,109 @@ export const MarkdownRenderer = memo(
 
     const sanitizedContent = sanitize ? DOMPurify.sanitize(content, DOMPURIFY_CONFIG) : content
 
-    const handleCopy = async (code: string, id: string) => {
-      await navigator.clipboard.writeText(code)
-      setCopiedBlocks(prev => new Set([...prev, id]))
-      setTimeout(() => {
-        setCopiedBlocks(prev => {
-          const next = new Set(prev)
-          next.delete(id)
-          return next
-        })
-      }, 2000)
-    }
-
-    const components: Components = {
-      li({ children }) {
-        // Remove any leading whitespace/newlines from list items
-        // This fixes the issue where numbered lists have newlines between number and text
-        if (Array.isArray(children)) {
-          // Filter out pure whitespace text nodes at the beginning
-          const filteredChildren = children.filter((child, index) => {
-            if (index === 0 && typeof child === 'string' && child.trim() === '') {
-              return false
-            }
-            return true
+    const handleCopy = useCallback(async (code: string, id: string) => {
+      const success = await copyToClipboard(code)
+      if (success) {
+        setCopiedBlocks(prev => new Set([...prev, id]))
+        setTimeout(() => {
+          setCopiedBlocks(prev => {
+            const next = new Set(prev)
+            next.delete(id)
+            return next
           })
-          return <li>{filteredChildren}</li>
-        }
-        return <li>{children}</li>
-      },
-      p({ children, ...props }) {
-        // Check if we're inside a list item
-        const isInList = (props as any).node?.parent?.tagName === 'li'
-        // Let CSS handle margins, only control display
-        return <p style={{ display: isInList ? 'inline' : 'block' }}>{children}</p>
-      },
-      code(props) {
-        const { className, children } = props as any
-        // Check if it's an inline code or code block by looking at the presence of language class
-        const match = /language-(\w+)/.exec(className || '')
-        const codeString = String(children).replace(/\n$/, '')
-        const codeId = `code-${Math.random().toString(36).substr(2, 9)}`
+        }, 2000)
+      }
+    }, [])
 
-        return match ? (
-          <div className="relative group">
-            <SyntaxHighlighter
-              language={match[1]}
-              useInlineStyles={false}
-              className="rsh-code-block text-sm"
-              PreTag={({ children, ...props }) => (
-                <pre className="rsh-pre" {...props}>
-                  {children}
-                </pre>
-              )}
+    const components: Components = React.useMemo(
+      () => ({
+        li({ children }) {
+          // Remove any leading whitespace/newlines from list items
+          // This fixes the issue where numbered lists have newlines between number and text
+          if (Array.isArray(children)) {
+            // Filter out pure whitespace text nodes at the beginning
+            const filteredChildren = children.filter((child, index) => {
+              if (index === 0 && typeof child === 'string' && child.trim() === '') {
+                return false
+              }
+              return true
+            })
+            return <li>{filteredChildren}</li>
+          }
+          return <li>{children}</li>
+        },
+        p({ children, ...props }) {
+          // Check if we're inside a list item
+          const isInList = (props as any).node?.parent?.tagName === 'li'
+          // Let CSS handle margins, only control display
+          return <p style={{ display: isInList ? 'inline' : 'block' }}>{children}</p>
+        },
+        code(props) {
+          const { className, children } = props as any
+          // Check if it's an inline code or code block by looking at the presence of language class
+          const match = /language-(\w+)/.exec(className || '')
+          const codeString = String(children).replace(/\n$/, '')
+          const codeId = `code-${Math.random().toString(36).substr(2, 9)}`
+
+          return match ? (
+            <div className="relative group not-prose">
+              <div className="overflow-x-auto">
+                <SyntaxHighlighter
+                  language={match[1]}
+                  useInlineStyles={false}
+                  className="rsh-code-block text-sm"
+                  PreTag={({ children, ...props }) => (
+                    <pre className="rsh-pre" {...props}>
+                      {children}
+                    </pre>
+                  )}
+                >
+                  {codeString}
+                </SyntaxHighlighter>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="absolute top-2 right-2 h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity duration-200 z-10 touch:opacity-100 md:touch:opacity-0 md:touch:group-hover:opacity-100"
+                onClick={e => {
+                  e.stopPropagation()
+                  handleCopy(codeString, codeId)
+                }}
+                aria-label="Copy code"
+                title="Copy code"
+              >
+                {copiedBlocks.has(codeId) ? (
+                  <Check className="h-3 w-3 text-success" />
+                ) : (
+                  <Copy className="h-3 w-3" />
+                )}
+              </Button>
+            </div>
+          ) : (
+            <code className="px-1 py-0.5 bg-accent/20 text-accent rounded-none text-sm font-mono">
+              {children}
+            </code>
+          )
+        },
+        pre({ children }) {
+          // Pre is handled by code block above
+          return <>{children}</>
+        },
+        a({ href, children }) {
+          return (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent underline hover:text-accent/80 transition-colors"
             >
-              {codeString}
-            </SyntaxHighlighter>
-            <button
-              onClick={() => handleCopy(codeString, codeId)}
-              className="absolute top-2 right-2 p-1.5 bg-background/80 border border-border rounded-none opacity-0 group-hover:opacity-100 transition-opacity"
-              aria-label="Copy code"
-            >
-              {copiedBlocks.has(codeId) ? (
-                <Check className="w-3.5 h-3.5 text-success" />
-              ) : (
-                <Copy className="w-3.5 h-3.5 text-muted-foreground" />
-              )}
-            </button>
-          </div>
-        ) : (
-          <code className="px-1 py-0.5 bg-accent/20 text-accent rounded-none text-sm font-mono">
-            {children}
-          </code>
-        )
-      },
-      pre({ children }) {
-        // Pre is handled by code block above
-        return <>{children}</>
-      },
-      a({ href, children }) {
-        return (
-          <a
-            href={href}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-accent underline hover:text-accent/80 transition-colors"
-          >
-            {children}
-          </a>
-        )
-      },
-    }
+              {children}
+            </a>
+          )
+        },
+      }),
+      [handleCopy, copiedBlocks],
+    )
 
     return (
       <ReactMarkdown


### PR DESCRIPTION
## What problem(s) was I solving?

The `humanlayer thoughts init` command needs to be run after setting up a worktree, as documented in the user's CLAUDE.md file. However, this was a manual step that could be easily forgotten, and claude needs attention to cd into a dir to run a command. By adding a Makefile target, we make it easier and more discoverable for developers to initialize thoughts for the repository, and **most importantly** it makes it so we can prompt claude `make -C worktree-dir thoughts` and have it run without approval if `make:*` is allowed already

## What user-facing changes did I ship?

- Added a new `make thoughts` target that runs `humanlayer thoughts init --directory humanlayer`
- This provides a standardized way to initialize the thoughts system for the HumanLayer repository

## How I implemented it

Added a simple Makefile target called `thoughts` that executes the `humanlayer thoughts init` command with the `--directory humanlayer` flag. This flag skips the interactive prompt and directly specifies the repository directory name.

The target was placed after the `setup` target to maintain logical grouping of initialization-related commands.

## How to verify it

- [x] I have ensured `make check test` passes
- Run `make thoughts` in the repository root
- The command should execute `humanlayer thoughts init --directory humanlayer`
- Thoughts should be initialized for the repository

## Description for the changelog

Add Makefile target for initializing thoughts system