### PR TITLE
fix: strip leading/trailing newlines from thinking blocks

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
@@ -478,7 +478,7 @@ export function eventToDisplayObject(
 
   if (event.event_type === ConversationEventType.Thinking) {
     // Thinking messages are always from assistant
-    const fullContent = event.content || ''
+    const fullContent = (event.content || '').trim()
 
     subject = (
       <div className="text-muted-foreground italic">


### PR DESCRIPTION
## What problem(s) was I solving?

Thinking blocks in the WUI sometimes display excessive vertical spacing due to leading newlines in the content. When Claude's thinking content includes multiple newlines at the beginning (e.g., `\n\n\n\n`), these are rendered as-is by the MarkdownRenderer, creating large visual gaps that make the UI look broken and hard to read.

This issue was reported in [ENG-1651](https://linear.app/humanlayer/issue/ENG-1651) with screenshots showing the problematic spacing.

## What user-facing changes did I ship?

- Thinking blocks now display with consistent, clean spacing regardless of leading/trailing newlines in the content
- The fix is purely visual - no data is modified, stored thinking content remains unchanged
- All internal formatting within thinking blocks (paragraph breaks, lists, etc.) is preserved
- Only affects thinking block display; other message types (assistant, user, tool calls) remain unchanged

## How I implemented it

The fix is minimal and surgical - I added `.trim()` to the thinking content processing in `eventToDisplayObject.tsx:481`:

```typescript
// Before:
const fullContent = event.content || ''

// After:
const fullContent = (event.content || '').trim()
```

This approach:
- Strips leading and trailing whitespace only at display time
- Preserves all internal formatting and line breaks
- Has zero impact on stored data or other components
- Uses a lightweight string operation with negligible performance impact

## How to verify it

- [x] I have ensured `make check test` passes

Manual verification steps:
1. Open a session in WUI that has thinking blocks with excessive newlines
2. Verify that the large vertical gaps are gone
3. Confirm that internal formatting (lists, code blocks, paragraphs) within thinking content is preserved
4. Check that other message types display normally without any changes

## Description for the changelog

fix(wui): strip excessive whitespace from thinking block display