### PR TITLE
Ignore tauri releases from eslint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ check-ts:
 check-hlyr:
 	@$(MAKE) -C hlyr check VERBOSE=$(VERBOSE)
 
-check-wui: clean-wui-release
+check-wui:
 	@$(MAKE) -C humanlayer-wui check VERBOSE=$(VERBOSE)
 
 check-tui:

--- a/humanlayer-wui/eslint.config.mjs
+++ b/humanlayer-wui/eslint.config.mjs
@@ -5,7 +5,7 @@ import eslintConfigPrettier from 'eslint-config-prettier/flat'
 
 export default [
   {
-    ignores: ['dist/**/*'],
+    ignores: ['dist/**/*', 'src-tauri/target/**/*'],
   },
   {
     files: ['**/*.{js,mjs,cjs,ts,tsx}'],


### PR DESCRIPTION
## What problem(s) was I solving?

The `make check-test` command was failing when Tauri release builds were present in the `humanlayer-wui/src-tauri/target/release/` directory. ESLint was attempting to lint the generated JavaScript files in the Tauri release build output, which would cause the lint check to fail with errors in auto-generated code that we don't control.

## What user-facing changes did I ship?

No user-facing changes. This is a developer experience improvement that fixes the lint checking process.

## How I implemented it

1. Added `src-tauri/target/**/*` to the ESLint ignore patterns in `humanlayer-wui/eslint.config.mjs` to exclude all Tauri build output from linting
2. Removed the `clean-wui-release` dependency from the `check-wui` target in the Makefile, as it's no longer necessary to clean release builds before running checks

## How to verify it

- [x] I have ensured `make check test` passes

## Description for the changelog

Fix ESLint errors when Tauri release builds are present by ignoring the src-tauri/target directory