### PR TITLE
Enable forking from failed sessions in WUI

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -551,6 +551,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
             onSelectEvent={handleForkSelect}
             isOpen={forkViewOpen}
             onOpenChange={setForkViewOpen}
+            sessionStatus={session.status}
           />
         </div>
       )}
@@ -578,6 +579,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
             onSelectEvent={handleForkSelect}
             isOpen={forkViewOpen}
             onOpenChange={setForkViewOpen}
+            sessionStatus={session.status}
           />
         </div>
       )}
@@ -774,6 +776,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
             handleContinueSession={actions.handleContinueSession}
             handleResponseInputKeyDown={actions.handleResponseInputKeyDown}
             isForkMode={actions.isForkMode}
+            onOpenForkView={() => setForkViewOpen(true)}
           />
           <AutoAcceptIndicator enabled={autoAcceptEdits} className="mt-2" />
         </CardContent>

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ForkViewModal.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ForkViewModal.tsx
@@ -59,7 +59,7 @@ function ForkViewModalContent({
 
   // Add current option as a special index (-1) only if session is not failed
   const showCurrentOption = sessionStatus !== SessionStatus.Failed
-  const allOptions = showCurrentOption 
+  const allOptions = showCurrentOption
     ? [...userMessageIndices, { event: null, index: -1 }]
     : userMessageIndices
 

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseInput.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseInput.tsx
@@ -2,7 +2,12 @@ import React, { forwardRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { SessionInfo, SessionStatus } from '@/lib/daemon/types'
-import { getSessionStatusText, getInputPlaceholder, getHelpText, getForkInputPlaceholder } from '../utils/sessionStatus'
+import {
+  getSessionStatusText,
+  getInputPlaceholder,
+  getHelpText,
+  getForkInputPlaceholder,
+} from '../utils/sessionStatus'
 import { GitBranch } from 'lucide-react'
 
 interface ResponseInputProps {
@@ -64,12 +69,7 @@ export const ResponseInput = forwardRef<HTMLTextAreaElement, ResponseInputProps>
         <div className="flex items-center justify-between py-1">
           <span className="text-sm text-muted-foreground">{getSessionStatusText(session.status)}</span>
           {onOpenForkView && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={onOpenForkView}
-              className="h-8 gap-2"
-            >
+            <Button variant="ghost" size="sm" onClick={onOpenForkView} className="h-8 gap-2">
               <GitBranch className="h-4 w-4" />
               Fork from previous
             </Button>
@@ -85,7 +85,9 @@ export const ResponseInput = forwardRef<HTMLTextAreaElement, ResponseInputProps>
         <div className="flex gap-2">
           <Textarea
             ref={ref}
-            placeholder={isForkMode ? getForkInputPlaceholder(session.status) : getInputPlaceholder(session.status)}
+            placeholder={
+              isForkMode ? getForkInputPlaceholder(session.status) : getInputPlaceholder(session.status)
+            }
             value={responseInput}
             onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setResponseInput(e.target.value)}
             onKeyDown={handleResponseInputKeyDown}

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseInput.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseInput.tsx
@@ -2,7 +2,8 @@ import React, { forwardRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { SessionInfo, SessionStatus } from '@/lib/daemon/types'
-import { getSessionStatusText, getInputPlaceholder, getHelpText } from '../utils/sessionStatus'
+import { getSessionStatusText, getInputPlaceholder, getHelpText, getForkInputPlaceholder } from '../utils/sessionStatus'
+import { GitBranch } from 'lucide-react'
 
 interface ResponseInputProps {
   session: SessionInfo
@@ -12,6 +13,7 @@ interface ResponseInputProps {
   handleContinueSession: () => void
   handleResponseInputKeyDown: (e: React.KeyboardEvent) => void
   isForkMode?: boolean
+  onOpenForkView?: () => void
 }
 
 export const ResponseInput = forwardRef<HTMLTextAreaElement, ResponseInputProps>(
@@ -24,6 +26,7 @@ export const ResponseInput = forwardRef<HTMLTextAreaElement, ResponseInputProps>
       handleContinueSession,
       handleResponseInputKeyDown,
       isForkMode,
+      onOpenForkView,
     },
     ref,
   ) => {
@@ -55,11 +58,22 @@ export const ResponseInput = forwardRef<HTMLTextAreaElement, ResponseInputProps>
       // Regular help text
       return getHelpText(session.status)
     }
-    // Only show the simple status text if session is failed
-    if (session.status === SessionStatus.Failed) {
+    // Only show the simple status text if session is failed AND not in fork mode
+    if (session.status === SessionStatus.Failed && !isForkMode) {
       return (
         <div className="flex items-center justify-between py-1">
           <span className="text-sm text-muted-foreground">{getSessionStatusText(session.status)}</span>
+          {onOpenForkView && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onOpenForkView}
+              className="h-8 gap-2"
+            >
+              <GitBranch className="h-4 w-4" />
+              Fork from previous
+            </Button>
+          )}
         </div>
       )
     }
@@ -71,7 +85,7 @@ export const ResponseInput = forwardRef<HTMLTextAreaElement, ResponseInputProps>
         <div className="flex gap-2">
           <Textarea
             ref={ref}
-            placeholder={getInputPlaceholder(session.status)}
+            placeholder={isForkMode ? getForkInputPlaceholder(session.status) : getInputPlaceholder(session.status)}
             value={responseInput}
             onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setResponseInput(e.target.value)}
             onKeyDown={handleResponseInputKeyDown}

--- a/humanlayer-wui/src/components/internal/SessionDetail/utils/sessionStatus.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/utils/sessionStatus.tsx
@@ -33,3 +33,12 @@ export const getHelpText = (status: string): React.ReactNode => {
     </>
   )
 }
+
+// Add a new function for fork-specific placeholders
+export const getForkInputPlaceholder = (status: string): string => {
+  if (status === 'failed') {
+    return 'Edit this message to fork from selected point...'
+  }
+  // Fall back to regular placeholder for other statuses
+  return getInputPlaceholder(status)
+}


### PR DESCRIPTION
## What problem(s) was I solving?

Previously, when a Claude Code session failed, users had no way to recover from the failed state. The only option was to start a completely new session, losing all context and progress from the previous conversation. This was particularly frustrating when sessions failed due to transient issues or after significant work had been done.

## What user-facing changes did I ship?

- **Fork button for failed sessions**: Added a "Fork from previous" button that appears in the failed session status area, allowing users to easily access the fork functionality
- **Fork modal improvements**: The fork modal now properly handles failed sessions by hiding the "Current (latest state)" option, since failed sessions don't have a valid current state to fork from
- **Enhanced input field behavior**: When forking from a failed session, the input field now appears with fork-specific placeholder text ("Edit this message to fork from selected point...") to guide users
- **Improved UX flow**: Users can now seamlessly recover from failed sessions by selecting any previous conversation point and continuing from there

## How I implemented it

The implementation required changes across several components in the WUI:

1. **SessionDetail component**: Added `sessionStatus` prop to ForkViewModal and wired up the `onOpenForkView` callback to ResponseInput
2. **ForkViewModal component**: 
   - Added logic to conditionally show/hide the "Current (latest state)" option based on session status
   - Passed session status through to properly handle failed sessions
3. **ResponseInput component**:
   - Added new "Fork from previous" button that appears for failed sessions
   - Integrated fork-specific placeholder text when in fork mode
   - Modified the rendering logic to show input field even for failed sessions when in fork mode
4. **sessionStatus utils**: Added `getForkInputPlaceholder` function to provide context-aware placeholder text

## How to verify it

- [x] I have ensured `make check test` passes

### Manual testing steps:
1. Start a Claude Code session in the WUI
2. Cause the session to fail (e.g., by terminating the Claude process or triggering an error)
3. Verify that a "Fork from previous" button appears in the failed session's status area
4. Click the button and verify the fork modal opens
5. Verify that the "Current (latest state)" option is not shown in the fork modal
6. Select a previous conversation point and verify the input field appears with the fork-specific placeholder
7. Enter a new message and verify the fork creates a new session successfully

## Description for the changelog

Enable forking from failed Claude Code sessions in the WUI, allowing users to recover and continue work from any previous conversation point when a session fails