### PR TITLE
Enable devtools in tauri releases

### DIFF
--- a/humanlayer-wui/src-tauri/Cargo.toml
+++ b/humanlayer-wui/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## What problem(s) was I solving?

The WebKit developer tools were not available in production Tauri releases, making it difficult to debug issues that only occur in the production environment. This limited our ability to troubleshoot production-specific problems with the HumanLayer Web UI (WUI).

## What user-facing changes did I ship?

None directly. This is a developer-facing change that enables the WebKit developer tools in production builds of the HumanLayer Web UI. Users won't notice any difference in the application behavior, but developers will now be able to inspect and debug the application when running production releases.

## How I implemented it

Added the "devtools" feature flag to the Tauri dependency in the `humanlayer-wui/src-tauri/Cargo.toml` file. This is a one-line change that enables the developer tools in both development and production builds.

## How to verify it

- [x] I have ensured `make check test` passes

To manually verify the change:
1. Build a production release of the WUI
2. Launch the application
3. Right-click in the application window and verify that developer tools options are available in the context menu
4. Verify that the developer tools open correctly and function as expected

## Description for the changelog

Enable WebKit developer tools in HumanLayer Web UI production builds for improved debugging capabilities