### PR TITLE
command tweaks for style

### DIFF
--- a/.claude/commands/create_plan.md
+++ b/.claude/commands/create_plan.md
@@ -325,6 +325,7 @@ After structure approval:
    - Research actual code patterns using parallel sub-tasks
    - Include specific file paths and line numbers
    - Write measurable success criteria with clear automated vs manual distinction
+   - automated steps should use `make` whenever possible - for example `make -C humanlayer-wui check` instead of `cd humanalyer-wui && bun run fmt`
 
 4. **Be Practical**:
    - Focus on incremental, testable changes

--- a/.claude/commands/create_plan.md
+++ b/.claude/commands/create_plan.md
@@ -22,8 +22,8 @@ Please provide:
 
 I'll analyze this information and work with you to create a comprehensive plan.
 
-Tip: You can also invoke this command with a ticket file directly: `/implementation_plan thoughts/allison/tickets/eng_1234.md`
-For deeper analysis, try: `/implementation_plan think deeply about thoughts/allison/tickets/eng_1234.md`
+Tip: You can also invoke this command with a ticket file directly: `/create_plan thoughts/allison/tickets/eng_1234.md`
+For deeper analysis, try: `/create_plan think deeply about thoughts/allison/tickets/eng_1234.md`
 ```
 
 Then wait for the user's input.

--- a/.claude/commands/linear.md
+++ b/.claude/commands/linear.md
@@ -180,6 +180,8 @@ new columns for permission_prompt_tool and allowed_tools..."
 Title: Fix resumed sessions to inherit all configuration from parent
 
 Description:
+
+## Problem to solve
 Currently, resumed sessions only inherit Model and WorkingDir from parent sessions,
 causing all other configuration to be lost. Users must re-specify permissions and
 settings when resuming.
@@ -303,6 +305,7 @@ When moving tickets through the workflow:
 ## Important Notes
 
 - Keep tickets concise but complete - aim for scannable content
+- All tickets should include a clear "problem to solve" - if the user asks for a ticket and only gives implementation details, you MUST ask "To write a good ticket, please explain the problem you're trying to solve from a user perspective"
 - Focus on the "what" and "why", include "how" only if well-defined
 - Always preserve links to source material using the `links` parameter
 - Don't create tickets from early-stage brainstorming unless requested
@@ -311,6 +314,7 @@ When moving tickets through the workflow:
 - Ask for clarification rather than guessing project/status
 - Remember that Linear descriptions support full markdown including code blocks
 - Always use the `links` parameter for external URLs (not just markdown links)
+- remember - you must get a "Problem to solve"!
 
 ## Comment Quality Guidelines
 

--- a/.claude/commands/research_codebase.md
+++ b/.claude/commands/research_codebase.md
@@ -29,6 +29,7 @@ Then wait for the user's research query.
    - Create multiple Task agents to research different aspects concurrently
    - Always include these parallel tasks:
      - **Codebase exploration tasks** (one for each relevant component/directory)
+     - **Web Research tasks** (to confirm best practices and ground codebase context in alternative approaches)
      - **Thoughts directory exploration task** (to find historical context and insights)
    - Each codebase sub-agent should focus on a specific directory, component, or question
    - Write detailed prompts for each sub-agent following these guidelines:
@@ -45,8 +46,21 @@ Then wait for the user's research query.
      3. Look for connections to [related components]
      4. Find examples of usage in [relevant areas]
      5. Note any patterns or conventions used
+     6. Use only READ-ONLY tools (Read, Grep, Glob, LS)
      Return: File paths, line numbers, and concise explanations of findings
      ```
+   - Example web sub-agent prompt:
+     ```
+     Research [specific component/pattern] using WebSearch and/or WebFetch:
+     1. Find all pages related to [topic]
+     2. Identify how [concept] could be implemented (include page:quotation references
+     3. Look for connections to [related components]
+     4. Find examples of usage in [relevant areas]
+     5. Note any patterns or conventions used
+     6. Use only WEB TOOLS (WebFetch, WebSearch) and READ-ONLY tools (Read, Grep, Glob, LS)
+     Return: web pages, exact quotations, and concise explanations of findings
+     ```
+
    - Thoughts directory sub-agent prompt:
      ```
      Explore the thoughts/ directory for context related to [topic]:

--- a/.claude/commands/research_codebase.md
+++ b/.claude/commands/research_codebase.md
@@ -76,13 +76,8 @@ Then wait for the user's research query.
    - Answer the user's specific questions with concrete evidence
 
 5. **Gather metadata for the research document:**
-   - Get current date and time with timezone: `date '+%Y-%m-%d %H:%M:%S %Z'`
-   - Get git commit from repository root: `cd $(git rev-parse --show-toplevel) && git log -1 --format=%H`
-   - Get current branch: `git branch --show-current`
-   - Get researcher name from thoughts system: Parse `humanlayer thoughts status` output for "User: " line
-   - Get repository name: `basename $(git rev-parse --show-toplevel)`
-   - Create timestamp-based filename using date without timezone: `date '+%Y-%m-%d_%H-%M-%S'`
-   - Format: `thoughts/shared/research/YYYY-MM-DD_HH-MM-SS_topic.md`
+   - Run the `hack/spec_metadata.sh` script to generate all relevant metadata
+   - Filename: `thoughts/shared/research/YYYY-MM-DD_HH-MM-SS_topic.md`
 
 6. **Generate research document:**
    - Use the metadata gathered in step 4

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./hack/spec_metadata.sh)"
+    ]
+  },
+  "enableAllProjectMcpServers": false
+}

--- a/Makefile
+++ b/Makefile
@@ -547,7 +547,10 @@ daemon-dev: daemon-dev-build
 	$(eval DEV_DB := $(shell make -s copy-db-to-dev))
 	@echo "Starting dev daemon with database: $(DEV_DB)"
 	echo "$(TIMESTAMP) starting dev daemon in $$(pwd)" > ~/.humanlayer/logs/daemon-dev-$(TIMESTAMP).log
-	cd hld && HUMANLAYER_DATABASE_PATH=$(DEV_DB) HUMANLAYER_DAEMON_SOCKET=~/.humanlayer/daemon-dev.sock HUMANLAYER_DAEMON_VERSION_OVERRIDE=dev ./hld-dev 2>&1 | tee -a ~/.humanlayer/logs/daemon-dev-$(TIMESTAMP).log
+	cd hld && HUMANLAYER_DATABASE_PATH=$(DEV_DB) \
+		HUMANLAYER_DAEMON_SOCKET=~/.humanlayer/daemon-dev.sock \
+		HUMANLAYER_DAEMON_VERSION_OVERRIDE=$$(git branch --show-current) \
+		./hld-dev 2>&1 | tee -a ~/.humanlayer/logs/daemon-dev-$(TIMESTAMP).log
 
 # Run dev WUI with custom socket
 .PHONY: wui-dev

--- a/hack/spec_metadata.sh
+++ b/hack/spec_metadata.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Collect metadata
+DATETIME_TZ=$(date '+%Y-%m-%d %H:%M:%S %Z')
+FILENAME_TS=$(date '+%Y-%m-%d_%H-%M-%S')
+
+if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  REPO_ROOT=$(git rev-parse --show-toplevel)
+  REPO_NAME=$(basename "$REPO_ROOT")
+  GIT_BRANCH=$(git branch --show-current 2>/dev/null || git rev-parse --abbrev-ref HEAD)
+  GIT_COMMIT=$(git rev-parse HEAD)
+else
+  REPO_ROOT=""
+  REPO_NAME=""
+  GIT_BRANCH=""
+  GIT_COMMIT=""
+fi
+
+# Optional: thoughts system status (may be long). Limit lines to avoid noise.
+THOUGHTS_STATUS=""
+if command -v humanlayer >/dev/null 2>&1; then
+  # Capture first 40 lines; adjust as needed.
+  THOUGHTS_STATUS=$(humanlayer thoughts status 2>/dev/null | head -n 40)
+fi
+
+# Print similar to the individual command outputs
+echo "Current Date/Time (TZ): $DATETIME_TZ"
+[ -n "$GIT_COMMIT" ] && echo "Current Git Commit Hash: $GIT_COMMIT"
+[ -n "$GIT_BRANCH" ] && echo "Current Branch Name: $GIT_BRANCH"
+[ -n "$REPO_NAME" ] && echo "Repository Name: $REPO_NAME"
+echo "Timestamp For Filename: $FILENAME_TS"
+[ -n "$THOUGHTS_STATUS" ] && {
+  echo "$THOUGHTS_STATUS"
+}

--- a/hld/CLAUDE.md
+++ b/hld/CLAUDE.md
@@ -8,7 +8,14 @@ It uses a database at ~/.humanlayer/daemon.db - you can access it with sqlite3 t
 sqlite3 ~/.humanlayer/daemon.db "SELECT * FROM sessions ORDER BY created_at DESC LIMIT 5;"
 ```
 
-You cannot run this process, you cannot restart it. If you make changes, you must ask the user to rebuild it.
+before running any sqlite3 commands, first fetch the schema, e.g. for `sessions`:
+
+```bash
+sqlite3 ~/.humanlayer/daemon.db ".schema sessions"
+```
+
+
+You cannot run the daemon process yourself, you cannot restart it. If you make changes, you must ask the user to rebuild it.
 
 You can test RPC calls with nc:
 

--- a/hld/CLAUDE.md
+++ b/hld/CLAUDE.md
@@ -1,26 +1,40 @@
 This is the humanlayer Daemon (HLD) that powers the WUI (humanlayer-wui)
 
-The logs are in ~/.humanlayer/logs/daemon-TIMESTAMP.log
+You cannot run this process, you cannot restart it. If you make changes, you must ask the user to rebuild it.
 
-It uses a database at ~/.humanlayer/daemon.db - you can access it with sqlite3 to inspect progress and debug things, e.g.
+The logs are in ~/.humanlayer/logs/daemon-*.log
+
+It uses a database at ~/.humanlayer/*.db - you can access it with sqlite3 to inspect progress and debug things, e.g.
 
 ```bash
 sqlite3 ~/.humanlayer/daemon.db "SELECT * FROM sessions ORDER BY created_at DESC LIMIT 5;"
 ```
 
-before running any sqlite3 commands, first fetch the schema, e.g. for `sessions`:
+for development builds, you will likely want to get the path of a dev clone of the prod db:
 
 ```bash
-sqlite3 ~/.humanlayer/daemon.db ".schema sessions"
+sqlite3 ~/.humanlayer/daemon-2025-07-20-12-32-10.db "SELECT * FROM sessions ORDER BY created_at DESC LIMIT 5;"
+```
+
+you can check the schema for a dev database with:
+
+```bash
+sqlite3 ~/.humanlayer/daemon-YYYY-MM-DD-HH-MM-SS.db ".schema"
 ```
 
 
-You cannot run the daemon process yourself, you cannot restart it. If you make changes, you must ask the user to rebuild it.
+depending on what are looking at, you want either
+
+- `~/.humanlayer/daemon.sock`
+- `~/.humanlayer/daemon-dev.sock`
+
+If you are debugging code changes, they are most likely to be in the dev socket.
 
 You can test RPC calls with nc:
 
 ```bash
-echo '{"jsonrpc":"2.0","method":"getSessionLeaves","params":{},"id":1}' | nc -U ~/.humanlayer/daemon.sock | jq '.'
+echo '{"jsonrpc":"2.0","method":"getSessionLeaves","params":{},"id":1}' | nc -U SOCKET_PATH | jq '.'
 ```
+
 
 For testing guidelines and database isolation requirements, see TESTING.md

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -110,8 +110,11 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
     return verb.charAt(0).toUpperCase() + verb.slice(1)
   })
 
-  // Randomly choose spinner type on mount (0: fancy, 1: simple, 2: minimal, 3: bars)
-  const spinnerType = useMemo(() => Math.floor(Math.random() * 4), [])
+  // Randomly choose spinner type on mount (0: fancy, 1: simple, 2: bars)
+  const spinnerType = useMemo(() => {
+    const types = [0, 1, 3] // Excluding 2 (minimal)
+    return types[Math.floor(Math.random() * types.length)]
+  }, [])
 
   useEffect(() => {
     if (!isActivelyProcessing) return


### PR DESCRIPTION
## What problem(s) was I solving?

When working with Claude commands and the Makefile, there's inconsistent styling and some instructions could be clearer. This makes the developer experience less smooth when switching between different commands and build processes. Specifically:

1. The create_plan command didn't specify the preferred way to run automated steps
2. Linear ticket examples were missing proper formatting for "Problem to solve" sections
3. The Makefile daemon-dev target had inconsistent multi-line formatting compared to other targets
4. It was hard to tell dev WUI sessions apart if there were multiple running in different worktrees
5. The research_codebase command had manual metadata collection that could be automated
6. The hld CLAUDE.md file didn't provide guidance on checking database schemas before queries

## What user-facing changes did I ship?

No direct user-facing changes - this is a developer experience improvement for users of Claude Code working with this repository.

- random - remove 3-dots spinner from the list

## How I implemented it

1. **Enhanced create_plan.md**: 
   - Added explicit guidance to use `make` commands for automated steps (e.g., `make -C humanlayer-wui check` instead of `cd humanlayer-wui && bun run fmt`) to maintain consistency with our build tooling
   - Fixed incorrect command references that said `/implementation_plan` instead of `/create_plan`

2. **Improved linear.md formatting**: 
   - Added "## Problem to solve" header to the ticket example to demonstrate proper formatting
   - Added two reminders about requiring a "Problem to solve" section in all tickets
   - This ensures tickets follow a consistent structure that focuses on the user problem

3. **Cleaned up Makefile**: 
   - Reformatted the `daemon-dev` target to use proper multi-line environment variable syntax
   - Changed `HUMANLAYER_DAEMON_VERSION_OVERRIDE` from hardcoded "dev" to dynamically use the current git branch name
   - This allows the daemon version shown in the WUI footer to reflect the actual branch, making it easier to distinguish between multiple dev sessions running in different worktrees

4. **Automated research metadata collection**:
   - Created `hack/spec_metadata.sh` script to automatically collect git commit, branch, date, repository info, and thoughts status
   - Updated `research_codebase.md` to use this script instead of manual commands
   - Added the script to `.claude/settings.json` allowlist to ensure Claude can execute it
   - This reduces the chance of errors and speeds up research document generation

5. **Enhanced hld/CLAUDE.md**:
   - Added guidance to check database schema before running queries (e.g., `.schema sessions`)
   - Clarified that Claude cannot run or restart the daemon process
   - This helps prevent SQL errors from incorrect column references

## How to verify it

- [x] I have ensured `make check test` passes

## Description for the changelog

Improve Claude command consistency, automate metadata collection, and enhance developer documentation