### PR TITLE
Allison/eng 1725 rust 1880 breaks our tauri build

### DIFF
--- a/humanlayer-wui/Makefile
+++ b/humanlayer-wui/Makefile
@@ -33,6 +33,9 @@ rust-check: ## Run Rust compilation check
 rust-clippy: ## Run Rust linter (clippy)
 	cd src-tauri && cargo clippy -- -D warnings
 
+rust-clippy-fix: ## Run clippy fix
+	cd src-tauri && cargo clippy --fix --allow-dirty
+
 # Placeholder for future test command
 
 check-quiet: ## Run all quality checks with quiet output

--- a/humanlayer-wui/src-tauri/src/daemon_client/client.rs
+++ b/humanlayer-wui/src-tauri/src/daemon_client/client.rs
@@ -108,7 +108,7 @@ impl DaemonClient {
 
         if let Some(result) = response.result {
             serde_json::from_value(result)
-                .map_err(|e| Error::InvalidResponse(format!("Failed to parse result: {}", e)))
+                .map_err(|e| Error::InvalidResponse(format!("Failed to parse result: {e}")))
         } else {
             Err(Error::InvalidResponse("No result in response".to_string()))
         }
@@ -256,8 +256,7 @@ impl DaemonClientTrait for DaemonClient {
 
         if !response.success {
             return Err(Error::Session(format!(
-                "Failed to interrupt session {}",
-                session_id
+                "Failed to interrupt session {session_id}"
             )));
         }
 
@@ -305,8 +304,7 @@ impl DaemonClientTrait for DaemonClient {
 
         if !response.success {
             return Err(Error::Session(format!(
-                "Failed to update title for session {}",
-                session_id
+                "Failed to update title for session {session_id}"
             )));
         }
 

--- a/humanlayer-wui/src-tauri/src/daemon_client/connection.rs
+++ b/humanlayer-wui/src-tauri/src/daemon_client/connection.rs
@@ -61,7 +61,7 @@ impl Connection {
         let mut stream = self.stream.lock().await;
 
         // Send the message with newline
-        let message_with_newline = format!("{}\n", message);
+        let message_with_newline = format!("{message}\n");
         stream
             .write_all(message_with_newline.as_bytes())
             .await
@@ -108,8 +108,7 @@ impl Connection {
         // Check if socket exists
         if !path.exists() {
             return Err(Error::Connection(format!(
-                "Socket not found at {:?}. Is the daemon running?",
-                path
+                "Socket not found at {path:?}. Is the daemon running?"
             )));
         }
 

--- a/humanlayer-wui/src-tauri/src/daemon_client/subscriptions.rs
+++ b/humanlayer-wui/src-tauri/src/daemon_client/subscriptions.rs
@@ -91,7 +91,7 @@ async fn handle_subscription(
 ) -> Result<()> {
     // Send the subscription request
     stream
-        .write_all(format!("{}\n", request_str).as_bytes())
+        .write_all(format!("{request_str}\n").as_bytes())
         .await?;
     stream.flush().await?;
 

--- a/humanlayer-wui/src-tauri/src/lib.rs
+++ b/humanlayer-wui/src-tauri/src/lib.rs
@@ -268,7 +268,7 @@ async fn unsubscribe_from_events(
             // Parse the subscription ID
             let id = subscription_id
                 .parse::<u64>()
-                .map_err(|e| format!("Invalid subscription ID: {}", e))?;
+                .map_err(|e| format!("Invalid subscription ID: {e}"))?;
 
             client.unsubscribe(id).await.map_err(|e| e.to_string())?;
             tracing::info!(


### PR DESCRIPTION
## What problem(s) was I solving?

Rust 1.88.0 introduced stricter linting rules for string formatting that broke our Tauri build in the `humanlayer-wui` project. The clippy linter was flagging format string patterns that could be simplified using inline variable syntax instead of explicit format arguments.

## What user-facing changes did I ship?

None. This is an internal code quality fix that maintains the same functionality while conforming to newer Rust style guidelines.

## How I implemented it

1. **Updated string formatting**: Converted all format strings in the daemon client code from the older style `format!("text {}", var)` to the more modern inline style `format!("text {var}")`. This affected:
   - Error messages in `client.rs`
   - Connection error messages in `connection.rs`
   - Subscription handling in `subscriptions.rs`
   - Subscription ID parsing in `lib.rs`

2. **Added convenience command**: Created a new `rust-clippy-fix` make target in the `humanlayer-wui/Makefile` to automatically fix clippy warnings, making it easier to address similar issues in the future.

## How to verify it

- [x] I have ensured `make check test` passes

## Description for the changelog

Fix Rust 1.88.0 compatibility issues in Tauri build by updating string formatting to use inline variable syntax