### PR TITLE
feat(wui): improve session status display clarity

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { useConversation, useKeyboardNavigationProtection } from '@/hooks'
 import { ChevronDown, Archive, Pencil } from 'lucide-react'
 import { getStatusTextClass } from '@/utils/component-utils'
+import { renderSessionStatus } from '@/utils/sessionStatus'
 import { truncate } from '@/utils/formatting'
 import { daemonClient } from '@/lib/daemon/client'
 import { useStore } from '@/AppStore'
@@ -612,7 +613,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
             <small
               className={`font-mono text-xs uppercase tracking-wider ${getStatusTextClass(session.status)}`}
             >
-              {`${session.status}${session.model ? ` / ${session.model}` : ''}`}
+              {`${renderSessionStatus(session).toUpperCase()}${session.model ? ` / ${session.model}` : ''}`}
             </small>
             {session.working_dir && (
               <small className="font-mono text-xs text-muted-foreground">{session.working_dir}</small>
@@ -689,7 +690,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
             <small
               className={`font-mono text-xs uppercase tracking-wider ${getStatusTextClass(session.status)}`}
             >
-              {`${session.status}${session.model ? ` / ${session.model}` : ''}`}
+              {`${renderSessionStatus(session).toUpperCase()}${session.model ? ` / ${session.model}` : ''}`}
             </small>
           </hgroup>
           <ForkViewModal

--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -16,6 +16,7 @@ import type { LucideIcon } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { daemonClient } from '@/lib/daemon/client'
+import { renderSessionStatus } from '@/utils/sessionStatus'
 
 interface SessionTableProps {
   sessions: SessionInfo[]
@@ -393,7 +394,9 @@ export default function SessionTable({
                       </div>
                     </div>
                   </TableCell>
-                  <TableCell className={getStatusTextClass(session.status)}>{session.status}</TableCell>
+                  <TableCell className={getStatusTextClass(session.status)}>
+                    {renderSessionStatus(session)}
+                  </TableCell>
                   <TableCell className="max-w-[200px]">
                     <Tooltip>
                       <TooltipTrigger asChild>

--- a/humanlayer-wui/src/utils/sessionStatus.tsx
+++ b/humanlayer-wui/src/utils/sessionStatus.tsx
@@ -1,0 +1,14 @@
+export const renderSessionStatus = (session: { status: string; archived?: boolean }): string => {
+  // If session is completed but not archived, show "waiting_for_input"
+  if (session.status === 'completed' && !session.archived) {
+    return 'waiting_for_input'
+  }
+
+  // If session is waiting_input, show "needs_approval"
+  if (session.status === 'waiting_input') {
+    return 'needs_approval'
+  }
+
+  // For all other cases, return the status as-is
+  return session.status
+}


### PR DESCRIPTION
## What problem(s) was I solving?

The current session status display in the WUI uses technical terms that may not be intuitive for users. When a session is "completed" but not archived, users may not realize they can continue the conversation. Similarly, "waiting_input" doesn't clearly indicate that approval is needed.

## What user-facing changes did I ship?

Updated the session status display to use more user-friendly terminology:
- Sessions that are "completed" but not archived now display as "waiting_for_input"
- Sessions with status "waiting_input" now display as "needs_approval"

This change applies to both the session table and session detail views.

## How I implemented it

Created a new utility function `renderSessionStatus()` in `utils/sessionStatus.tsx` that transforms the raw database status values into user-friendly display text. This function:
- Checks if a session is completed but not archived, and returns "waiting_for_input"
- Maps "waiting_input" status to "needs_approval"
- Returns all other statuses unchanged

Updated the following components to use this utility:
- `SessionTable.tsx` - for the session list view
- `SessionDetail/SessionDetail.tsx` - for the session header display

This is a UI-only change that doesn't modify the underlying data model, making it safe and easy to revert if needed.

## How to verify it

- [x] I have ensured `make check test` passes

Manual testing:
1. Start a new Claude session
2. Send a message and wait for completion
3. Verify the status shows as "waiting_for_input" in the session table
4. Open the session detail view and verify the header shows "WAITING_FOR_INPUT"
5. Archive the session and verify it shows as "completed" in the archive view
6. Trigger an approval request and verify it shows as "needs_approval"

## Description for the changelog

Improved session status display clarity by showing "waiting_for_input" for completed sessions and "needs_approval" for sessions requiring approval
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improved session status display clarity by mapping technical terms to user-friendly ones in session table and detail views.
> 
>   - **Behavior**:
>     - Updated session status display to use user-friendly terms: "completed" to "waiting_for_input" if not archived, and "waiting_input" to "needs_approval".
>     - Changes affect both session table and session detail views.
>   - **Implementation**:
>     - Added `renderSessionStatus()` in `sessionStatus.tsx` to map raw status values to user-friendly text.
>     - Updated `SessionTable.tsx` and `SessionDetail.tsx` to use `renderSessionStatus()` for status display.
>   - **Verification**:
>     - Manual testing includes checking status display in session table and detail views, and verifying behavior when archiving sessions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 378372643426e36c8c09a6d6c69e561ff17535dc. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->