### PR TITLE
feat: Add GitHub Actions workflow for macOS release builds

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,0 +1,108 @@
+name: Build macOS Release Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Version tag for the release (e.g., v0.1.0)'
+        required: true
+        type: string
+  push:
+    branches:
+      - add-macos-release-workflow  # TEMPORARY - Remove before merging to main
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'hld/go.mod'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install WUI dependencies
+        working-directory: humanlayer-wui
+        run: bun install
+
+      - name: Build Tauri app (including DMG)
+        working-directory: humanlayer-wui
+        run: bun run tauri build
+
+      - name: Build daemon for macOS ARM
+        working-directory: hld
+        run: GOOS=darwin GOARCH=arm64 go build -o hld-darwin-arm64 ./cmd/hld
+
+      - name: Create install instructions
+        run: |
+          cat > INSTALL.md << 'EOF'
+          # HumanLayer macOS Installation Instructions
+
+          ## Prerequisites
+          - macOS (Apple Silicon/M-series)
+          - Node.js installed
+
+          ## Installation Steps
+
+          1. **Install the WUI Application**
+             - Open the downloaded `humanlayer-wui_*.dmg` file
+             - Drag the HumanLayer WUI app to your Applications folder
+             - Close the DMG window
+
+          2. **Install the Daemon**
+             - Download `hld-darwin-arm64`
+             - Make it executable: `chmod +x hld-darwin-arm64`
+             - Move to your PATH: `sudo mv hld-darwin-arm64 /usr/local/bin/hld`
+             - Verify installation: `hld --version`
+
+          3. **Install the CLI**
+             ```bash
+             npm install -g humanlayer@0.10.0
+             ```
+
+          4. **Start Using HumanLayer**
+             - Run the daemon: `hld`
+             - Launch the WUI from Applications
+             - Use the CLI: `humanlayer --help`
+
+          ## Troubleshooting
+
+          If macOS blocks the daemon from running:
+          1. Go to System Settings > Privacy & Security
+          2. Look for the blocked app message
+          3. Click "Allow Anyway"
+
+          For more help, visit: https://docs.humanlayer.dev
+          EOF
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: humanlayer-wui-macos-dmg
+          path: humanlayer-wui/src-tauri/target/release/bundle/dmg/*.dmg
+          if-no-files-found: error
+
+      - name: Upload daemon artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hld-darwin-arm64
+          path: hld/hld-darwin-arm64
+          if-no-files-found: error
+
+      - name: Upload install instructions
+        uses: actions/upload-artifact@v4
+        with:
+          name: INSTALL
+          path: INSTALL.md
+          if-no-files-found: error

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Build Tauri app (including DMG)
         working-directory: humanlayer-wui
         run: bun run tauri build
+        env:
+          APPLE_SIGNING_IDENTITY: "-"  # Ad-hoc signing to prevent "damaged" error
 
       - name: Build daemon for macOS ARM
         working-directory: hld
@@ -59,6 +61,8 @@ jobs:
              - Open the downloaded `humanlayer-wui_*.dmg` file
              - Drag the HumanLayer WUI app to your Applications folder
              - Close the DMG window
+             - **Important**: For first launch, right-click the app and select "Open"
+               (This is required for unsigned apps on macOS)
 
           2. **Install the Daemon**
              - Download `hld-darwin-arm64`
@@ -76,9 +80,23 @@ jobs:
              - Launch the WUI from Applications
              - Use the CLI: `humanlayer --help`
 
+          ## Security Notice
+
+          This build is ad-hoc signed but not notarized with Apple. On first launch:
+          - You'll see a security warning - this is normal
+          - Click "Cancel" on the warning dialog
+          - Right-click the app and choose "Open"
+          - Click "Open" in the security dialog
+
           ## Troubleshooting
 
-          If macOS blocks the daemon from running:
+          **If you see "app is damaged and can't be opened":**
+          Run this command in Terminal:
+          ```bash
+          xattr -cr /Applications/humanlayer-wui.app
+          ```
+
+          **If macOS blocks the daemon from running:**
           1. Go to System Settings > Privacy & Security
           2. Look for the blocked app message
           3. Click "Allow Anyway"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -106,3 +106,71 @@ jobs:
           name: INSTALL
           path: INSTALL.md
           if-no-files-found: error
+
+      # Create GitHub Release with artifacts
+      - name: Create Release
+        if: github.event_name == 'workflow_dispatch'
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.release_version }}
+          release_name: HumanLayer ${{ github.event.inputs.release_version }} - macOS Release
+          body: |
+            ## HumanLayer ${{ github.event.inputs.release_version }} - macOS Release
+
+            This release includes:
+            - HumanLayer WUI (Desktop Application) - DMG installer
+            - HumanLayer Daemon (hld) - ARM64 binary
+            - Installation instructions
+
+            ### Installation
+            Please download all three files below and follow the instructions in `INSTALL.md`.
+
+            ### Requirements
+            - macOS (Apple Silicon/M-series)
+            - Node.js for the CLI component
+          draft: true
+          prerelease: false
+
+      - name: Find DMG file
+        if: github.event_name == 'workflow_dispatch'
+        id: find_dmg
+        run: |
+          DMG_PATH=$(find humanlayer-wui/src-tauri/target/release/bundle/dmg -name "*.dmg" | head -1)
+          echo "dmg_path=$DMG_PATH" >> $GITHUB_OUTPUT
+          echo "dmg_name=$(basename $DMG_PATH)" >> $GITHUB_OUTPUT
+
+      - name: Upload Release Asset - DMG
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ steps.find_dmg.outputs.dmg_path }}
+          asset_name: ${{ steps.find_dmg.outputs.dmg_name }}
+          asset_content_type: application/x-apple-diskimage
+
+      - name: Upload Release Asset - Daemon
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: hld/hld-darwin-arm64
+          asset_name: hld-darwin-arm64
+          asset_content_type: application/octet-stream
+
+      - name: Upload Release Asset - Install Instructions
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: INSTALL.md
+          asset_name: INSTALL.md
+          asset_content_type: text/markdown

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -7,9 +7,6 @@ on:
         description: 'Version tag for the release (e.g., v0.1.0)'
         required: true
         type: string
-  push:
-    branches:
-      - add-macos-release-workflow  # TEMPORARY - Remove before merging to main
 
 jobs:
   build-macos:

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write  # Needed to create releases
+
 jobs:
   build-macos:
     runs-on: macos-latest
@@ -108,12 +111,10 @@ jobs:
       - name: Create Release
         if: github.event_name == 'workflow_dispatch'
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.release_version }}
-          release_name: HumanLayer ${{ github.event.inputs.release_version }} - macOS Release
+          name: HumanLayer ${{ github.event.inputs.release_version }} - macOS Release
           body: |
             ## HumanLayer ${{ github.event.inputs.release_version }} - macOS Release
 
@@ -131,43 +132,7 @@ jobs:
           draft: true
           prerelease: false
 
-      - name: Find DMG file
-        if: github.event_name == 'workflow_dispatch'
-        id: find_dmg
-        run: |
-          DMG_PATH=$(find humanlayer-wui/src-tauri/target/release/bundle/dmg -name "*.dmg" | head -1)
-          echo "dmg_path=$DMG_PATH" >> $GITHUB_OUTPUT
-          echo "dmg_name=$(basename $DMG_PATH)" >> $GITHUB_OUTPUT
-
-      - name: Upload Release Asset - DMG
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.find_dmg.outputs.dmg_path }}
-          asset_name: ${{ steps.find_dmg.outputs.dmg_name }}
-          asset_content_type: application/x-apple-diskimage
-
-      - name: Upload Release Asset - Daemon
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: hld/hld-darwin-arm64
-          asset_name: hld-darwin-arm64
-          asset_content_type: application/octet-stream
-
-      - name: Upload Release Asset - Install Instructions
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: INSTALL.md
-          asset_name: INSTALL.md
-          asset_content_type: text/markdown
+          files: |
+            humanlayer-wui/src-tauri/target/release/bundle/dmg/*.dmg
+            hld/hld-darwin-arm64
+            INSTALL.md

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -46,64 +46,6 @@ jobs:
         working-directory: hld
         run: GOOS=darwin GOARCH=arm64 go build -o hld-darwin-arm64 ./cmd/hld
 
-      - name: Create install instructions
-        run: |
-          cat > INSTALL.md << 'EOF'
-          # HumanLayer macOS Installation Instructions
-
-          ## Prerequisites
-          - macOS (Apple Silicon/M-series)
-          - Node.js installed
-
-          ## Installation Steps
-
-          1. **Install the WUI Application**
-             - Open the downloaded `humanlayer-wui_*.dmg` file
-             - Drag the HumanLayer WUI app to your Applications folder
-             - Close the DMG window
-             - **Important**: For first launch, right-click the app and select "Open"
-               (This is required for unsigned apps on macOS)
-
-          2. **Install the Daemon**
-             - Download `hld-darwin-arm64`
-             - Make it executable: `chmod +x hld-darwin-arm64`
-             - Move to your PATH: `sudo mv hld-darwin-arm64 /usr/local/bin/hld`
-             - Verify installation: `hld --version`
-
-          3. **Install the CLI**
-             ```bash
-             npm install -g humanlayer@0.10.0
-             ```
-
-          4. **Start Using HumanLayer**
-             - Run the daemon: `hld`
-             - Launch the WUI from Applications
-             - Use the CLI: `humanlayer --help`
-
-          ## Security Notice
-
-          This build is ad-hoc signed but not notarized with Apple. On first launch:
-          - You'll see a security warning - this is normal
-          - Click "Cancel" on the warning dialog
-          - Right-click the app and choose "Open"
-          - Click "Open" in the security dialog
-
-          ## Troubleshooting
-
-          **If you see "app is damaged and can't be opened":**
-          Run this command in Terminal:
-          ```bash
-          xattr -cr /Applications/humanlayer-wui.app
-          ```
-
-          **If macOS blocks the daemon from running:**
-          1. Go to System Settings > Privacy & Security
-          2. Look for the blocked app message
-          3. Click "Allow Anyway"
-
-          For more help, visit: https://docs.humanlayer.dev
-          EOF
-
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4
         with:
@@ -118,13 +60,6 @@ jobs:
           path: hld/hld-darwin-arm64
           if-no-files-found: error
 
-      - name: Upload install instructions
-        uses: actions/upload-artifact@v4
-        with:
-          name: INSTALL
-          path: INSTALL.md
-          if-no-files-found: error
-
       # Create GitHub Release with artifacts
       - name: Create Release
         if: github.event_name == 'workflow_dispatch'
@@ -137,20 +72,60 @@ jobs:
             ## HumanLayer ${{ github.event.inputs.release_version }} - macOS Release
 
             This release includes:
-            - HumanLayer WUI (Desktop Application) - DMG installer
-            - HumanLayer Daemon (hld) - ARM64 binary
-            - Installation instructions
+            - **HumanLayer WUI** - Desktop application (DMG installer)
+            - **HumanLayer Daemon (hld)** - Command-line daemon (ARM64 binary)
 
-            ### Installation
-            Please download all three files below and follow the instructions in `INSTALL.md`.
+            ### 🔐 macOS Security Notice
+
+            **Important**: This app is not notarized with Apple. You'll need to approve it in System Settings on first launch:
+
+            1. Open the downloaded DMG and drag the app to Applications
+            2. Try to open the app (it will be blocked)
+            3. Click "Done" on the error dialog
+            4. Go to **System Settings > Privacy & Security**
+            5. Find the warning about "humanlayer-wui" and click **"Open Anyway"**
+            6. Open the app again - it will now work
+
+            ### Installation Instructions
+
+            #### 1. Install the WUI Application
+            - Download and open `humanlayer-wui_*.dmg`
+            - Drag the HumanLayer WUI app to your Applications folder
+            - Follow the security steps above for first launch
+
+            #### 2. Install the Daemon
+            ```bash
+            # Download hld-darwin-arm64 from the assets below, then:
+            chmod +x hld-darwin-arm64
+            sudo mv hld-darwin-arm64 /usr/local/bin/hld
+            hld --version
+            ```
+
+            #### 3. Install the CLI
+            ```bash
+            npm install -g humanlayer@0.10.0
+            ```
+
+            #### 4. Start Using HumanLayer
+            - Run the daemon: `hld`
+            - Launch the WUI from Applications
+            - Use the CLI: `humanlayer --help`
 
             ### Requirements
             - macOS (Apple Silicon/M-series)
-            - Node.js for the CLI component
+            - Node.js installed
+
+            ### Troubleshooting
+
+            If you see "app is damaged and can't be opened":
+            ```bash
+            xattr -cr /Applications/humanlayer-wui.app
+            ```
+
+            For more help, visit [docs.humanlayer.dev](https://docs.humanlayer.dev)
           draft: true
           prerelease: false
 
           files: |
             humanlayer-wui/src-tauri/target/release/bundle/dmg/*.dmg
             hld/hld-darwin-arm64
-            INSTALL.md

--- a/humanlayer-wui/RELEASE.md
+++ b/humanlayer-wui/RELEASE.md
@@ -1,0 +1,86 @@
+# macOS Release Workflow Usage Guide
+
+## Testing the Workflow (Before Merging)
+
+The workflow has a temporary push trigger for testing on the `add-macos-release-workflow` branch. This allows testing before merging to main.
+
+### Using gh CLI:
+
+```bash
+# After pushing changes to the branch
+gh workflow run release-macos.yml --ref add-macos-release-workflow -f release_version=v0.1.0-test
+
+# Check workflow status
+gh run list --workflow=release-macos.yml
+
+# Watch a specific run
+gh run watch
+```
+
+### Important: Remove the push trigger before merging!
+
+The `push:` trigger in the workflow file is temporary and must be removed before creating the PR.
+
+## Prerequisites
+
+- Push access to the repository
+- Release version decided (e.g., v0.1.0)
+
+## Triggering a Release Build
+
+1. Go to the [Actions tab](../../actions) in GitHub
+2. Select "Build macOS Release Artifacts" from the left sidebar
+3. Click "Run workflow" button on the right
+4. Enter the version tag (e.g., `v0.1.0`)
+5. Click the green "Run workflow" button
+
+## Monitoring the Build
+
+1. Click on the running workflow to see progress
+2. Build typically takes 10-15 minutes
+3. Check each step for any errors
+
+## Downloading Artifacts
+
+After successful completion:
+
+1. Scroll to the "Artifacts" section at the bottom
+2. Download all three artifacts:
+   - `humanlayer-wui-macos-dmg` - The WUI application installer
+   - `hld-darwin-arm64` - The daemon binary
+   - `INSTALL` - Installation instructions
+
+## Creating a GitHub Release (Optional)
+
+To create a formal release:
+
+1. Go to [Releases page](../../releases)
+2. Click "Draft a new release"
+3. Choose a tag: Enter the same version (e.g., `v0.1.0`)
+4. Release title: `HumanLayer v0.1.0 - macOS Release`
+5. Attach the three downloaded artifacts
+6. Add release notes
+7. Publish release
+
+## Updating for New npm Versions
+
+When the npm package version changes:
+
+1. Edit `.github/workflows/release-macos.yml`
+2. Find the line `npm install -g humanlayer@0.10.0`
+3. Update to the new version
+4. Commit and push the change
+
+## Troubleshooting
+
+### Build Failures
+
+- **Rust/Cargo errors**: Check if Rust dependencies changed
+- **Go build errors**: Verify Go version matches `hld/go.mod`
+- **Bun/npm errors**: Clear caches with `bun install --force`
+
+### Artifact Issues
+
+- **Missing DMG**: Check Tauri build logs for errors
+- **Missing daemon**: Verify Go cross-compilation settings
+- **Wrong architecture**: Ensure `GOARCH=arm64` is set

--- a/humanlayer-wui/RELEASE.md
+++ b/humanlayer-wui/RELEASE.md
@@ -92,3 +92,18 @@ When the npm package version changes:
 - **Missing DMG**: Check Tauri build logs for errors
 - **Missing daemon**: Verify Go cross-compilation settings
 - **Wrong architecture**: Ensure `GOARCH=arm64` is set
+
+### macOS Security Issues
+
+The workflow uses ad-hoc signing to prevent "damaged app" errors on Apple Silicon. However, users will still see security warnings.
+
+**For "app is damaged" errors:**
+
+- The workflow should prevent this with ad-hoc signing
+- If it still occurs, users can run: `xattr -cr /Applications/humanlayer-wui.app`
+
+**For security warnings:**
+
+- This is expected for unsigned apps
+- Users must right-click and select "Open" for first launch
+- Or approve in System Settings > Privacy & Security

--- a/humanlayer-wui/RELEASE.md
+++ b/humanlayer-wui/RELEASE.md
@@ -40,27 +40,35 @@ The `push:` trigger in the workflow file is temporary and must be removed before
 2. Build typically takes 10-15 minutes
 3. Check each step for any errors
 
-## Downloading Artifacts
+## Workflow Results
 
 After successful completion:
 
-1. Scroll to the "Artifacts" section at the bottom
-2. Download all three artifacts:
+### For Push Triggers (Testing Only)
+
+1. Artifacts are uploaded to GitHub Actions
+2. Download from the "Artifacts" section at the bottom of the workflow run
+3. Three artifacts available:
    - `humanlayer-wui-macos-dmg` - The WUI application installer
    - `hld-darwin-arm64` - The daemon binary
    - `INSTALL` - Installation instructions
 
-## Creating a GitHub Release (Optional)
+### For Manual Triggers (workflow_dispatch)
 
-To create a formal release:
+1. A draft GitHub Release is automatically created
+2. All artifacts are attached to the release
+3. Release includes pre-formatted description and installation instructions
+4. Go to [Releases page](../../releases) to review and publish the draft
+
+## Publishing the Release
+
+When triggered via `workflow_dispatch`:
 
 1. Go to [Releases page](../../releases)
-2. Click "Draft a new release"
-3. Choose a tag: Enter the same version (e.g., `v0.1.0`)
-4. Release title: `HumanLayer v0.1.0 - macOS Release`
-5. Attach the three downloaded artifacts
-6. Add release notes
-7. Publish release
+2. Find the draft release with your version tag
+3. Review the auto-generated release notes
+4. Edit if needed (add changelog, known issues, etc.)
+5. Click "Publish release" to make it public
 
 ## Updating for New npm Versions
 


### PR DESCRIPTION
Creating PR to add macOS release workflow
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds GitHub Actions workflow for macOS release builds and documentation for usage and testing.
> 
>   - **Workflow**:
>     - Adds `release-macos.yml` for building macOS release artifacts using GitHub Actions.
>     - Supports manual trigger via `workflow_dispatch` with `release_version` input.
>     - Builds Tauri app and daemon for macOS ARM, uploads artifacts, and creates a draft GitHub release.
>   - **Environment Setup**:
>     - Uses `actions/checkout@v4`, `dtolnay/rust-toolchain@stable`, `actions/setup-go@v5`, and `oven-sh/setup-bun@v2`.
>     - Installs WUI dependencies and builds Tauri app with ad-hoc signing.
>   - **Documentation**:
>     - Adds `RELEASE.md` with usage guide, testing instructions, and troubleshooting tips.
>     - Describes steps for triggering builds, monitoring progress, and publishing releases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 05299b359b96491b444f8377ddee95ed92d184e6. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->