### PR TITLE
[ENG-1608] Fix false conflict detection in hlyr thoughts sync command

### DIFF
--- a/.claude/commands/create_plan.md
+++ b/.claude/commands/create_plan.md
@@ -325,6 +325,7 @@ After structure approval:
    - Research actual code patterns using parallel sub-tasks
    - Include specific file paths and line numbers
    - Write measurable success criteria with clear automated vs manual distinction
+   - automated steps should use `make` whenever possible - for example `make -C humanlayer-wui check` instead of `cd humanalyer-wui && bun run fmt`
 
 4. **Be Practical**:
    - Focus on incremental, testable changes

--- a/.claude/commands/linear.md
+++ b/.claude/commands/linear.md
@@ -180,6 +180,8 @@ new columns for permission_prompt_tool and allowed_tools..."
 Title: Fix resumed sessions to inherit all configuration from parent
 
 Description:
+
+## Problem to solve
 Currently, resumed sessions only inherit Model and WorkingDir from parent sessions,
 causing all other configuration to be lost. Users must re-specify permissions and
 settings when resuming.
@@ -303,6 +305,7 @@ When moving tickets through the workflow:
 ## Important Notes
 
 - Keep tickets concise but complete - aim for scannable content
+- All tickets should include a clear "problem to solve" - if the user asks for a ticket and only gives implementation details, you MUST ask "To write a good ticket, please explain the problem you're trying to solve from a user perspective"
 - Focus on the "what" and "why", include "how" only if well-defined
 - Always preserve links to source material using the `links` parameter
 - Don't create tickets from early-stage brainstorming unless requested
@@ -311,6 +314,7 @@ When moving tickets through the workflow:
 - Ask for clarification rather than guessing project/status
 - Remember that Linear descriptions support full markdown including code blocks
 - Always use the `links` parameter for external URLs (not just markdown links)
+- remember - you must get a "Problem to solve"!
 
 ## Comment Quality Guidelines
 

--- a/hlyr/src/commands/thoughts/sync.ts
+++ b/hlyr/src/commands/thoughts/sync.ts
@@ -55,7 +55,12 @@ function syncThoughts(thoughtsRepo: string, message: string): void {
       })
     } catch (error) {
       const errorStr = error.toString()
-      if (errorStr.includes('CONFLICT') || errorStr.includes('rebase')) {
+      if (
+        errorStr.includes('CONFLICT (') ||
+        errorStr.includes('Automatic merge failed') ||
+        errorStr.includes('Patch failed at') ||
+        errorStr.includes('When you have resolved this problem, run "git rebase --continue"')
+      ) {
         console.error(chalk.red('Error: Merge conflict detected in thoughts repository'))
         console.error(chalk.red('Please resolve conflicts manually in:'), expandedRepo)
         console.error(


### PR DESCRIPTION
## What problem(s) was I solving?

The `humanlayer thoughts sync` command was incorrectly detecting false conflicts due to an overly broad error string check. Any git error containing the word "rebase" was treated as a merge conflict, causing the sync process to exit prematurely and preventing the push operation from completing. This affected users in several scenarios:

- When specifying the wrong branch for rebase (e.g., "Please specify which branch you want to rebase against")
- During network failures or authentication issues 
- When there are uncommitted changes ("Cannot rebase: You have unstaged changes")
- Any other git error that happened to contain the word "rebase"

## What user-facing changes did I ship?

The thoughts sync command now correctly identifies only actual merge conflicts and allows the sync process to continue for other types of git errors. Users will see:

- Warnings instead of fatal errors for non-conflict git issues during pull
- The push operation will complete even if the pull fails for reasons other than conflicts
- More accurate error messages that distinguish between actual conflicts and other git issues

## How I implemented it

I replaced the overly broad conflict detection logic that checked for any occurrence of "rebase" with specific conflict indicators that only match actual merge conflicts:

- `CONFLICT (` - The opening of git's conflict messages like "CONFLICT (content):"
- `Automatic merge failed` - Git's message when merge conflicts prevent automatic resolution
- `Patch failed at` - Indicates a rebase conflict on a specific commit
- `When you have resolved this problem, run "git rebase --continue"` - Git's instruction that appears only during actual rebase conflicts

This change is minimal and focused, modifying only the error detection logic in `hlyr/src/commands/thoughts/sync.ts` without changing the overall sync flow or git commands used.

## How to verify it

- [x] I have ensured `make check test` passes

Manual verification steps:
- Run `humanlayer thoughts sync` in a repository with no conflicts - should complete successfully
- Create an actual merge conflict and verify it's still detected properly
- Test with network disconnected - should show warning but not claim conflict
- Test with uncommitted changes - should show warning but not claim conflict

## Description for the changelog

Fixed false conflict detection in `humanlayer thoughts sync` command that was preventing push operations when encountering non-conflict git errors containing the word "rebase"
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes false conflict detection in `humanlayer thoughts sync` command by refining error string checks to only identify actual merge conflicts.
> 
>   - **Behavior**:
>     - Refines conflict detection in `syncThoughts()` in `sync.ts` to only identify actual merge conflicts.
>     - Handles specific conflict indicators: `CONFLICT (`, `Automatic merge failed`, `Patch failed at`, and `When you have resolved this problem, run "git rebase --continue"`.
>     - Allows sync process to continue for non-conflict git errors, showing warnings instead of fatal errors.
>   - **Verification**:
>     - Manual tests include running sync in a conflict-free repo, creating actual conflicts, testing with network issues, and testing with uncommitted changes.
>   - **Misc**:
>     - Minor documentation updates in `.claude/commands/create_plan.md` and `.claude/commands/linear.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for e41925bf18d2bd61ef11d6f39cc0220903acaf1b. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->