### PR TITLE
dexter/eng 1799 add feedback button with keyboard shortcut and update

### DIFF
--- a/humanlayer-wui/src/components/Layout.tsx
+++ b/humanlayer-wui/src/components/Layout.tsx
@@ -13,6 +13,9 @@ import { useSessionEventsWithNotifications } from '@/hooks/useSessionEventsWithN
 import { Toaster } from 'sonner'
 import { notificationService } from '@/services/NotificationService'
 import { useTheme } from '@/contexts/ThemeContext'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { MessageCircle } from 'lucide-react'
+import { openUrl } from '@tauri-apps/plugin-opener'
 import '@/App.css'
 
 export function Layout() {
@@ -48,6 +51,17 @@ export function Layout() {
       preventDefault: true,
     },
   )
+
+  // Global hotkey for feedback
+  useHotkeys('mod+shift+f', async () => {
+    try {
+      await openUrl(
+        'https://github.com/humanlayer/humanlayer/issues/new?title=Feedback%20on%20CodeLayer&body=%23%23%23%20Problem%20to%20solve%20%2F%20Expected%20Behavior%0A%0A%0A%23%23%23%20Proposed%20solution',
+      )
+    } catch (error) {
+      console.error('Failed to open feedback URL:', error)
+    }
+  })
 
   // Connect to daemon on mount
   useEffect(() => {
@@ -213,6 +227,21 @@ export function Layout() {
           )}
         </div>
         <div className="flex items-center gap-3">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <a
+                href="https://github.com/humanlayer/humanlayer/issues/new?title=Feedback%20on%20CodeLayer&body=%23%23%23%20Problem%20to%20solve%20%2F%20Expected%20Behavior%0A%0A%0A%23%23%23%20Proposed%20solution"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center px-1.5 py-0.5 text-xs font-mono border border-border bg-background text-foreground hover:bg-accent/10 transition-colors"
+              >
+                <MessageCircle className="w-3 h-3" />
+              </a>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Submit feedback (⌘⇧F)</p>
+            </TooltipContent>
+          </Tooltip>
           <ThemeSelector />
           <div className="flex items-center gap-2 font-mono text-xs">
             <span className="uppercase tracking-wider">{status}</span>

--- a/humanlayer-wui/src/components/ThemeSelector.tsx
+++ b/humanlayer-wui/src/components/ThemeSelector.tsx
@@ -3,6 +3,7 @@ import { useTheme, type Theme } from '@/contexts/ThemeContext'
 import { Moon, Sun, Coffee, Cat, ScanEye, Framer, Box, Palette } from 'lucide-react'
 import { useHotkeys, useHotkeysContext } from 'react-hotkeys-hook'
 import { SessionTableHotkeysScope } from './internal/SessionTable'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
 const themes: { value: Theme; label: string; icon: React.ComponentType<{ className?: string }> }[] = [
   { value: 'solarized-dark', label: 'Solarized Dark', icon: Moon },
@@ -113,14 +114,20 @@ export function ThemeSelector() {
 
   return (
     <div className="relative">
-      <button
-        ref={buttonRef}
-        onClick={() => setIsOpen(!isOpen)}
-        className="px-1.5 py-0.5 text-xs font-mono border border-border bg-background text-foreground hover:bg-accent/10 transition-colors"
-        title={`Theme: ${currentTheme?.label || 'Unknown'}`}
-      >
-        {currentTheme ? <currentTheme.icon className="w-3 h-3" /> : <ScanEye className="w-3 h-3" />}
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            ref={buttonRef}
+            onClick={() => setIsOpen(!isOpen)}
+            className="px-1.5 py-0.5 text-xs font-mono border border-border bg-background text-foreground hover:bg-accent/10 transition-colors"
+          >
+            {currentTheme ? <currentTheme.icon className="w-3 h-3" /> : <ScanEye className="w-3 h-3" />}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Theme: {currentTheme?.label || 'Unknown'} (Ctrl+T)</p>
+        </TooltipContent>
+      </Tooltip>
 
       {isOpen && (
         <>

--- a/humanlayer-wui/src/contexts/ThemeContext.tsx
+++ b/humanlayer-wui/src/contexts/ThemeContext.tsx
@@ -23,7 +23,7 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = useState<Theme>(() => {
     const stored = localStorage.getItem('wui-theme')
-    return (stored as Theme) || 'solarized-dark'
+    return (stored as Theme) || 'catppuccin'
   })
 
   useEffect(() => {


### PR DESCRIPTION
## What problem(s) was I solving?

Users had no built-in way to submit feedback directly from the HumanLayer WUI application. They had to manually navigate to GitHub and create issues from scratch, which created unnecessary friction in the feedback process. Additionally, the default solarized-dark theme, while functional, wasn't providing the best first impression for new users.

## What user-facing changes did I ship?

1. **Feedback Button**: Added a new feedback button in the status bar next to the theme selector
   - Displays a MessageCircle icon in a styled box matching the theme selector
   - Includes a tooltip showing "Submit feedback (⌘⇧F)"
   - Opens a pre-filled GitHub issue template with structured sections

2. **Global Keyboard Shortcut**: Implemented `Cmd+Shift+F` (Mac) / `Ctrl+Shift+F` (Windows/Linux) to quickly open the feedback form from anywhere in the app

3. **Enhanced Theme Selector**: Added a tooltip to the theme selector showing the current theme name and its keyboard shortcut (Ctrl+T)

4. **Default Theme Change**: Updated the default theme from `solarized-dark` to `catppuccin` for a more appealing initial user experience

## How I implemented it

1. **Layout Component** (`humanlayer-wui/src/components/Layout.tsx`):
   - Imported Tauri's `openUrl` from `@tauri-apps/plugin-opener` for secure external URL handling
   - Added the feedback button as an anchor element styled to match the theme selector
   - Implemented the global hotkey using `useHotkeys` hook with proper error handling
   - Pre-filled the GitHub issue URL with a template including "Problem to solve" and "Proposed solution" sections

2. **Theme Selector** (`humanlayer-wui/src/components/ThemeSelector.tsx`):
   - Wrapped the theme button in a Tooltip component
   - Removed the HTML title attribute in favor of the richer tooltip experience
   - Displayed current theme name and keyboard shortcut in the tooltip

3. **Theme Context** (`humanlayer-wui/src/contexts/ThemeContext.tsx`):
   - Changed the default theme fallback from 'solarized-dark' to 'catppuccin'

4. **Security Considerations**:
   - Used Tauri's plugin-opener instead of `window.open()` for better security and cross-platform consistency
   - The plugin was already initialized in the Rust backend, so no backend changes were needed

## How to verify it

- [x] I have ensured `make check test` passes

**Manual Testing Required:**
- [ ] Click the feedback button and verify it opens GitHub with the pre-filled issue template
- [ ] Press Cmd+Shift+F (Mac) or Ctrl+Shift+F (Windows/Linux) and verify the keyboard shortcut works
- [ ] Hover over the feedback button and verify the tooltip shows "Submit feedback (⌘⇧F)"
- [ ] Hover over the theme selector and verify it shows the current theme and "(Ctrl+T)"
- [ ] Clear browser localStorage and verify the default theme is now catppuccin

## Description for the changelog

Added feedback button with global keyboard shortcut (Cmd+Shift+F) to quickly submit GitHub issues, enhanced UI tooltips, and updated default theme to catppuccin for better user experience.