### PR TITLE
fix ordering to install/build sdk first prior to wui

### DIFF
--- a/hack/setup_repo.sh
+++ b/hack/setup_repo.sh
@@ -33,16 +33,16 @@ run_silent "hlyr npm install" npm i -C hlyr
 run_silent "humanlayer-ts npm install" npm i -C humanlayer-ts
 run_silent "humanlayer-ts-vercel-ai-sdk npm install" npm i -C humanlayer-ts-vercel-ai-sdk
 
-echo "📦 Installing WUI dependencies..."
-run_silent "humanlayer-wui bun install" bun install --cwd=humanlayer-wui
-
 echo "📦 Installing HLD SDK dependencies..."
 run_silent "hld-sdk bun install" bun install --cwd=hld/sdk/typescript
 
-echo "🏗️  Building hlyr (requires mocks and npm dependencies)..."
-run_silent "hlyr build" npm run build -C hlyr
-
 echo "🏗️  Building HLD TypeScript SDK..."
 run_silent "hld-sdk build" sh -c "cd hld/sdk/typescript && bun run build"
+
+echo "📦 Installing WUI dependencies..."
+run_silent "humanlayer-wui bun install" bun install --cwd=humanlayer-wui
+
+echo "🏗️  Building hlyr (requires mocks and npm dependencies)..."
+run_silent "hlyr build" npm run build -C hlyr
 
 echo "✅ Repository setup complete!"


### PR DESCRIPTION
## What problem(s) was I solving?

`make check test` fails even with `make setup` due to hld sdk needing to build first

## What user-facing changes did I ship?

## How I implemented it

Make hld sdk build first prior to wui setup

## How to verify it

- [x] I have ensured `make check test` passes

## Description for the changelog

## A picture of a cute animal (not mandatory but encouraged)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reorders `setup_repo.sh` to install and build SDK before WUI to prevent dependency issues.
> 
>   - **Order Change**:
>     - Moved WUI dependency installation and build steps after SDK installation and build in `setup_repo.sh`.
>   - **Behavior**:
>     - Ensures SDK is installed and built before WUI, preventing potential dependency issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for d880aab9780158c6f67c9266ec4aa084c865fdcb. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->