### PR TITLE
Add display handlers for NotebookRead and NotebookEdit tools

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
@@ -195,6 +195,34 @@ export function eventToDisplayObject(
       )
     }
 
+    if (event.tool_name === 'NotebookRead') {
+      const toolInput = JSON.parse(event.tool_input_json!)
+      subject = (
+        <span>
+          <span className="font-bold">{event.tool_name} </span>
+          <span className="font-mono text-sm text-muted-foreground">{toolInput.notebook_path}</span>
+          {toolInput.cell_id && (
+            <span className="text-muted-foreground"> (cell: {toolInput.cell_id})</span>
+          )}
+        </span>
+      )
+    }
+
+    if (event.tool_name === 'NotebookEdit') {
+      const toolInput = JSON.parse(event.tool_input_json!)
+      const action = toolInput.edit_mode || 'replace'
+      subject = (
+        <span>
+          <span className="font-bold">{event.tool_name} </span>
+          <span className="text-muted-foreground">{action} cell in </span>
+          <span className="font-mono text-sm text-muted-foreground">{toolInput.notebook_path}</span>
+          {toolInput.cell_id && (
+            <span className="text-muted-foreground"> (cell: {toolInput.cell_id})</span>
+          )}
+        </span>
+      )
+    }
+
     if (event.tool_name === 'WebSearch') {
       iconComponent = <Globe className={iconClasses} />
       const toolInput = JSON.parse(event.tool_input_json!)
@@ -389,6 +417,35 @@ export function eventToDisplayObject(
           {snapshot && (
             <div className="mt-2 text-xs text-muted-foreground">
               Snapshot from: {formatTimestamp(snapshot.created_at)}
+            </div>
+          )}
+        </div>
+      )
+    }
+
+    if (event.tool_name === 'NotebookEdit') {
+      const toolInput = JSON.parse(event.tool_input_json!)
+      const action = toolInput.edit_mode || 'replace'
+
+      previewFile = (
+        <div className={`border ${getBorderClass()} rounded p-4 mt-4`}>
+          <div className="flex items-center gap-2 mb-2">
+            <FileText className="w-4 h-4" />
+            <span className="font-medium text-sm">Notebook Cell {action}</span>
+          </div>
+          <div className="font-mono text-xs text-muted-foreground mb-2">{toolInput.notebook_path}</div>
+          {toolInput.cell_id && (
+            <div className="text-xs text-muted-foreground mb-2">Cell ID: {toolInput.cell_id}</div>
+          )}
+          {toolInput.cell_type && (
+            <div className="text-xs text-muted-foreground mb-2">Cell Type: {toolInput.cell_type}</div>
+          )}
+          {action !== 'delete' && (
+            <div className="mt-3">
+              <div className="text-xs text-muted-foreground mb-1">New Content:</div>
+              <pre className="bg-muted/50 p-2 rounded text-xs overflow-x-auto">
+                <code>{toolInput.new_source}</code>
+              </pre>
             </div>
           )}
         </div>
@@ -604,6 +661,9 @@ export function getToolIcon(toolName: string | undefined): React.ReactNode {
       return <ListTodo className="w-3.5 h-3.5" />
     case 'WebSearch':
       return <Globe className="w-3.5 h-3.5" />
+    case 'NotebookRead':
+    case 'NotebookEdit':
+      return <FileText className="w-3.5 h-3.5" />
     default:
       return <Wrench className="w-3.5 h-3.5" />
   }


### PR DESCRIPTION
## What problem(s) was I solving?

The WUI (Web UI) was not properly displaying events for the NotebookRead and NotebookEdit tools. When these tools were used during a Claude Code session, they would show up as "Unknown Subject" or with empty text in the session detail view, making it difficult for users to understand what operations were being performed on Jupyter notebooks.

## What user-facing changes did I ship?

- **NotebookRead tool**: Now displays the tool name with the notebook file path and optional cell ID when reading specific cells
- **NotebookEdit tool**: Shows the tool name, action type (replace/insert/delete), notebook file path, and cell ID
- **Icon support**: Both notebook tools now display with an appropriate FileText icon
- **Approval preview**: NotebookEdit operations show detailed preview information including:
  - Cell type (code/markdown)
  - Cell ID being modified
  - The new content that will be written (for replace/insert operations)
  - Clear indication of the action being performed

## How I implemented it

I extended the `eventToDisplayObject` function in `humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx` to handle the NotebookRead and NotebookEdit tools:

1. **Tool name detection**: Added specific handling for both tools when rendering the subject line
2. **Subject formatting**: Created descriptive subject lines that include the notebook path and relevant cell information
3. **Preview rendering**: For NotebookEdit, implemented a detailed preview card showing all relevant information about the edit operation
4. **Icon mapping**: Added both tools to the `getToolIcon` function to display the FileText icon

The implementation follows the existing patterns in the codebase for other tools like Edit, MultiEdit, and Write, ensuring consistency in the user experience.

## How to verify it

- [x] I have ensured `make check test` passes

To manually verify:
1. Start a Claude Code session that uses Jupyter notebooks
2. Use the NotebookRead tool to read a notebook or specific cell
3. Use the NotebookEdit tool to modify notebook cells
4. Open the WUI and navigate to the session detail view
5. Verify that:
   - NotebookRead events show the notebook path and cell ID (if specified)
   - NotebookEdit events show the action type, path, and cell details
   - The preview for NotebookEdit shows the new content and cell metadata
   - Both tools display with the FileText icon

## Description for the changelog

Add proper display handlers for NotebookRead and NotebookEdit tools in the WUI, showing file paths, cell IDs, and edit previews instead of "Unknown Subject"