### PR TITLE
Remove legacy types and transformation logic in daemon client

### DIFF
--- a/hld/session/continue_inheritance_test.go
+++ b/hld/session/continue_inheritance_test.go
@@ -88,6 +88,7 @@ func TestContinueSessionInheritance(t *testing.T) {
 
 		if childSession == nil {
 			t.Fatal("Child session not found")
+			return // this return exists purely to satisfy the linter
 		}
 
 		// Verify all fields were inherited
@@ -202,6 +203,7 @@ func TestContinueSessionInheritance(t *testing.T) {
 
 		if childSession == nil {
 			t.Fatal("Child session not found")
+			return // this return exists purely to satisfy the linter
 		}
 
 		// Verify title was inherited
@@ -256,6 +258,7 @@ func TestContinueSessionInheritance(t *testing.T) {
 
 		if childSession == nil {
 			t.Fatal("Child session not found")
+			return // this return exists purely to satisfy the linter
 		}
 
 		// Verify empty title was inherited (should be empty)
@@ -332,6 +335,7 @@ func TestContinueSessionInheritance(t *testing.T) {
 
 		if childSession == nil {
 			t.Fatal("Child session not found")
+			return // this return exists purely to satisfy the linter
 		}
 
 		// Get MCP servers for child session
@@ -453,6 +457,7 @@ func TestContinueSessionInheritance(t *testing.T) {
 
 		if childSession == nil {
 			t.Fatal("Child session not found")
+			return // this return exists purely to satisfy the linter
 		}
 
 		// Verify overrides were applied
@@ -562,6 +567,7 @@ func TestContinueSessionInheritance(t *testing.T) {
 
 		if childSession == nil {
 			t.Fatal("Child session not found")
+			return // this return exists purely to satisfy the linter
 		}
 
 		// Get MCP servers for child
@@ -670,6 +676,7 @@ func TestContinueSessionInheritance(t *testing.T) {
 
 				if childSession == nil {
 					t.Fatal("Child session not found")
+					return // this return exists purely to satisfy the linter
 				}
 
 				// Verify title was inherited correctly
@@ -724,6 +731,7 @@ func TestContinueSessionInheritance(t *testing.T) {
 
 		if parentSession == nil {
 			t.Fatal("Parent session not found")
+			return // this return exists purely to satisfy the linter
 		}
 
 		// Verify parent inherited title
@@ -763,6 +771,7 @@ func TestContinueSessionInheritance(t *testing.T) {
 
 		if childSession == nil {
 			t.Fatal("Child session not found")
+			return // this return exists purely to satisfy the linter
 		}
 
 		// Verify child inherited the same original title

--- a/humanlayer-wui/src/AppStore.test.ts
+++ b/humanlayer-wui/src/AppStore.test.ts
@@ -1,10 +1,10 @@
 import { describe, test, expect, beforeEach } from 'bun:test'
 import { useStore } from './AppStore'
-import type { SessionInfo } from '@/lib/daemon/types'
+import type { Session } from '@/lib/daemon/types'
 import { createMockSessions } from './test-utils'
 
 // Mock sessions for testing
-const mockSessions: SessionInfo[] = createMockSessions(8)
+const mockSessions: Session[] = createMockSessions(8)
 
 describe('AppStore - Range Selection', () => {
   beforeEach(() => {

--- a/humanlayer-wui/src/AppStore.ts
+++ b/humanlayer-wui/src/AppStore.ts
@@ -1,26 +1,26 @@
-import type { SessionInfo } from '@/lib/daemon/types'
+import type { Session } from '@/lib/daemon/types'
 import { ViewMode } from '@/lib/daemon/types'
 import { create } from 'zustand'
 import { daemonClient } from '@/lib/daemon'
 
 interface StoreState {
   /* Sessions */
-  sessions: SessionInfo[]
-  focusedSession: SessionInfo | null
+  sessions: Session[]
+  focusedSession: Session | null
   viewMode: ViewMode
   selectedSessions: Set<string> // For bulk selection
   activeSessionDetail: {
-    session: SessionInfo
+    session: Session
     conversation: any[] // ConversationEvent[] from useConversation
     loading: boolean
     error: string | null
   } | null
 
-  initSessions: (sessions: SessionInfo[]) => void
-  updateSession: (sessionId: string, updates: Partial<SessionInfo>) => void
+  initSessions: (sessions: Session[]) => void
+  updateSession: (sessionId: string, updates: Partial<Session>) => void
   updateSessionStatus: (sessionId: string, status: string) => void
   refreshSessions: () => Promise<void>
-  setFocusedSession: (session: SessionInfo | null) => void
+  setFocusedSession: (session: Session | null) => void
   focusNextSession: () => void
   focusPreviousSession: () => void
   interruptSession: (sessionId: string) => Promise<void>
@@ -35,8 +35,8 @@ interface StoreState {
   bulkSelect: (sessionId: string, direction: 'asc' | 'desc') => void
 
   /* Active Session Detail Actions */
-  setActiveSessionDetail: (sessionId: string, session: SessionInfo, conversation: any[]) => void
-  updateActiveSessionDetail: (updates: Partial<SessionInfo>) => void
+  setActiveSessionDetail: (sessionId: string, session: Session, conversation: any[]) => void
+  updateActiveSessionDetail: (updates: Partial<Session>) => void
   updateActiveSessionConversation: (conversation: any[]) => void
   clearActiveSessionDetail: () => void
   fetchActiveSessionDetail: (sessionId: string) => Promise<void>
@@ -64,8 +64,8 @@ export const useStore = create<StoreState>((set, get) => ({
   viewMode: ViewMode.Normal,
   selectedSessions: new Set<string>(),
   activeSessionDetail: null,
-  initSessions: (sessions: SessionInfo[]) => set({ sessions }),
-  updateSession: (sessionId: string, updates: Partial<SessionInfo>) =>
+  initSessions: (sessions: Session[]) => set({ sessions }),
+  updateSession: (sessionId: string, updates: Partial<Session>) =>
     set(state => ({
       sessions: state.sessions.map(session =>
         session.id === sessionId ? { ...session, ...updates } : session,
@@ -113,7 +113,7 @@ export const useStore = create<StoreState>((set, get) => ({
       console.error('Failed to refresh sessions:', error)
     }
   },
-  setFocusedSession: (session: SessionInfo | null) => set({ focusedSession: session }),
+  setFocusedSession: (session: Session | null) => set({ focusedSession: session }),
   focusNextSession: () =>
     set(state => {
       const { sessions, focusedSession } = state
@@ -491,9 +491,9 @@ export const useStore = create<StoreState>((set, get) => ({
   },
 
   // Active Session Detail Actions
-  setActiveSessionDetail: (_sessionId: string, session: SessionInfo, conversation: any[]) =>
+  setActiveSessionDetail: (_sessionId: string, session: Session, conversation: any[]) =>
     set({ activeSessionDetail: { session, conversation, loading: false, error: null } }),
-  updateActiveSessionDetail: (updates: Partial<SessionInfo>) =>
+  updateActiveSessionDetail: (updates: Partial<Session>) =>
     set(state => ({
       activeSessionDetail: state.activeSessionDetail
         ? {
@@ -516,7 +516,7 @@ export const useStore = create<StoreState>((set, get) => ({
     // Set loading state
     set({
       activeSessionDetail: {
-        session: {} as SessionInfo, // Temporary placeholder
+        session: {} as Session, // Temporary placeholder
         conversation: [],
         loading: true,
         error: null,
@@ -543,7 +543,7 @@ export const useStore = create<StoreState>((set, get) => ({
 
       set({
         activeSessionDetail: {
-          session: {} as SessionInfo,
+          session: {} as Session,
           conversation: [],
           loading: false,
           error: errorMessage,

--- a/humanlayer-wui/src/components/Layout.tsx
+++ b/humanlayer-wui/src/components/Layout.tsx
@@ -205,14 +205,13 @@ export function Layout() {
                       className="p-4 border border-border bg-secondary/20 font-mono text-sm"
                     >
                       <div className="mb-2">
-                        <span className="text-accent">Tool:</span> {approval.tool_name}
+                        <span className="text-accent">Tool:</span> {approval.toolName}
                       </div>
                       <div className="mb-2">
-                        <span className="text-accent">Session:</span> {approval.session_id.slice(0, 8)}
+                        <span className="text-accent">Session:</span> {approval.sessionId.slice(0, 8)}
                       </div>
                       <div className="mb-3">
-                        <span className="text-accent">Input:</span>{' '}
-                        {JSON.stringify(approval.tool_input)}
+                        <span className="text-accent">Input:</span> {JSON.stringify(approval.toolInput)}
                       </div>
                       <div className="flex gap-2">
                         <Button onClick={() => handleApproval(approval, true)} size="sm">

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -380,12 +380,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
 
       // Check if session is active (requires confirmation)
       const isActiveSession = (
-        [
-          SessionStatus.Starting,
-          SessionStatus.Running,
-          SessionStatus.Interrupting,
-          SessionStatus.WaitingInput,
-        ] as SessionStatus[]
+        [SessionStatus.Starting, SessionStatus.Running, SessionStatus.WaitingInput] as SessionStatus[]
       ).includes(session.status)
 
       const isArchiving = !session.archived

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { toast } from 'sonner'
 
-import { ConversationEvent, SessionInfo, ApprovalStatus, SessionStatus } from '@/lib/daemon/types'
+import { ConversationEvent, Session, ApprovalStatus, SessionStatus } from '@/lib/daemon/types'
 import { Card, CardContent } from '@/components/ui/card'
 import { useConversation, useKeyboardNavigationProtection } from '@/hooks'
 import { ChevronDown, Archive, Pencil } from 'lucide-react'
@@ -32,7 +32,7 @@ import { useSessionClipboard } from './hooks/useSessionClipboard'
 import { useStealHotkeyScope } from '@/hooks/useStealHotkeyScope'
 
 interface SessionDetailProps {
-  session: SessionInfo
+  session: Session
   onClose: () => void
 }
 
@@ -136,7 +136,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
 
   // Get session from store to access auto_accept_edits
   const sessionFromStore = useStore(state => state.sessions.find(s => s.id === session.id))
-  const autoAcceptEdits = sessionFromStore?.auto_accept_edits ?? false
+  const autoAcceptEdits = sessionFromStore?.autoAcceptEdits ?? false
 
   // Generate random verb that changes every 10-20 seconds
   const [randomVerb, setRandomVerb] = useState(() => {
@@ -243,15 +243,15 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
 
       // Find the selected user message
       const selectedEvent = events[eventIndex]
-      if (selectedEvent?.event_type === 'message' && selectedEvent?.role === 'user') {
+      if (selectedEvent?.eventType === 'message' && selectedEvent?.role === 'user') {
         // Find the session ID from the event before this one
         const previousEvent = eventIndex > 0 ? events[eventIndex - 1] : null
-        const forkFromSessionId = previousEvent?.session_id || session.id
+        const forkFromSessionId = previousEvent?.sessionId || session.id
 
         // Store both the message content and the session ID to fork from
         setPendingForkMessage({
           ...selectedEvent,
-          session_id: forkFromSessionId, // Override with the previous event's session ID
+          sessionId: forkFromSessionId, // Override with the previous event's session ID
         })
       }
     },
@@ -298,7 +298,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
 
   const lastTodo = events
     ?.toReversed()
-    .find(e => e.event_type === 'tool_call' && e.tool_name === 'TodoWrite')
+    .find(e => e.eventType === 'tool_call' && e.toolName === 'TodoWrite')
 
   // Clear focus on escape, then close if nothing focused
   // This needs special handling for confirmingApprovalId
@@ -523,7 +523,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
   useEffect(() => {
     const checkPendingApprovalVisibility = () => {
       if (session.status === SessionStatus.WaitingInput) {
-        const pendingEvent = events.find(e => e.approval_status === ApprovalStatus.Pending)
+        const pendingEvent = events.find(e => e.approvalStatus === ApprovalStatus.Pending)
         if (pendingEvent) {
           const container = document.querySelector('[data-conversation-container]')
           const element = container?.querySelector(`[data-event-id="${pendingEvent.id}"]`)
@@ -603,7 +603,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
                 <>
                   <span>
                     {session.title || session.summary || truncate(session.query, 50)}{' '}
-                    {session.parent_session_id && (
+                    {session.parentSessionId && (
                       <span className="text-muted-foreground">[continued]</span>
                     )}
                   </span>
@@ -629,8 +629,8 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
                 </span>
               )}
             </small>
-            {session.working_dir && (
-              <small className="font-mono text-xs text-muted-foreground">{session.working_dir}</small>
+            {session.workingDir && (
+              <small className="font-mono text-xs text-muted-foreground">{session.workingDir}</small>
             )}
           </hgroup>
           <ForkViewModal
@@ -686,7 +686,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
                 <>
                   <span>
                     {session.title || session.summary || truncate(session.query, 50)}{' '}
-                    {session.parent_session_id && (
+                    {session.parentSessionId && (
                       <span className="text-muted-foreground">[continued]</span>
                     )}
                   </span>
@@ -732,7 +732,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
             {
               events
                 .slice(0, previewEventIndex)
-                .filter(e => e.event_type === 'message' && e.role === 'user').length
+                .filter(e => e.eventType === 'message' && e.role === 'user').length
             }
           </span>
         </div>

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/EventMetaInfo.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/EventMetaInfo.tsx
@@ -15,7 +15,7 @@ export function EventMetaInfo({ event }: { event: ConversationEvent }) {
         </div>
         <div>
           <span className="font-medium text-muted-foreground">Type:</span>
-          <span className="ml-2 font-mono">{event.event_type}</span>
+          <span className="ml-2 font-mono">{event.eventType}</span>
         </div>
         <div>
           <span className="font-medium text-muted-foreground">Role:</span>
@@ -24,47 +24,47 @@ export function EventMetaInfo({ event }: { event: ConversationEvent }) {
         <div>
           <span className="font-medium text-muted-foreground">Created:</span>
           <span className="ml-2 font-mono text-xs">
-            {event.created_at ? formatAbsoluteTimestamp(event.created_at) : 'Unknown'}
+            {event.createdAt ? formatAbsoluteTimestamp(event.createdAt) : 'Unknown'}
           </span>
         </div>
         <div>
           <span className="font-medium text-muted-foreground">Completed:</span>
-          <span className="ml-2">{event.is_completed ? '✓' : '⏳'}</span>
+          <span className="ml-2">{event.isCompleted ? '✓' : '⏳'}</span>
         </div>
-        {event.tool_name && (
+        {event.toolName && (
           <>
             <div>
               <span className="font-medium text-muted-foreground">Tool:</span>
-              <span className="ml-2 font-mono">{event.tool_name}</span>
+              <span className="ml-2 font-mono">{event.toolName}</span>
             </div>
             <div>
               <span className="font-medium text-muted-foreground">Tool ID:</span>
-              <span className="ml-2 font-mono text-xs">{event.tool_id}</span>
+              <span className="ml-2 font-mono text-xs">{event.toolId}</span>
             </div>
           </>
         )}
-        {event.approval_status && (
+        {event.approvalStatus && (
           <div>
             <span className="font-medium text-muted-foreground">Approval:</span>
-            <span className="ml-2 font-mono">{event.approval_status}</span>
+            <span className="ml-2 font-mono">{event.approvalStatus}</span>
           </div>
         )}
       </div>
 
-      {event.tool_input_json && (
+      {event.toolInputJson && (
         <div className="mt-3">
           <span className="font-medium text-muted-foreground">Tool Input:</span>
           <pre className="mt-1 text-xs bg-background rounded p-2 overflow-x-auto">
-            {JSON.stringify(JSON.parse(event.tool_input_json), null, 2)}
+            {JSON.stringify(JSON.parse(event.toolInputJson), null, 2)}
           </pre>
         </div>
       )}
 
-      {event.tool_result_content && (
+      {event.toolResultContent && (
         <div className="mt-3">
           <span className="font-medium text-muted-foreground">Tool Result:</span>
           <pre className="mt-1 text-xs bg-background rounded p-2 overflow-x-auto max-h-32 overflow-y-auto">
-            {event.tool_result_content}
+            {event.toolResultContent}
           </pre>
         </div>
       )}

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ForkViewModal.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ForkViewModal.tsx
@@ -54,7 +54,7 @@ function ForkViewModalContent({
   // Filter to only user messages (excluding the first one)
   const userMessageIndices = events
     .map((e, i) => ({ event: e, index: i }))
-    .filter(({ event }) => event.event_type === 'message' && event.role === 'user')
+    .filter(({ event }) => event.eventType === 'message' && event.role === 'user')
     .slice(1) // Exclude first message since it can't be forked
 
   // Add current option as a special index (-1) only if session is not failed

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseInput.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseInput.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
-import { SessionInfo, SessionStatus } from '@/lib/daemon/types'
+import { Session, SessionStatus } from '@/lib/daemon/types'
 import {
   getSessionStatusText,
   getInputPlaceholder,
@@ -11,7 +11,7 @@ import {
 import { GitBranch } from 'lucide-react'
 
 interface ResponseInputProps {
-  session: SessionInfo
+  session: Session
   responseInput: string
   setResponseInput: (input: string) => void
   isResponding: boolean

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/TodoWidget.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/TodoWidget.tsx
@@ -5,7 +5,7 @@ import { CheckCircle, CircleDashed, Hourglass } from 'lucide-react'
 // TODO(3): Add animations for status changes
 
 export function TodoWidget({ event }: { event: ConversationEvent }) {
-  const toolInput = JSON.parse(event.tool_input_json!)
+  const toolInput = JSON.parse(event.toolInputJson!)
   const todos = toolInput.todos
   const completedCount = todos.filter((todo: any) => todo.status === 'completed').length
   const pendingCount = todos.filter((todo: any) => todo.status === 'pending').length

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ToolResultModal.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ToolResultModal.tsx
@@ -95,15 +95,15 @@ export function ToolResultModal({
           <DialogTitle className="text-sm font-mono">
             <div className="flex items-center gap-2">
               {/* Add tool icon */}
-              <span className="text-accent">{getToolIcon(toolCall?.tool_name)}</span>
+              <span className="text-accent">{getToolIcon(toolCall?.toolName)}</span>
               <span>
-                {toolCall?.tool_name || 'Tool Result'}
-                {!toolResult && toolCall && !toolCall.is_completed && (
+                {toolCall?.toolName || 'Tool Result'}
+                {!toolResult && toolCall && !toolCall.isCompleted && (
                   <span className="text-xs text-muted-foreground ml-2">(in progress)</span>
                 )}
               </span>
               {/* Show primary parameter */}
-              {toolCall?.tool_input_json && (
+              {toolCall?.toolInputJson && (
                 <span className="text-xs text-muted-foreground">{getToolPrimaryParam(toolCall)}</span>
               )}
             </div>
@@ -114,7 +114,7 @@ export function ToolResultModal({
           <ScrollArea className="h-full">
             <div className="px-4 py-4 space-y-4">
               {/* Tool Input Section */}
-              {toolCall?.tool_input_json && (
+              {toolCall?.toolInputJson && (
                 <div>
                   <h3 className="text-sm font-medium text-muted-foreground mb-2">Input</h3>
                   {renderToolInput(toolCall)}
@@ -126,7 +126,7 @@ export function ToolResultModal({
                 <div>
                   <h3 className="text-sm font-medium text-muted-foreground mb-2">Result</h3>
                   <pre className="font-mono text-sm whitespace-pre-wrap break-words">
-                    {toolResult.tool_result_content || 'No content'}
+                    {toolResult.toolResultContent || 'No content'}
                   </pre>
                 </div>
               )}
@@ -159,21 +159,21 @@ function formatToolInput(inputJson: string | undefined): string {
 }
 
 function getToolPrimaryParam(toolCall: ConversationEvent): string {
-  if (!toolCall.tool_input_json) return ''
+  if (!toolCall.toolInputJson) return ''
 
   try {
-    const args = JSON.parse(toolCall.tool_input_json)
+    const args = JSON.parse(toolCall.toolInputJson)
 
     // Show the most relevant argument based on tool name
-    if (toolCall.tool_name === 'Read' && args.file_path) {
+    if (toolCall.toolName === 'Read' && args.file_path) {
       return args.file_path
-    } else if (toolCall.tool_name === 'Bash' && args.command) {
+    } else if (toolCall.toolName === 'Bash' && args.command) {
       return truncate(args.command, 60)
-    } else if (toolCall.tool_name === 'Edit' && args.file_path) {
+    } else if (toolCall.toolName === 'Edit' && args.file_path) {
       return args.file_path
-    } else if (toolCall.tool_name === 'Write' && args.file_path) {
+    } else if (toolCall.toolName === 'Write' && args.file_path) {
       return args.file_path
-    } else if (toolCall.tool_name === 'Grep' && args.pattern) {
+    } else if (toolCall.toolName === 'Grep' && args.pattern) {
       return args.pattern
     }
 
@@ -186,14 +186,14 @@ function getToolPrimaryParam(toolCall: ConversationEvent): string {
 }
 
 function renderToolInput(toolCall: ConversationEvent): React.ReactNode {
-  if (!toolCall.tool_input_json) return null
+  if (!toolCall.toolInputJson) return null
 
   try {
-    const args = JSON.parse(toolCall.tool_input_json)
+    const args = JSON.parse(toolCall.toolInputJson)
 
     // Special rendering for MCP tools
-    if (toolCall.tool_name?.startsWith('mcp__')) {
-      const parts = toolCall.tool_name.split('__')
+    if (toolCall.toolName?.startsWith('mcp__')) {
+      const parts = toolCall.toolName.split('__')
       const service = parts[1] || 'unknown'
       const method = parts.slice(2).join('__') || 'unknown'
 
@@ -220,7 +220,7 @@ function renderToolInput(toolCall: ConversationEvent): React.ReactNode {
     }
 
     // Special rendering for Write tool
-    if (toolCall.tool_name === 'Write') {
+    if (toolCall.toolName === 'Write') {
       return (
         <div className="space-y-2">
           <div className="font-mono text-sm">
@@ -238,7 +238,7 @@ function renderToolInput(toolCall: ConversationEvent): React.ReactNode {
     }
 
     // Special rendering for Edit tool
-    if (toolCall.tool_name === 'Edit') {
+    if (toolCall.toolName === 'Edit') {
       return (
         <div className="space-y-2">
           <div className="font-mono text-sm">
@@ -256,7 +256,7 @@ function renderToolInput(toolCall: ConversationEvent): React.ReactNode {
     }
 
     // Special rendering for MultiEdit tool
-    if (toolCall.tool_name === 'MultiEdit') {
+    if (toolCall.toolName === 'MultiEdit') {
       const allEdits = args.edits.map((e: any) => ({
         oldValue: e.old_string,
         newValue: e.new_string,
@@ -281,14 +281,14 @@ function renderToolInput(toolCall: ConversationEvent): React.ReactNode {
     // Default JSON rendering for other tools
     return (
       <pre className="font-mono text-sm whitespace-pre-wrap bg-muted/50 rounded-md p-4 break-words">
-        {formatToolInput(toolCall.tool_input_json)}
+        {formatToolInput(toolCall.toolInputJson)}
       </pre>
     )
   } catch {
     // Fallback to raw display if JSON parsing fails
     return (
       <pre className="font-mono text-sm whitespace-pre-wrap bg-muted/50 rounded-md p-4 break-words">
-        {toolCall.tool_input_json}
+        {toolCall.toolInputJson}
       </pre>
     )
   }

--- a/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
@@ -424,8 +424,8 @@ export function eventToDisplayObject(
       )
     }
 
-    if (event.tool_name === 'NotebookEdit') {
-      const toolInput = JSON.parse(event.tool_input_json!)
+    if (event.toolName === 'NotebookEdit') {
+      const toolInput = JSON.parse(event.toolInputJson!)
       const action = toolInput.edit_mode || 'replace'
 
       previewFile = (

--- a/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
@@ -65,18 +65,18 @@ export function eventToDisplayObject(
   // console.log('event', event)
   // Check if this is a thinking message
   const isThinking =
-    event.event_type === ConversationEventType.Thinking ||
+    event.eventType === ConversationEventType.Thinking ||
     (event.role === 'assistant' && event.content?.startsWith('<thinking>'))
 
-  const iconClasses = `w-4 h-4 align-middle relative top-[1px] ${event.event_type === ConversationEventType.ToolCall && !event.is_completed ? 'pulse-warning' : ''}`
+  const iconClasses = `w-4 h-4 align-middle relative top-[1px] ${event.eventType === ConversationEventType.ToolCall && !event.isCompleted ? 'pulse-warning' : ''}`
 
   // Tool Calls
-  if (event.event_type === ConversationEventType.ToolCall) {
+  if (event.eventType === ConversationEventType.ToolCall) {
     iconComponent = <Wrench className={iconClasses} />
 
     // Claude Code converts "LS" to "List"
-    if (event.tool_name === 'LS') {
-      const toolInput = JSON.parse(event.tool_input_json!)
+    if (event.toolName === 'LS') {
+      const toolInput = JSON.parse(event.toolInputJson!)
       subject = (
         <span>
           <span className="font-bold">List </span>
@@ -85,21 +85,21 @@ export function eventToDisplayObject(
       )
     }
 
-    if (event.tool_name === 'Read') {
-      const toolInput = JSON.parse(event.tool_input_json!)
+    if (event.toolName === 'Read') {
+      const toolInput = JSON.parse(event.toolInputJson!)
       subject = (
         <span>
-          <span className="font-bold">{event.tool_name} </span>
+          <span className="font-bold">{event.toolName} </span>
           <span className="font-mono text-sm text-muted-foreground">{toolInput.file_path}</span>
         </span>
       )
     }
 
-    if (event.tool_name === 'Glob') {
-      const toolInput = JSON.parse(event.tool_input_json!)
+    if (event.toolName === 'Glob') {
+      const toolInput = JSON.parse(event.toolInputJson!)
       subject = (
         <span>
-          <span className="font-bold">{event.tool_name} </span>
+          <span className="font-bold">{event.toolName} </span>
           <span className="font-mono text-sm text-muted-foreground">
             <span className="font-bold">{toolInput.pattern}</span> against{' '}
             <span className="font-bold">{toolInput.path}</span>
@@ -108,12 +108,12 @@ export function eventToDisplayObject(
       )
     }
 
-    if (event.tool_name === 'Bash') {
-      const toolInput = JSON.parse(event.tool_input_json!)
+    if (event.toolName === 'Bash') {
+      const toolInput = JSON.parse(event.toolInputJson!)
       subject = (
         <span>
           <div className="flex items-baseline gap-2">
-            <span className="font-bold">{event.tool_name} </span>
+            <span className="font-bold">{event.toolName} </span>
             {toolInput.description && (
               <span className="text-sm text-muted-foreground">{toolInput.description}</span>
             )}
@@ -125,18 +125,18 @@ export function eventToDisplayObject(
       )
     }
 
-    if (event.tool_name === 'Task') {
-      const toolInput = JSON.parse(event.tool_input_json!)
+    if (event.toolName === 'Task') {
+      const toolInput = JSON.parse(event.toolInputJson!)
       subject = (
         <span>
-          <span className="font-bold">{event.tool_name} </span>
+          <span className="font-bold">{event.toolName} </span>
           <span className="font-mono text-sm text-muted-foreground">{toolInput.description}</span>
         </span>
       )
     }
 
-    if (event.tool_name === 'TodoWrite') {
-      const toolInput = JSON.parse(event.tool_input_json!)
+    if (event.toolName === 'TodoWrite') {
+      const toolInput = JSON.parse(event.toolInputJson!)
       const todos = toolInput.todos
       const completedCount = todos.filter((todo: any) => todo.status === 'completed').length
       const pendingCount = todos.filter((todo: any) => todo.status === 'pending').length
@@ -151,21 +151,21 @@ export function eventToDisplayObject(
       )
     }
 
-    if (event.tool_name === 'Edit') {
-      const toolInput = JSON.parse(event.tool_input_json!)
+    if (event.toolName === 'Edit') {
+      const toolInput = JSON.parse(event.toolInputJson!)
       subject = (
         <span>
-          <span className="font-bold">{event.tool_name} </span>
+          <span className="font-bold">{event.toolName} </span>
           <span className="font-mono text-sm text-muted-foreground">to {toolInput.file_path}</span>
         </span>
       )
     }
 
-    if (event.tool_name === 'MultiEdit') {
-      const toolInput = JSON.parse(event.tool_input_json!)
+    if (event.toolName === 'MultiEdit') {
+      const toolInput = JSON.parse(event.toolInputJson!)
       subject = (
         <span>
-          <span className="font-bold">{event.tool_name} </span>
+          <span className="font-bold">{event.toolName} </span>
           <span className="font-mono text-sm text-muted-foreground">
             {toolInput.edits.length} edit{toolInput.edits.length === 1 ? '' : 's'} to{' '}
             {toolInput.file_path}
@@ -174,32 +174,32 @@ export function eventToDisplayObject(
       )
     }
 
-    if (event.tool_name === 'Grep') {
-      const toolInput = JSON.parse(event.tool_input_json!)
+    if (event.toolName === 'Grep') {
+      const toolInput = JSON.parse(event.toolInputJson!)
       subject = (
         <span>
-          <span className="font-bold">{event.tool_name} </span>
+          <span className="font-bold">{event.toolName} </span>
           <span className="font-mono text-sm text-muted-foreground">{toolInput.pattern}</span>
         </span>
       )
     }
 
-    if (event.tool_name === 'Write') {
+    if (event.toolName === 'Write') {
       iconComponent = <FilePenLine className={iconClasses} />
-      const toolInput = JSON.parse(event.tool_input_json!)
+      const toolInput = JSON.parse(event.toolInputJson!)
       subject = (
         <span>
-          <span className="font-bold">{event.tool_name} </span>
+          <span className="font-bold">{event.toolName} </span>
           <span className="font-mono text-sm text-muted-foreground">{toolInput.file_path}</span>
         </span>
       )
     }
 
-    if (event.tool_name === 'NotebookRead') {
-      const toolInput = JSON.parse(event.tool_input_json!)
+    if (event.toolName === 'NotebookRead') {
+      const toolInput = JSON.parse(event.toolInputJson!)
       subject = (
         <span>
-          <span className="font-bold">{event.tool_name} </span>
+          <span className="font-bold">{event.toolName} </span>
           <span className="font-mono text-sm text-muted-foreground">{toolInput.notebook_path}</span>
           {toolInput.cell_id && (
             <span className="text-muted-foreground"> (cell: {toolInput.cell_id})</span>
@@ -208,12 +208,12 @@ export function eventToDisplayObject(
       )
     }
 
-    if (event.tool_name === 'NotebookEdit') {
-      const toolInput = JSON.parse(event.tool_input_json!)
+    if (event.toolName === 'NotebookEdit') {
+      const toolInput = JSON.parse(event.toolInputJson!)
       const action = toolInput.edit_mode || 'replace'
       subject = (
         <span>
-          <span className="font-bold">{event.tool_name} </span>
+          <span className="font-bold">{event.toolName} </span>
           <span className="text-muted-foreground">{action} cell in </span>
           <span className="font-mono text-sm text-muted-foreground">{toolInput.notebook_path}</span>
           {toolInput.cell_id && (
@@ -223,9 +223,9 @@ export function eventToDisplayObject(
       )
     }
 
-    if (event.tool_name === 'WebSearch') {
+    if (event.toolName === 'WebSearch') {
       iconComponent = <Globe className={iconClasses} />
-      const toolInput = JSON.parse(event.tool_input_json!)
+      const toolInput = JSON.parse(event.toolInputJson!)
       subject = (
         <span>
           <span className="font-bold">Web Search </span>
@@ -235,13 +235,13 @@ export function eventToDisplayObject(
     }
 
     // MCP tool handling
-    if (event.tool_name?.startsWith('mcp__')) {
+    if (event.toolName?.startsWith('mcp__')) {
       // Parse the MCP tool name: mcp__service__method
-      const parts = event.tool_name.split('__')
+      const parts = event.toolName.split('__')
       const service = parts[1] || 'unknown'
       const method = parts.slice(2).join('__') || 'unknown' // Handle methods with __ in name
 
-      const toolInput = event.tool_input_json ? JSON.parse(event.tool_input_json) : {}
+      const toolInput = event.toolInputJson ? JSON.parse(event.toolInputJson) : {}
 
       subject = (
         <span>
@@ -275,18 +275,19 @@ export function eventToDisplayObject(
   const formattedToolSubject = subject
 
   // Approvals
-  if (event.approval_status) {
-    const approvalStatusToColor = {
+  if (event.approvalStatus) {
+    const approvalStatusToColor: Record<string, string> = {
       [ApprovalStatus.Pending]: 'text-[var(--terminal-warning)]',
       [ApprovalStatus.Approved]: 'text-[var(--terminal-success)]',
       [ApprovalStatus.Denied]: 'text-[var(--terminal-error)]',
+      resolved: 'text-[var(--terminal-success)]', // Add resolved status
     }
     iconComponent = <UserCheck className={iconClasses} />
     let previewFile = null
 
     // Get border class based on approval status
     const getBorderClass = () => {
-      switch (event.approval_status) {
+      switch (event.approvalStatus) {
         case ApprovalStatus.Pending:
           return 'border-dashed border-muted-foreground'
         case ApprovalStatus.Approved:
@@ -299,14 +300,14 @@ export function eventToDisplayObject(
     }
 
     // For Write tool calls, display the file contents in a nice format
-    if (event.tool_name === 'Write') {
-      const toolInput = JSON.parse(event.tool_input_json!)
+    if (event.toolName === 'Write') {
+      const toolInput = JSON.parse(event.toolInputJson!)
       const snapshot = getSnapshot?.(toolInput.file_path)
 
       previewFile = (
         <div className={`border ${getBorderClass()} rounded p-4 mt-4`}>
           <div className="mb-4">
-            {event.approval_status ? (
+            {event.approvalStatus ? (
               <span className="font-mono text-sm text-muted-foreground">
                 <span className="font-bold">{toolInput.file_path}</span>
               </span>
@@ -333,15 +334,15 @@ export function eventToDisplayObject(
       )
     }
 
-    if (event.tool_name === 'Edit') {
-      const toolInput = JSON.parse(event.tool_input_json!)
+    if (event.toolName === 'Edit') {
+      const toolInput = JSON.parse(event.toolInputJson!)
       const snapshot = getSnapshot?.(toolInput.file_path)
 
       previewFile = (
         <div className={`border ${getBorderClass()} rounded p-4 mt-4`}>
           <div className="mb-4 flex items-center justify-between">
             <div>
-              {event.approval_status ? (
+              {event.approvalStatus ? (
                 <span className="font-mono text-sm text-muted-foreground">
                   <span className="font-bold">{toolInput.file_path}</span>
                 </span>
@@ -354,7 +355,7 @@ export function eventToDisplayObject(
                 </>
               )}
             </div>
-            {event.approval_status === ApprovalStatus.Pending && (
+            {event.approvalStatus === ApprovalStatus.Pending && (
               <DiffViewToggle
                 isSplitView={isSplitView ?? false}
                 onToggle={onToggleSplitView ?? (() => {})}
@@ -375,8 +376,8 @@ export function eventToDisplayObject(
       )
     }
 
-    if (event.tool_name === 'MultiEdit') {
-      const toolInput = JSON.parse(event.tool_input_json!)
+    if (event.toolName === 'MultiEdit') {
+      const toolInput = JSON.parse(event.toolInputJson!)
       const snapshot = getSnapshot?.(toolInput.file_path)
       const allEdits = toolInput.edits.map((e: any) => ({
         oldValue: e.old_string,
@@ -387,7 +388,7 @@ export function eventToDisplayObject(
         <div className={`border ${getBorderClass()} rounded p-4 mt-4`}>
           <div className="mb-4 flex items-center justify-between">
             <div>
-              {event.approval_status ? (
+              {event.approvalStatus ? (
                 <span className="font-mono text-sm text-muted-foreground">
                   {toolInput.edits.length} edit{toolInput.edits.length === 1 ? '' : 's'} to{' '}
                   <span className="font-bold">{toolInput.file_path}</span>
@@ -402,7 +403,7 @@ export function eventToDisplayObject(
                 </>
               )}
             </div>
-            {event.approval_status === ApprovalStatus.Pending && (
+            {event.approvalStatus === ApprovalStatus.Pending && (
               <DiffViewToggle
                 isSplitView={isSplitView ?? false}
                 onToggle={onToggleSplitView ?? (() => {})}
@@ -457,10 +458,10 @@ export function eventToDisplayObject(
       subject = (
         <span>
           <div className="flex items-baseline gap-2">
-            <span className={`${approvalStatusToColor[event.approval_status]}`}>
+            <span className={`${approvalStatusToColor[event.approvalStatus]}`}>
               {formattedToolSubject}
             </span>
-            {event.approval_status === ApprovalStatus.Pending && (
+            {event.approvalStatus === ApprovalStatus.Pending && (
               <span className="text-sm text-muted-foreground">(needs approval)</span>
             )}
           </div>
@@ -471,22 +472,22 @@ export function eventToDisplayObject(
       // Fallback to original behavior for tools without special formatting
       subject = (
         <span>
-          <span className={`font-bold ${approvalStatusToColor[event.approval_status]}`}>
-            {event.tool_name}
+          <span className={`font-bold ${approvalStatusToColor[event.approvalStatus]}`}>
+            {event.toolName}
           </span>
-          {event.approval_status === ApprovalStatus.Pending && (
+          {event.approvalStatus === ApprovalStatus.Pending && (
             <span className="ml-2 text-sm text-muted-foreground">(needs approval)</span>
           )}
-          {!previewFile && <div className="mt-4">{formatJson(event.tool_input_json!)}</div>}
+          {!previewFile && <div className="mt-4">{formatJson(event.toolInputJson!)}</div>}
           {previewFile}
         </span>
       )
     }
 
     // Add approve/deny buttons for pending approvals
-    if (event.approval_status === ApprovalStatus.Pending && event.approval_id && onApprove && onDeny) {
-      const isDenying = denyingApprovalId === event.approval_id
-      const isApproving = approvingApprovalId === event.approval_id
+    if (event.approvalStatus === ApprovalStatus.Pending && event.approvalId && onApprove && onDeny) {
+      const isDenying = denyingApprovalId === event.approvalId
+      const isApproving = approvingApprovalId === event.approvalId
 
       body = (
         <div className="mt-4 flex gap-2 justify-end">
@@ -498,13 +499,13 @@ export function eventToDisplayObject(
                 variant={isApproving ? 'outline' : 'default'}
                 onClick={e => {
                   e.stopPropagation()
-                  onApprove(event.approval_id!)
+                  onApprove(event.approvalId!)
                 }}
                 disabled={isApproving}
               >
                 {isApproving
                   ? 'Approving...'
-                  : confirmingApprovalId === event.approval_id
+                  : confirmingApprovalId === event.approvalId
                     ? 'Approve?'
                     : 'Approve'}{' '}
                 <kbd className="ml-1 px-1 py-0.5 text-xs bg-muted/50 rounded">A</kbd>
@@ -516,7 +517,7 @@ export function eventToDisplayObject(
                   variant="destructive"
                   onClick={e => {
                     e.stopPropagation()
-                    onStartDeny?.(event.approval_id!)
+                    onStartDeny?.(event.approvalId!)
                   }}
                 >
                   Deny <kbd className="ml-1 px-1 py-0.5 text-xs bg-muted/50 rounded">D</kbd>
@@ -524,14 +525,14 @@ export function eventToDisplayObject(
               )}
             </>
           ) : (
-            <DenyForm approvalId={event.approval_id!} onDeny={onDeny} onCancel={onCancelDeny} />
+            <DenyForm approvalId={event.approvalId!} onDeny={onDeny} onCancel={onCancelDeny} />
           )}
         </div>
       )
     }
   }
 
-  if (event.event_type === ConversationEventType.Thinking) {
+  if (event.eventType === ConversationEventType.Thinking) {
     // Thinking messages are always from assistant
     const fullContent = (event.content || '').trim()
 
@@ -543,7 +544,7 @@ export function eventToDisplayObject(
     body = null // Everything is in subject for thinking messages
   }
 
-  if (event.event_type === ConversationEventType.Message) {
+  if (event.eventType === ConversationEventType.Message) {
     // For assistant messages, show full content without truncation
     if (event.role === 'assistant') {
       const fullContent = event.content || ''
@@ -564,7 +565,7 @@ export function eventToDisplayObject(
     }
   }
 
-  if (event.event_type === ConversationEventType.Thinking) {
+  if (event.eventType === ConversationEventType.Thinking) {
     iconComponent = <Brain className={iconClasses} />
   } else if (event.role === 'assistant') {
     iconComponent = <Bot className={iconClasses} />
@@ -575,24 +576,24 @@ export function eventToDisplayObject(
   }
 
   // Display tool result content for tool calls
-  if (event.event_type === ConversationEventType.ToolCall) {
+  if (event.eventType === ConversationEventType.ToolCall) {
     if (toolResult) {
       // For denied approvals, show the denial comment in red
-      if (event.approval_status === ApprovalStatus.Denied) {
+      if (event.approvalStatus === ApprovalStatus.Denied) {
         subject = (
           <>
             {subject}
             <div className="mt-1 text-sm font-mono flex items-start gap-1">
               <span className="text-muted-foreground/50">⎿</span>
               <span className="text-destructive">
-                Denied: {toolResult.tool_result_content || 'No reason provided'}
+                Denied: {toolResult.toolResultContent || 'No reason provided'}
               </span>
             </div>
           </>
         )
       } else {
         // Normal tool result display
-        const resultDisplay = formatToolResult(event.tool_name || '', toolResult, event)
+        const resultDisplay = formatToolResult(event.toolName || '', toolResult, event)
         if (resultDisplay) {
           // Append to existing subject with indentation
           subject = (
@@ -626,10 +627,10 @@ export function eventToDisplayObject(
     id: event.id,
     role: event.role,
     subject,
-    isCompleted: event.is_completed,
+    isCompleted: event.isCompleted,
     iconComponent,
     body,
-    created_at: event.created_at,
+    created_at: event.createdAt,
     toolResultContent,
     isThinking,
   }

--- a/humanlayer-wui/src/components/internal/SessionDetail/formatToolResult.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/formatToolResult.tsx
@@ -7,17 +7,12 @@ import { truncate } from '@/utils/formatting'
 // TODO(3): Extract magic numbers to constants (e.g., truncate lengths, line limits)
 
 // Format tool result content into abbreviated display
-<<<<<<< HEAD
 export function formatToolResult(
   toolName: string,
   toolResult: ConversationEvent,
   toolCall?: ConversationEvent,
 ): React.ReactNode {
-  const content = toolResult.tool_result_content || ''
-=======
-export function formatToolResult(toolName: string, toolResult: ConversationEvent): React.ReactNode {
   const content = toolResult.toolResultContent || ''
->>>>>>> b99ff02 (Remove legacy types and transformation logic in daemon client)
 
   // Handle empty content
   if (!content.trim()) {
@@ -186,9 +181,9 @@ export function formatToolResult(toolName: string, toolResult: ConversationEvent
     case 'Grep': {
       // Try to get the grep mode from the tool call parameters
       let mode = 'files_with_matches' // default
-      if (toolCall?.tool_input_json) {
+      if (toolCall?.toolInputJson) {
         try {
-          const params = JSON.parse(toolCall.tool_input_json)
+          const params = JSON.parse(toolCall.toolInputJson)
           mode = params.output_mode || mode
         } catch {
           // Fall back to default if parsing fails
@@ -213,7 +208,6 @@ export function formatToolResult(toolName: string, toolResult: ConversationEvent
         // Fallback: count based on mode
         const lineCount = content
           .split('\n')
-<<<<<<< HEAD
           .filter(l => l.trim() && !l.includes('(Results are truncated')).length
 
         if (mode === 'content') {
@@ -236,10 +230,6 @@ export function formatToolResult(toolName: string, toolResult: ConversationEvent
           // files_with_matches mode (default)
           abbreviated = `Found ${lineCount} files`
         }
-=======
-          .filter((l: string) => l.trim() && !l.includes('(Results are truncated')).length
-        abbreviated = `Found ${fileCount} files`
->>>>>>> b99ff02 (Remove legacy types and transformation logic in daemon client)
       }
       break
     }

--- a/humanlayer-wui/src/components/internal/SessionDetail/formatToolResult.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/formatToolResult.tsx
@@ -7,12 +7,17 @@ import { truncate } from '@/utils/formatting'
 // TODO(3): Extract magic numbers to constants (e.g., truncate lengths, line limits)
 
 // Format tool result content into abbreviated display
+<<<<<<< HEAD
 export function formatToolResult(
   toolName: string,
   toolResult: ConversationEvent,
   toolCall?: ConversationEvent,
 ): React.ReactNode {
   const content = toolResult.tool_result_content || ''
+=======
+export function formatToolResult(toolName: string, toolResult: ConversationEvent): React.ReactNode {
+  const content = toolResult.toolResultContent || ''
+>>>>>>> b99ff02 (Remove legacy types and transformation logic in daemon client)
 
   // Handle empty content
   if (!content.trim()) {
@@ -92,7 +97,7 @@ export function formatToolResult(
     }
 
     case 'Bash': {
-      const lines = content.split('\n').filter(l => l.trim())
+      const lines = content.split('\n').filter((l: string) => l.trim())
       if (!content || lines.length === 0) {
         abbreviated = 'Command completed'
       } else if (lines.length === 1) {
@@ -172,7 +177,7 @@ export function formatToolResult(
       if (content === 'No files found') {
         abbreviated = 'No files found'
       } else {
-        const fileCount = content.split('\n').filter(l => l.trim()).length
+        const fileCount = content.split('\n').filter((l: string) => l.trim()).length
         abbreviated = `Found ${fileCount} files`
       }
       break
@@ -208,6 +213,7 @@ export function formatToolResult(
         // Fallback: count based on mode
         const lineCount = content
           .split('\n')
+<<<<<<< HEAD
           .filter(l => l.trim() && !l.includes('(Results are truncated')).length
 
         if (mode === 'content') {
@@ -230,13 +236,17 @@ export function formatToolResult(
           // files_with_matches mode (default)
           abbreviated = `Found ${lineCount} files`
         }
+=======
+          .filter((l: string) => l.trim() && !l.includes('(Results are truncated')).length
+        abbreviated = `Found ${fileCount} files`
+>>>>>>> b99ff02 (Remove legacy types and transformation logic in daemon client)
       }
       break
     }
 
     case 'LS': {
       // Count items in the tree structure (lines starting with " - ")
-      const lsItems = content.split('\n').filter(l => l.trim().startsWith('-')).length
+      const lsItems = content.split('\n').filter((l: string) => l.trim().startsWith('-')).length
       abbreviated = `${lsItems} items`
       break
     }
@@ -329,7 +339,7 @@ export function formatToolResult(
           abbreviated = `${service} ${method} completed`
         } else {
           // Show first line or character count for longer responses
-          const lines = content.split('\n').filter(l => l.trim())
+          const lines = content.split('\n').filter((l: string) => l.trim())
           if (lines.length === 1 && lines[0].length < 80) {
             abbreviated = lines[0]
           } else if (content.length > 200) {

--- a/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionActions.ts
+++ b/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionActions.ts
@@ -1,13 +1,13 @@
 import React, { useState, useCallback, useEffect } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useNavigate } from 'react-router-dom'
-import { SessionInfo, ConversationEvent, ViewMode } from '@/lib/daemon/types'
+import { Session, ConversationEvent, ViewMode } from '@/lib/daemon/types'
 import { daemonClient } from '@/lib/daemon/client'
 import { notificationService } from '@/services/NotificationService'
 import { useStore } from '@/AppStore'
 
 interface UseSessionActionsProps {
-  session: SessionInfo
+  session: Session
   onClose: () => void
   pendingForkMessage?: ConversationEvent | null
   onForkCommit?: () => void
@@ -34,7 +34,7 @@ export function useSessionActions({
     if (pendingForkMessage) {
       setResponseInput(pendingForkMessage.content || '')
       // Set the session ID to fork from (the one before this message)
-      setForkFromSessionId(pendingForkMessage.session_id || null)
+      setForkFromSessionId(pendingForkMessage.sessionId || null)
     }
   }, [pendingForkMessage])
 
@@ -110,10 +110,10 @@ export function useSessionActions({
 
   // Navigate to parent session
   const handleNavigateToParent = useCallback(() => {
-    if (session.parent_session_id) {
-      navigate(`/sessions/${session.parent_session_id}`)
+    if (session.parentSessionId) {
+      navigate(`/sessions/${session.parentSessionId}`)
     }
-  }, [session.parent_session_id, navigate])
+  }, [session.parentSessionId, navigate])
 
   // Keyboard shortcuts
   // Note: Escape key is handled in SessionDetail to manage confirmingApprovalId state
@@ -130,7 +130,7 @@ export function useSessionActions({
 
   // P key to navigate to parent session
   useHotkeys('p', () => {
-    if (session.parent_session_id) {
+    if (session.parentSessionId) {
       handleNavigateToParent()
     }
   })

--- a/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionApprovals.ts
+++ b/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionApprovals.ts
@@ -74,7 +74,7 @@ export function useSessionApprovals({
     () => {
       // Find any pending approval event
       const pendingApprovalEvent = events.find(
-        e => e.approval_status === ApprovalStatus.Pending && e.approval_id && e.id !== undefined,
+        e => e.approvalStatus === ApprovalStatus.Pending && e.approvalId && e.id !== undefined,
       )
 
       if (!pendingApprovalEvent || pendingApprovalEvent.id === undefined) return
@@ -87,7 +87,7 @@ export function useSessionApprovals({
 
         // Only set confirming state if element was out of view and we're scrolling to it
         if (!wasInView) {
-          setConfirmingApprovalId(pendingApprovalEvent.approval_id!)
+          setConfirmingApprovalId(pendingApprovalEvent.approvalId!)
         }
         return
       }
@@ -95,12 +95,12 @@ export function useSessionApprovals({
       // If the pending approval is already focused
       if (focusedEventId === pendingApprovalEvent.id) {
         // If we're in confirming state, approve it
-        if (confirmingApprovalId === pendingApprovalEvent.approval_id) {
-          handleApprove(pendingApprovalEvent.approval_id!)
+        if (confirmingApprovalId === pendingApprovalEvent.approvalId) {
+          handleApprove(pendingApprovalEvent.approvalId!)
           setConfirmingApprovalId(null)
         } else {
           // If not in confirming state, approve directly
-          handleApprove(pendingApprovalEvent.approval_id!)
+          handleApprove(pendingApprovalEvent.approvalId!)
         }
       }
     },
@@ -121,7 +121,7 @@ export function useSessionApprovals({
     e => {
       // Find any pending approval event
       const pendingApprovalEvent = events.find(
-        e => e.approval_status === ApprovalStatus.Pending && e.approval_id && e.id !== undefined,
+        e => e.approvalStatus === ApprovalStatus.Pending && e.approvalId && e.id !== undefined,
       )
 
       if (!pendingApprovalEvent || pendingApprovalEvent.id === undefined) return
@@ -138,7 +138,7 @@ export function useSessionApprovals({
 
       // If the pending approval is already focused, show the deny form
       if (focusedEventId === pendingApprovalEvent.id) {
-        handleStartDeny(pendingApprovalEvent.approval_id!)
+        handleStartDeny(pendingApprovalEvent.approvalId!)
       }
     },
     [events, focusedEventId, handleStartDeny, setFocusedEventId, setFocusSource],
@@ -149,8 +149,8 @@ export function useSessionApprovals({
     if (denyingApprovalId) {
       const container = document.querySelector('[data-conversation-container]')
       // Find the event that contains this approval
-      const event = events.find(e => e.approval_id === denyingApprovalId)
-      if (container && event && !event.approval_status && event.id !== undefined) {
+      const event = events.find(e => e.approvalId === denyingApprovalId)
+      if (container && event && !event.approvalStatus && event.id !== undefined) {
         const eventElement = container.querySelector(`[data-event-id="${event.id}"]`)
         if (eventElement && !isElementInView(event.id)) {
           // Scroll the deny form into view

--- a/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionClipboard.ts
+++ b/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionClipboard.ts
@@ -5,7 +5,7 @@ import { SessionDetailHotkeysScope } from '../SessionDetail'
 
 export function useSessionClipboard(focusedEvent: ConversationEvent | null, enabled: boolean = true) {
   const getMessageContent = (event: ConversationEvent): string | null => {
-    if (event.event_type !== ConversationEventType.Message) return null
+    if (event.eventType !== ConversationEventType.Message) return null
     if (event.role !== 'user' && event.role !== 'assistant') return null
     return event.content || null
   }

--- a/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionNavigation.ts
+++ b/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionNavigation.ts
@@ -47,40 +47,36 @@ export function useSessionNavigation({
     if (!hasSubTasks) {
       // Simple case: just regular events
       events
-        .filter(
-          event => event.event_type !== ConversationEventType.ToolResult && event.id !== undefined,
-        )
+        .filter(event => event.eventType !== ConversationEventType.ToolResult && event.id !== undefined)
         .forEach(event => items.push({ id: event.id!, type: 'event' }))
     } else {
       // Complex case: handle task groups
-      const rootEvents = events.filter(e => !e.parent_tool_use_id)
+      const rootEvents = events.filter(e => !e.parentToolUseId)
       const subEventsByParent = new Map<string, ConversationEvent[]>()
 
       events.forEach(event => {
-        if (event.parent_tool_use_id) {
-          const siblings = subEventsByParent.get(event.parent_tool_use_id) || []
+        if (event.parentToolUseId) {
+          const siblings = subEventsByParent.get(event.parentToolUseId) || []
           siblings.push(event)
-          subEventsByParent.set(event.parent_tool_use_id, siblings)
+          subEventsByParent.set(event.parentToolUseId, siblings)
         }
       })
 
       rootEvents
-        .filter(
-          event => event.event_type !== ConversationEventType.ToolResult && event.id !== undefined,
-        )
+        .filter(event => event.eventType !== ConversationEventType.ToolResult && event.id !== undefined)
         .forEach(event => {
           // Check if this is a task group
           const isTaskGroup =
-            event.tool_name === 'Task' && event.tool_id && subEventsByParent.has(event.tool_id)
+            event.toolName === 'Task' && event.toolId && subEventsByParent.has(event.toolId)
 
           if (isTaskGroup) {
             items.push({ id: event.id!, type: 'taskgroup' })
 
             // If expanded, add sub-events
-            if (expandedTasks.has(event.tool_id!)) {
-              const subEvents = subEventsByParent.get(event.tool_id!) || []
+            if (expandedTasks.has(event.toolId!)) {
+              const subEvents = subEventsByParent.get(event.toolId!) || []
               subEvents
-                .filter(e => e.event_type !== ConversationEventType.ToolResult && e.id !== undefined)
+                .filter(e => e.eventType !== ConversationEventType.ToolResult && e.id !== undefined)
                 .forEach(subEvent => {
                   items.push({ id: subEvent.id!, type: 'subevent' })
                 })
@@ -147,33 +143,33 @@ export function useSessionNavigation({
       startKeyboardNavigation?.()
 
       const focusedEvent = events.find(e => e.id === focusedEventId)
-      if (!focusedEvent || focusedEvent.event_type !== ConversationEventType.ToolCall) return
+      if (!focusedEvent || focusedEvent.eventType !== ConversationEventType.ToolCall) return
 
       // Handle task group expansion for Task events with sub-events
-      if (focusedEvent.tool_name === 'Task' && focusedEvent.tool_id && hasSubTasks) {
+      if (focusedEvent.toolName === 'Task' && focusedEvent.toolId && hasSubTasks) {
         const subEventsByParent = new Map<string, ConversationEvent[]>()
         events.forEach(event => {
-          if (event.parent_tool_use_id) {
-            const siblings = subEventsByParent.get(event.parent_tool_use_id) || []
+          if (event.parentToolUseId) {
+            const siblings = subEventsByParent.get(event.parentToolUseId) || []
             siblings.push(event)
-            subEventsByParent.set(event.parent_tool_use_id, siblings)
+            subEventsByParent.set(event.parentToolUseId, siblings)
           }
         })
 
-        const hasSubEvents = subEventsByParent.has(focusedEvent.tool_id)
+        const hasSubEvents = subEventsByParent.has(focusedEvent.toolId)
         if (hasSubEvents) {
-          toggleTaskGroup(focusedEvent.tool_id)
+          toggleTaskGroup(focusedEvent.toolId)
           return
         }
       }
 
       // Handle tool result inspection (existing behavior)
       if (setExpandedToolResult && setExpandedToolCall) {
-        const toolResult = focusedEvent.tool_id
+        const toolResult = focusedEvent.toolId
           ? events.find(
               e =>
-                e.event_type === ConversationEventType.ToolResult &&
-                e.tool_result_for_id === focusedEvent.tool_id,
+                e.eventType === ConversationEventType.ToolResult &&
+                e.toolResultForId === focusedEvent.toolId,
             )
           : null
 

--- a/humanlayer-wui/src/components/internal/SessionDetail/hooks/useTaskGrouping.ts
+++ b/humanlayer-wui/src/components/internal/SessionDetail/hooks/useTaskGrouping.ts
@@ -16,8 +16,8 @@ function buildTaskGroups(events: ConversationEvent[]): {
   rootEvents: ConversationEvent[]
   hasSubTasks: boolean
 } {
-  // Quick check: if no events have parent_tool_use_id, skip building
-  const hasSubTasks = events.some(e => e.parent_tool_use_id)
+  // Quick check: if no events have parentToolUseId, skip building
+  const hasSubTasks = events.some(e => e.parentToolUseId)
   if (!hasSubTasks) {
     return {
       taskGroups: new Map(),
@@ -32,10 +32,10 @@ function buildTaskGroups(events: ConversationEvent[]): {
 
   // Single pass to categorize events
   events.forEach(event => {
-    if (event.parent_tool_use_id) {
-      const siblings = eventsByParent.get(event.parent_tool_use_id) || []
+    if (event.parentToolUseId) {
+      const siblings = eventsByParent.get(event.parentToolUseId) || []
       siblings.push(event)
-      eventsByParent.set(event.parent_tool_use_id, siblings)
+      eventsByParent.set(event.parentToolUseId, siblings)
     } else {
       rootEvents.push(event)
     }
@@ -43,19 +43,19 @@ function buildTaskGroups(events: ConversationEvent[]): {
 
   // Build task groups for parent Tasks
   rootEvents.forEach(event => {
-    if (event.tool_name === 'Task' && event.tool_id && eventsByParent.has(event.tool_id)) {
-      const subEvents = eventsByParent.get(event.tool_id)!
+    if (event.toolName === 'Task' && event.toolId && eventsByParent.has(event.toolId)) {
+      const subEvents = eventsByParent.get(event.toolId)!
 
       // Calculate preview data
-      const toolCalls = subEvents.filter(e => e.event_type === ConversationEventType.ToolCall)
+      const toolCalls = subEvents.filter(e => e.eventType === ConversationEventType.ToolCall)
       const latestEvent = subEvents[subEvents.length - 1]
 
-      taskGroups.set(event.tool_id, {
+      taskGroups.set(event.toolId, {
         parentTask: event,
         subTaskEvents: subEvents,
         toolCallCount: toolCalls.length,
         latestEvent: latestEvent || null,
-        hasPendingApproval: subEvents.some(e => e.approval_status === ApprovalStatus.Pending),
+        hasPendingApproval: subEvents.some(e => e.approvalStatus === ApprovalStatus.Pending),
       })
     }
   })

--- a/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
@@ -75,9 +75,9 @@ export function ConversationContent({
   const filteredEvents = maxEventIndex !== undefined ? events.slice(0, maxEventIndex) : events
 
   const toolResults = filteredEvents.filter(
-    event => event.event_type === ConversationEventType.ToolResult,
+    event => event.eventType === ConversationEventType.ToolResult,
   )
-  const toolResultsByKey = keyBy(toolResults, 'tool_result_for_id')
+  const toolResultsByKey = keyBy(toolResults, 'toolResultForId')
 
   // Use task grouping hook - use props if provided, otherwise use local hook
   const localTaskGrouping = useTaskGrouping(filteredEvents)
@@ -88,7 +88,7 @@ export function ConversationContent({
   // Watch for new Read tool results and refetch snapshots
   useEffect(() => {
     const hasReadToolResults = filteredEvents.some(
-      event => event.event_type === ConversationEventType.ToolResult && event.tool_name === 'Read',
+      event => event.eventType === ConversationEventType.ToolResult && event.toolName === 'Read',
     )
 
     if (hasReadToolResults) {
@@ -97,7 +97,7 @@ export function ConversationContent({
   }, [filteredEvents, refetch])
 
   const displayObjects = filteredEvents
-    .filter(event => event.event_type !== ConversationEventType.ToolResult)
+    .filter(event => event.eventType !== ConversationEventType.ToolResult)
     .map(event =>
       eventToDisplayObject(
         event,
@@ -110,7 +110,7 @@ export function ConversationContent({
         confirmingApprovalId,
         isSplitView,
         onToggleSplitView,
-        event.tool_id ? toolResultsByKey[event.tool_id] : undefined,
+        event.toolId ? toolResultsByKey[event.toolId] : undefined,
         focusedEventId === event.id,
         getSnapshot,
       ),
@@ -137,7 +137,7 @@ export function ConversationContent({
           return (
             !prevEvent ||
             event.id !== prevEvent.id ||
-            event.tool_result_content !== prevEvent.tool_result_content
+            event.toolResultContent !== prevEvent.toolResultContent
           )
         })
 
@@ -175,8 +175,8 @@ export function ConversationContent({
   useEffect(() => {
     if (denyingApprovalId && containerRef.current) {
       // Find the event that contains this approval
-      const event = filteredEvents.find(e => e.approval_id === denyingApprovalId)
-      if (event && !event.approval_status) {
+      const event = filteredEvents.find(e => e.approvalId === denyingApprovalId)
+      if (event && !event.approvalStatus) {
         const eventElement = containerRef.current.querySelector(`[data-event-id="${event.id}"]`)
         if (eventElement) {
           const elementRect = eventElement.getBoundingClientRect()
@@ -240,12 +240,12 @@ export function ConversationContent({
                 }}
                 onClick={() => {
                   const event = events.find(e => e.id === displayObject.id)
-                  if (event?.event_type === ConversationEventType.ToolCall) {
-                    const toolResult = event.tool_id
+                  if (event?.eventType === ConversationEventType.ToolCall) {
+                    const toolResult = event.toolId
                       ? events.find(
                           e =>
-                            e.event_type === ConversationEventType.ToolResult &&
-                            e.tool_result_for_id === event.tool_id,
+                            e.eventType === ConversationEventType.ToolResult &&
+                            e.toolResultForId === event.toolId,
                         )
                       : null
                     if (setExpandedToolResult && setExpandedToolCall) {
@@ -287,7 +287,7 @@ export function ConversationContent({
                     {/* Copy button - only show for user and assistant messages */}
                     {(() => {
                       const event = events.find(e => e.id === displayObject.id)
-                      return event?.event_type === ConversationEventType.Message &&
+                      return event?.eventType === ConversationEventType.Message &&
                         (event.role === 'user' || event.role === 'assistant') ? (
                         <Button
                           variant="ghost"
@@ -337,17 +337,17 @@ export function ConversationContent({
     >
       <div>
         {rootEvents
-          .filter(event => event.event_type !== ConversationEventType.ToolResult)
+          .filter(event => event.eventType !== ConversationEventType.ToolResult)
           .map((event, index) => {
-            const taskGroup = taskGroups.get(event.tool_id || '')
+            const taskGroup = taskGroups.get(event.toolId || '')
 
             if (taskGroup) {
               return (
                 <TaskGroup
                   key={event.id}
                   group={taskGroup}
-                  isExpanded={actualExpandedTasks.has(event.tool_id!)}
-                  onToggle={() => actualToggleTaskGroup(event.tool_id!)}
+                  isExpanded={actualExpandedTasks.has(event.toolId!)}
+                  onToggle={() => actualToggleTaskGroup(event.toolId!)}
                   focusedEventId={focusedEventId}
                   setFocusedEventId={setFocusedEventId}
                   onApprove={onApprove}
@@ -380,7 +380,7 @@ export function ConversationContent({
                 confirmingApprovalId,
                 isSplitView,
                 onToggleSplitView,
-                event.tool_id ? toolResultsByKey[event.tool_id] : undefined,
+                event.toolId ? toolResultsByKey[event.toolId] : undefined,
                 focusedEventId === event.id,
                 getSnapshot,
               )
@@ -405,12 +405,12 @@ export function ConversationContent({
                     }}
                     onClick={() => {
                       const event = events.find(e => e.id === displayObject.id)
-                      if (event?.event_type === ConversationEventType.ToolCall) {
-                        const toolResult = event.tool_id
+                      if (event?.eventType === ConversationEventType.ToolCall) {
+                        const toolResult = event.toolId
                           ? events.find(
                               e =>
-                                e.event_type === ConversationEventType.ToolResult &&
-                                e.tool_result_for_id === event.tool_id,
+                                e.eventType === ConversationEventType.ToolResult &&
+                                e.toolResultForId === event.toolId,
                             )
                           : null
                         if (setExpandedToolResult && setExpandedToolCall) {
@@ -421,7 +421,7 @@ export function ConversationContent({
                     }}
                     className={`group relative p-4 cursor-pointer transition-shadow duration-200 ${
                       index !==
-                      rootEvents.filter(e => e.event_type !== ConversationEventType.ToolResult).length -
+                      rootEvents.filter(e => e.eventType !== ConversationEventType.ToolResult).length -
                         1
                         ? 'border-b'
                         : ''
@@ -456,7 +456,7 @@ export function ConversationContent({
                         {/* Copy button - only show for user and assistant messages */}
                         {(() => {
                           const currentEvent = events.find(e => e.id === displayObject.id)
-                          return currentEvent?.event_type === ConversationEventType.Message &&
+                          return currentEvent?.eventType === ConversationEventType.Message &&
                             (currentEvent.role === 'user' || currentEvent.role === 'assistant') ? (
                             <Button
                               variant="ghost"

--- a/humanlayer-wui/src/components/internal/SessionDetail/views/TaskGroup.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/TaskGroup.tsx
@@ -53,8 +53,8 @@ export function TaskGroup({
   shouldIgnoreMouseEvent,
 }: TaskGroupProps) {
   const { parentTask, toolCallCount, latestEvent, hasPendingApproval } = group
-  const description = JSON.parse(parentTask.tool_input_json || '{}').description || 'Task'
-  const isCompleted = parentTask.is_completed
+  const description = JSON.parse(parentTask.toolInputJson || '{}').description || 'Task'
+  const isCompleted = parentTask.isCompleted
 
   return (
     <div className="p-4 TaskGroup">
@@ -111,18 +111,18 @@ export function TaskGroup({
                   let previewText = ''
                   let icon = null
 
-                  if (latestEvent.tool_name) {
-                    previewText = `${latestEvent.tool_name}`
+                  if (latestEvent.toolName) {
+                    previewText = `${latestEvent.toolName}`
                     try {
-                      const toolInput = JSON.parse(latestEvent.tool_input_json || '{}')
-                      if (latestEvent.tool_name === 'Write' && toolInput.file_path) {
+                      const toolInput = JSON.parse(latestEvent.toolInputJson || '{}')
+                      if (latestEvent.toolName === 'Write' && toolInput.file_path) {
                         previewText = `Write to ${toolInput.file_path}`
                         icon = <FilePenLine className="w-3 h-3" />
-                      } else if (latestEvent.tool_name === 'Read' && toolInput.file_path) {
+                      } else if (latestEvent.toolName === 'Read' && toolInput.file_path) {
                         previewText = `Read ${toolInput.file_path}`
-                      } else if (latestEvent.tool_name === 'Bash' && toolInput.command) {
+                      } else if (latestEvent.toolName === 'Bash' && toolInput.command) {
                         previewText = `$ ${truncate(toolInput.command, 50)}`
-                      } else if (latestEvent.tool_name === 'Task' && toolInput.description) {
+                      } else if (latestEvent.toolName === 'Task' && toolInput.description) {
                         previewText = truncate(toolInput.description, 80)
                       }
                     } catch {
@@ -136,8 +136,8 @@ export function TaskGroup({
                     } else if (latestEvent.role === 'user') {
                       icon = <User className="w-3 h-3" />
                     }
-                  } else if (latestEvent.approval_status) {
-                    previewText = `Approval (${latestEvent.approval_status})`
+                  } else if (latestEvent.approvalStatus) {
+                    previewText = `Approval (${latestEvent.approvalStatus})`
                     icon = <UserCheck className="w-3 h-3" />
                   }
 
@@ -178,7 +178,7 @@ export function TaskGroup({
               confirmingApprovalId,
               isSplitView,
               onToggleSplitView,
-              subEvent.tool_id ? toolResultsByKey[subEvent.tool_id] : undefined,
+              subEvent.toolId ? toolResultsByKey[subEvent.toolId] : undefined,
               focusedEventId === subEvent.id,
               getSnapshot,
             )
@@ -203,8 +203,8 @@ export function TaskGroup({
                   }}
                   onClick={() => {
                     const event = subEvent
-                    if (event?.event_type === ConversationEventType.ToolCall) {
-                      const toolResult = event.tool_id ? toolResultsByKey[event.tool_id] : null
+                    if (event?.eventType === ConversationEventType.ToolCall) {
+                      const toolResult = event.toolId ? toolResultsByKey[event.toolId] : null
                       if (setExpandedToolResult && setExpandedToolCall) {
                         setExpandedToolResult(toolResult || null)
                         setExpandedToolCall(event)

--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -1,4 +1,4 @@
-import { SessionInfo } from '@/lib/daemon/types'
+import { Session } from '@/lib/daemon/types'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { useHotkeys, useHotkeysContext } from 'react-hotkeys-hook'
@@ -19,13 +19,13 @@ import { daemonClient } from '@/lib/daemon/client'
 import { renderSessionStatus } from '@/utils/sessionStatus'
 
 interface SessionTableProps {
-  sessions: SessionInfo[]
-  handleFocusSession?: (session: SessionInfo) => void
+  sessions: Session[]
+  handleFocusSession?: (session: Session) => void
   handleBlurSession?: () => void
   handleFocusNextSession?: () => void
   handleFocusPreviousSession?: () => void
-  handleActivateSession?: (session: SessionInfo) => void
-  focusedSession: SessionInfo | null
+  handleActivateSession?: (session: Session) => void
+  focusedSession: Session | null
   searchText?: string
   matchedSessions?: Map<string, any>
   emptyState?: {
@@ -406,12 +406,12 @@ export default function SessionTable({
                           className="block truncate cursor-help text-sm"
                           style={{ direction: 'rtl', textAlign: 'left' }}
                         >
-                          {session.working_dir || '-'}
+                          {session.workingDir || '-'}
                         </span>
                       </TooltipTrigger>
                       <TooltipContent className="max-w-[600px]">
                         <span className="font-mono text-sm">
-                          {session.working_dir || 'No working directory'}
+                          {session.workingDir || 'No working directory'}
                         </span>
                       </TooltipContent>
                     </Tooltip>
@@ -481,19 +481,17 @@ export default function SessionTable({
                   <TableCell>
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <span className="cursor-help">{formatTimestamp(session.start_time)}</span>
+                        <span className="cursor-help">{formatTimestamp(session.createdAt)}</span>
                       </TooltipTrigger>
-                      <TooltipContent>{formatAbsoluteTimestamp(session.start_time)}</TooltipContent>
+                      <TooltipContent>{formatAbsoluteTimestamp(session.createdAt)}</TooltipContent>
                     </Tooltip>
                   </TableCell>
                   <TableCell>
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <span className="cursor-help">{formatTimestamp(session.last_activity_at)}</span>
+                        <span className="cursor-help">{formatTimestamp(session.lastActivityAt)}</span>
                       </TooltipTrigger>
-                      <TooltipContent>
-                        {formatAbsoluteTimestamp(session.last_activity_at)}
-                      </TooltipContent>
+                      <TooltipContent>{formatAbsoluteTimestamp(session.lastActivityAt)}</TooltipContent>
                     </Tooltip>
                   </TableCell>
                 </TableRow>

--- a/humanlayer-wui/src/hooks/useConversation.ts
+++ b/humanlayer-wui/src/hooks/useConversation.ts
@@ -140,23 +140,23 @@ export function useFormattedConversation(
       let content = event.content || ''
       let type: FormattedMessage['type'] = 'message'
 
-      if (event.event_type === 'tool_call') {
+      if (event.eventType === 'tool_call') {
         type = 'tool_call'
-        content = `Calling ${event.tool_name || 'tool'}`
-        if (event.tool_input_json) {
+        content = `Calling ${event.toolName || 'tool'}`
+        if (event.toolInputJson) {
           try {
-            const input = JSON.parse(event.tool_input_json)
+            const input = JSON.parse(event.toolInputJson)
             content += `: ${JSON.stringify(input, null, 2)}`
           } catch {
-            content += `: ${event.tool_input_json}`
+            content += `: ${event.toolInputJson}`
           }
         }
-      } else if (event.event_type === 'tool_result') {
+      } else if (event.eventType === 'tool_result') {
         type = 'tool_result'
-        content = event.tool_result_content || 'Tool completed'
-      } else if (event.approval_status) {
+        content = event.toolResultContent || 'Tool completed'
+      } else if (event.approvalStatus) {
         type = 'approval'
-        content = `Approval ${event.approval_status}`
+        content = `Approval ${event.approvalStatus}`
       }
 
       return {
@@ -164,12 +164,12 @@ export function useFormattedConversation(
         type,
         role: event.role,
         content,
-        timestamp: new Date(event.created_at || new Date()),
+        timestamp: new Date(event.createdAt || new Date()),
         metadata: {
-          toolName: event.tool_name,
-          toolId: event.tool_id,
-          approvalStatus: event.approval_status || undefined,
-          approvalId: event.approval_id,
+          toolName: event.toolName,
+          toolId: event.toolId,
+          approvalStatus: event.approvalStatus || undefined,
+          approvalId: event.approvalId,
         },
       }
     })

--- a/humanlayer-wui/src/hooks/useSessionFilter.ts
+++ b/humanlayer-wui/src/hooks/useSessionFilter.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { SessionStatus, SessionInfo } from '@/lib/daemon/types'
+import { SessionStatus, Session } from '@/lib/daemon/types'
 import { fuzzySearch } from '@/lib/fuzzy-search'
 
 interface ParsedFilter {
@@ -36,13 +36,13 @@ export function parseStatusFilter(query: string): ParsedFilter {
 }
 
 interface UseSessionFilterOptions {
-  sessions: SessionInfo[]
+  sessions: Session[]
   query: string
   searchFields?: string[]
 }
 
 interface UseSessionFilterResult {
-  filteredSessions: SessionInfo[]
+  filteredSessions: Session[]
   statusFilter: SessionStatus | null
   searchText: string
   matchedSessions: Map<string, any> // session id -> fuzzy match data

--- a/humanlayer-wui/src/hooks/useSessions.ts
+++ b/humanlayer-wui/src/hooks/useSessions.ts
@@ -28,12 +28,12 @@ export function useSessions(): UseSessionsReturn {
       // Transform to UI-friendly format
       const summaries: SessionSummary[] = response.sessions.map(session => ({
         id: session.id,
-        runId: session.run_id,
+        runId: session.runId,
         status: session.status,
         query: session.query,
         model: session.model || 'default',
-        startTime: new Date(session.start_time),
-        endTime: session.end_time ? new Date(session.end_time) : undefined,
+        startTime: new Date(session.createdAt),
+        endTime: session.completedAt ? new Date(session.completedAt) : undefined,
         hasApprovals: false, // Will be enriched later if needed
       }))
 

--- a/humanlayer-wui/src/lib/daemon/http-client.ts
+++ b/humanlayer-wui/src/lib/daemon/http-client.ts
@@ -1,4 +1,11 @@
-import { CreateSessionResponseData, HLDClient, RecentPath as SDKRecentPath } from '@humanlayer/hld-sdk'
+import {
+  CreateSessionResponseData,
+  HLDClient,
+  RecentPath as SDKRecentPath,
+  Session,
+  Approval,
+  ConversationEvent,
+} from '@humanlayer/hld-sdk'
 import { getDaemonUrl, getDefaultHeaders } from './http-config'
 import type {
   DaemonClient as IDaemonClient,
@@ -7,14 +14,9 @@ import type {
   SessionState,
   SubscribeOptions,
   SubscriptionHandle,
-  ConversationEvent,
   SessionSnapshot,
   HealthCheckResponse,
-  LegacySession,
-  LegacyApproval,
-  LegacyConversationEvent,
 } from './types'
-import { ConversationEventType } from './types'
 
 export class HTTPDaemonClient implements IDaemonClient {
   private client?: HLDClient
@@ -136,16 +138,16 @@ export class HTTPDaemonClient implements IDaemonClient {
     // return this.transformSession(response)
   }
 
-  async listSessions(): Promise<LegacySession[]> {
+  async listSessions(): Promise<Session[]> {
     await this.ensureConnected()
     const response = await this.client!.listSessions({ leafOnly: true })
-    return response.map(s => this.transformSession(s))
+    return response
   }
 
   async getSessionLeaves(request?: {
     include_archived?: boolean
     archived_only?: boolean
-  }): Promise<{ sessions: LegacySession[] }> {
+  }): Promise<{ sessions: Session[] }> {
     await this.ensureConnected()
     // The SDK's listSessions with leafOnly=true is equivalent
     const response = await this.client!.listSessions({
@@ -153,7 +155,7 @@ export class HTTPDaemonClient implements IDaemonClient {
       includeArchived: request?.include_archived || request?.archived_only,
     })
     return {
-      sessions: response.map(s => this.transformSession(s)),
+      sessions: response,
     }
   }
 
@@ -163,8 +165,8 @@ export class HTTPDaemonClient implements IDaemonClient {
 
     // Transform to expected SessionState format
     return {
-      session: this.transformSession(session),
-      pending_approvals: [], // Will be populated if needed
+      session: session,
+      pendingApprovals: [], // Will be populated if needed
     }
   }
 
@@ -241,7 +243,6 @@ export class HTTPDaemonClient implements IDaemonClient {
   }
 
   // remove ignore once we've implemented this again
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async updateSessionTitle(sessionId: string, title: string): Promise<{ success: boolean }> {
     await this.ensureConnected()
     await this.client!.updateSession(sessionId, {
@@ -258,13 +259,13 @@ export class HTTPDaemonClient implements IDaemonClient {
       claude_session_id?: string
     },
     options?: RequestInit,
-  ): Promise<LegacyConversationEvent[]> {
+  ): Promise<ConversationEvent[]> {
     await this.ensureConnected()
     if (!params.session_id) {
       throw new Error('session_id is required')
     }
     const messages = await this.client!.getSessionMessages(params.session_id, options)
-    return messages.map(m => this.transformMessage(m))
+    return messages
   }
 
   async getSessionSnapshots(sessionId: string): Promise<SessionSnapshot[]> {
@@ -281,10 +282,10 @@ export class HTTPDaemonClient implements IDaemonClient {
 
   // Approval Methods
 
-  async fetchApprovals(sessionId?: string): Promise<LegacyApproval[]> {
+  async fetchApprovals(sessionId?: string): Promise<Approval[]> {
     await this.ensureConnected()
     const approvals = await this.client!.listApprovals(sessionId)
-    return approvals.map(a => this.transformApproval(a))
+    return approvals
   }
 
   async sendDecision(
@@ -336,10 +337,12 @@ export class HTTPDaemonClient implements IDaemonClient {
           {
             onMessage: event => {
               // Transform event to match expected format
+              // Handle timestamp conversion - SDK passes raw JSON, needs Date object
               options.onEvent({
                 type: event.type,
                 data: event.data,
-                timestamp: event.timestamp,
+                timestamp:
+                  typeof event.timestamp === 'string' ? new Date(event.timestamp) : event.timestamp,
               })
             },
             onError: error => {
@@ -390,130 +393,6 @@ export class HTTPDaemonClient implements IDaemonClient {
   private async ensureConnected(): Promise<void> {
     if (!this.connected) {
       await this.connect()
-    }
-  }
-
-  private transformSession(apiSession: any): LegacySession {
-    // Transform SDK response (camelCase) to legacy format (snake_case)
-    return {
-      id: apiSession.id || apiSession.session_id,
-      run_id: apiSession.runId || apiSession.run_id,
-      query: apiSession.query,
-      status: apiSession.status,
-      created_at:
-        apiSession.createdAt instanceof Date
-          ? apiSession.createdAt.toISOString()
-          : apiSession.createdAt || apiSession.created_at,
-      updated_at:
-        apiSession.lastActivityAt instanceof Date
-          ? apiSession.lastActivityAt.toISOString()
-          : apiSession.lastActivityAt ||
-            apiSession.updated_at ||
-            apiSession.createdAt ||
-            apiSession.created_at,
-      summary: apiSession.summary || '',
-      parent_session_id: apiSession.parentSessionId || apiSession.parent_session_id,
-      claude_session_id: apiSession.claudeSessionId || apiSession.claude_session_id,
-      auto_accept_edits: apiSession.autoAcceptEdits || apiSession.auto_accept_edits || false,
-      archived: apiSession.archived || false,
-      provider: apiSession.provider,
-      model: apiSession.model,
-      temperature: apiSession.temperature,
-      max_tokens: apiSession.maxTokens || apiSession.max_tokens,
-      stop_sequences: apiSession.stopSequences || apiSession.stop_sequences,
-      top_p: apiSession.topP || apiSession.top_p,
-      top_k: apiSession.topK || apiSession.top_k,
-      metadata: apiSession.metadata,
-      cost_usd: apiSession.costUsd || apiSession.cost_usd,
-      input_tokens: apiSession.inputTokens || apiSession.input_tokens,
-      output_tokens: apiSession.outputTokens || apiSession.output_tokens,
-      total_tokens: apiSession.totalTokens || apiSession.total_tokens,
-      // Add legacy fields
-      start_time:
-        apiSession.createdAt instanceof Date
-          ? apiSession.createdAt.toISOString()
-          : apiSession.createdAt || apiSession.created_at,
-      last_activity_at:
-        apiSession.lastActivityAt instanceof Date
-          ? apiSession.lastActivityAt.toISOString()
-          : apiSession.lastActivityAt ||
-            apiSession.last_activity_at ||
-            apiSession.updatedAt ||
-            apiSession.updated_at,
-      end_time: apiSession.completedAt
-        ? apiSession.completedAt instanceof Date
-          ? apiSession.completedAt.toISOString()
-          : apiSession.completedAt
-        : apiSession.end_time,
-      error: apiSession.errorMessage || apiSession.error,
-      working_dir: apiSession.workingDir || apiSession.working_dir,
-      title: apiSession.metadata?.title || apiSession.title,
-    }
-  }
-
-  private transformApproval(apiApproval: any): LegacyApproval {
-    // Transform SDK response (camelCase) to legacy format (snake_case)
-    return {
-      id: apiApproval.id,
-      session_id: apiApproval.sessionId || apiApproval.session_id,
-      run_id: apiApproval.runId || apiApproval.run_id,
-      status: apiApproval.status,
-      tool_name: apiApproval.toolName || apiApproval.tool_name,
-      tool_input: apiApproval.toolParameters || apiApproval.tool_parameters || apiApproval.tool_input,
-      tool_parameters: apiApproval.toolParameters || apiApproval.tool_parameters,
-      created_at:
-        apiApproval.createdAt instanceof Date
-          ? apiApproval.createdAt.toISOString()
-          : apiApproval.createdAt || apiApproval.created_at,
-      responded_at:
-        apiApproval.resolvedAt || apiApproval.resolved_at
-          ? (apiApproval.resolvedAt || apiApproval.resolved_at) instanceof Date
-            ? (apiApproval.resolvedAt || apiApproval.resolved_at).toISOString()
-            : apiApproval.resolvedAt || apiApproval.resolved_at
-          : apiApproval.responded_at,
-      resolved_at:
-        apiApproval.resolvedAt || apiApproval.resolved_at
-          ? (apiApproval.resolvedAt || apiApproval.resolved_at) instanceof Date
-            ? (apiApproval.resolvedAt || apiApproval.resolved_at).toISOString()
-            : apiApproval.resolvedAt || apiApproval.resolved_at
-          : undefined,
-      comment: apiApproval.resolution?.comment || apiApproval.comment,
-      resolution: apiApproval.resolution
-        ? {
-            decision: apiApproval.resolution.decision,
-            comment: apiApproval.resolution.comment,
-            resolved_by: apiApproval.resolution.resolvedBy || apiApproval.resolution.resolved_by,
-          }
-        : undefined,
-    }
-  }
-
-  private transformMessage(apiMessage: ConversationEvent): LegacyConversationEvent {
-    // The SDK ConversationEvent type might have different structure than what we need
-    // For now, pass through and add snake_case mappings as needed
-    const event = apiMessage as any
-    return {
-      id: event.id,
-      session_id: event.sessionId || event.session_id,
-      claude_session_id: event.claudeSessionId || event.claude_session_id,
-      sequence: event.sequence,
-      event_type: event.eventType || event.event_type || ConversationEventType.Message,
-      created_at: event.createdAt || event.created_at,
-      role: event.role,
-      content: event.content,
-      tool_id: event.toolId || event.tool_id,
-      tool_name: event.toolName || event.tool_name,
-      tool_input_json: event.toolInputJson || event.tool_input_json,
-      tool_result_for_id: event.toolResultForId || event.tool_result_for_id,
-      tool_result_content: event.toolResultContent || event.tool_result_content,
-      is_completed: event.isCompleted !== undefined ? event.isCompleted : event.is_completed,
-      approval_status: event.approvalStatus || event.approval_status,
-      approval_id: event.approvalId || event.approval_id,
-      parent_tool_use_id: event.parentToolUseId || event.parent_tool_use_id,
-      // Also include the SDK format fields for compatibility
-      type: event.type,
-      data: event.data,
-      timestamp: event.timestamp,
     }
   }
 }

--- a/humanlayer-wui/src/lib/daemon/types.ts
+++ b/humanlayer-wui/src/lib/daemon/types.ts
@@ -6,6 +6,9 @@ import type {
   Event,
   EventType,
   RecentPath as SDKRecentPath,
+  Session,
+  Approval,
+  ConversationEvent,
 } from '@humanlayer/hld-sdk'
 
 // Re-export SDK types and values
@@ -13,12 +16,11 @@ export { SessionStatus, ApprovalStatus }
 export type { Event, EventType }
 export type RecentPath = SDKRecentPath
 
-// Map to legacy types for backward compatibility
-export type Session = LegacySession // Components expect snake_case
-export type Approval = LegacyApproval // Components expect snake_case
+// Export SDK types directly
+export type { Session, Approval } from '@humanlayer/hld-sdk'
 
-// Map SDK types to existing interfaces for backward compatibility
-export type ConversationEvent = LegacyConversationEvent // Components expect snake_case
+// Export SDK ConversationEvent type directly
+export type { ConversationEvent } from '@humanlayer/hld-sdk'
 export type SessionSnapshot = FileSnapshotInfo // Components expect snake_case
 export type HealthCheckResponse = HealthResponse
 
@@ -28,8 +30,8 @@ export interface LaunchSessionParams extends CreateSessionRequest {
 }
 
 export interface SessionState {
-  session: LegacySession
-  pending_approvals: LegacyApproval[]
+  session: Session
+  pendingApprovals: Approval[]
 }
 
 export interface SubscribeOptions {
@@ -43,105 +45,19 @@ export interface SubscriptionHandle {
   unsubscribe: () => void
 }
 
-// Legacy type mappings for gradual migration
-// TODO: These legacy interfaces exist to maintain backward compatibility with the existing
-// codebase that expects snake_case properties. The SDK uses camelCase (TypeScript convention)
-// but the UI was built expecting snake_case from the original JSON-RPC API.
-//
-// Future refactor: Update all UI code to use camelCase properties directly from the SDK types,
-// then remove these legacy interfaces and the transform functions in http-client.ts
-export interface LegacySession {
-  // Snake_case properties for backward compatibility
-  id: string
-  run_id: string
-  query: string
-  status: SessionStatus
-  created_at: string
-  updated_at: string
-  summary: string
-  parent_session_id?: string
-  claude_session_id?: string
-  auto_accept_edits: boolean
-  archived: boolean
-  // Additional legacy fields
-  start_time: string
-  last_activity_at: string
-  end_time?: string
-  error?: string
-  working_dir?: string
-  title?: string
-  model?: string
-  provider?: string
-  temperature?: number
-  max_tokens?: number
-  stop_sequences?: string[]
-  top_p?: number
-  top_k?: number
-  metadata?: any
-  cost_usd?: number
-  input_tokens?: number
-  output_tokens?: number
-  total_tokens?: number
-}
-
-export interface LegacyApproval {
-  // Snake_case properties for backward compatibility
-  id: string
-  session_id: string
-  run_id: string
-  status: ApprovalStatus
-  tool_name: string
-  tool_input?: any
-  tool_parameters?: any
-  created_at: string
-  responded_at?: string
-  resolved_at?: string
-  comment?: string
-  resolution?: {
-    decision: string
-    comment?: string
-    resolved_by?: string
-  }
-}
-
-export interface LegacyConversationEvent {
-  // Snake_case properties for backward compatibility
-  id?: number
-  session_id?: string
-  claude_session_id?: string
-  sequence?: number
-  event_type: ConversationEventType
-  created_at?: string
-  role?: ConversationRole
-  content?: string
-  tool_id?: string
-  tool_name?: string
-  tool_input_json?: string
-  tool_result_for_id?: string
-  tool_result_content?: string
-  is_completed?: boolean
-  approval_status?: ApprovalStatus | null
-  approval_id?: string
-  parent_tool_use_id?: string
-  // For compatibility with SDK format
-  type?: string
-  data?: any
-  timestamp?: string
-}
-
 // Client interface using legacy types for backward compatibility
 export interface DaemonClient {
   connect(): Promise<void>
   disconnect(): Promise<void>
   health(): Promise<HealthCheckResponse>
 
-  // Session methods (returning legacy types)
+  // Session methods
   launchSession(params: LaunchSessionParams | LaunchSessionRequest): Promise<CreateSessionResponseData>
-  listSessions(): Promise<LegacySession[]>
+  listSessions(): Promise<Session[]>
   getSessionLeaves(request?: {
     include_archived?: boolean
     archived_only?: boolean
-  }): Promise<{ sessions: LegacySession[] }>
+  }): Promise<{ sessions: Session[] }>
   getSessionState(sessionId: string): Promise<SessionState>
   continueSession(
     sessionId: string,
@@ -160,18 +76,18 @@ export interface DaemonClient {
   ): Promise<{ success: boolean; archived_count: number }>
   updateSessionTitle(sessionId: string, title: string): Promise<{ success: boolean }>
 
-  // Conversation methods (returning legacy types)
+  // Conversation methods
   getConversation(
     params: {
       session_id?: string
       claude_session_id?: string
     },
     options?: RequestInit,
-  ): Promise<LegacyConversationEvent[]>
+  ): Promise<ConversationEvent[]>
   getSessionSnapshots(sessionId: string): Promise<SessionSnapshot[]>
 
-  // Approval methods (returning legacy types)
-  fetchApprovals(sessionId?: string): Promise<LegacyApproval[]>
+  // Approval methods
+  fetchApprovals(sessionId?: string): Promise<Approval[]>
   sendDecision(
     approvalId: string,
     decision: 'approve' | 'deny',
@@ -236,28 +152,8 @@ export interface LaunchSessionResponse {
   run_id: string
 }
 
-export interface SessionInfo {
-  id: string
-  run_id: string
-  claude_session_id?: string
-  parent_session_id?: string
-  status: SessionStatus
-  start_time: string
-  end_time?: string
-  last_activity_at: string
-  error?: string
-  query: string
-  summary: string
-  title?: string
-  model?: string
-  working_dir?: string
-  result?: any
-  auto_accept_edits: boolean
-  archived?: boolean
-}
-
 export interface ListSessionsResponse {
-  sessions: SessionInfo[]
+  sessions: Session[]
 }
 
 export interface GetSessionLeavesRequest {
@@ -266,7 +162,7 @@ export interface GetSessionLeavesRequest {
 }
 
 export interface GetSessionLeavesResponse {
-  sessions: SessionInfo[]
+  sessions: Session[]
 }
 
 // Contact channel types

--- a/humanlayer-wui/src/pages/SessionDetailPage.tsx
+++ b/humanlayer-wui/src/pages/SessionDetailPage.tsx
@@ -57,15 +57,14 @@ export function SessionDetailPage() {
     ? activeSessionDetail.session
     : {
         id: sessionId || '',
-        run_id: '',
+        runId: '',
         query: '',
         status: 'unknown' as any,
         model: '',
-        created_at: new Date().toISOString(),
-        start_time: new Date().toISOString(),
-        last_activity_at: new Date().toISOString(),
+        createdAt: new Date(),
+        lastActivityAt: new Date(),
         summary: '',
-        auto_accept_edits: false,
+        autoAcceptEdits: false,
       }
 
   return (

--- a/humanlayer-wui/src/pages/WuiDemo.tsx
+++ b/humanlayer-wui/src/pages/WuiDemo.tsx
@@ -5,7 +5,7 @@ import { Badge } from '@/components/ui/badge'
 import SessionTable from '@/components/internal/SessionTable'
 import { SessionTableSearch } from '@/components/SessionTableSearch'
 import { useSessionFilter } from '@/hooks/useSessionFilter'
-import { SessionInfo } from '@/lib/daemon/types'
+import { Session } from '@/lib/daemon/types'
 import { ThemeSelector } from '@/components/ThemeSelector'
 import { SessionLauncher } from '@/components/SessionLauncher'
 import { DemoStoreProvider, useDemoStore } from '@/stores/demo/providers/DemoStoreProvider'
@@ -31,7 +31,7 @@ function SessionTableWrapper() {
     searchFields: ['summary'],
   })
 
-  const handleActivateSession = (session: SessionInfo) => {
+  const handleActivateSession = (session: Session) => {
     console.log('Activating session:', session.id)
     // In demo mode, this would navigate to session detail
   }

--- a/humanlayer-wui/src/stores/appStore.ts
+++ b/humanlayer-wui/src/stores/appStore.ts
@@ -1,15 +1,15 @@
-import type { SessionInfo, Approval } from '@/lib/daemon/types'
+import type { Session, Approval } from '@/lib/daemon/types'
 import { SessionStatus } from '@/lib/daemon/types'
 import { create, StoreApi } from 'zustand'
 import { daemonClient } from '@/lib/daemon'
 
 export interface AppState {
   /* Sessions */
-  sessions: SessionInfo[]
-  focusedSession: SessionInfo | null
+  sessions: Session[]
+  focusedSession: Session | null
   activeSessionId: string | null
   activeSessionDetail: {
-    session: SessionInfo
+    session: Session
     conversation: any[] // ConversationEvent[] from useConversation
   } | null
 
@@ -23,18 +23,18 @@ export interface AppState {
   notifiedItems: Set<string>
 
   /* Actions */
-  initSessions: (sessions: SessionInfo[]) => void
-  updateSession: (sessionId: string, updates: Partial<SessionInfo>) => void
+  initSessions: (sessions: Session[]) => void
+  updateSession: (sessionId: string, updates: Partial<Session>) => void
   updateSessionStatus: (sessionId: string, status: string) => void
   refreshSessions: () => Promise<void>
-  setFocusedSession: (session: SessionInfo | null) => void
+  setFocusedSession: (session: Session | null) => void
   focusNextSession: () => void
   focusPreviousSession: () => void
   interruptSession: (sessionId: string) => Promise<void>
 
   /* Active Session Detail Actions */
-  setActiveSessionDetail: (sessionId: string, session: SessionInfo, conversation: any[]) => void
-  updateActiveSessionDetail: (updates: Partial<SessionInfo>) => void
+  setActiveSessionDetail: (sessionId: string, session: Session, conversation: any[]) => void
+  updateActiveSessionDetail: (updates: Partial<Session>) => void
   updateActiveSessionConversation: (conversation: any[]) => void
   clearActiveSessionDetail: () => void
   fetchActiveSessionDetail: (sessionId: string) => Promise<void>
@@ -68,8 +68,8 @@ export function createRealAppStore(): StoreApi<AppState> {
     notifiedItems: new Set<string>(),
 
     // Session Actions
-    initSessions: (sessions: SessionInfo[]) => set({ sessions }),
-    updateSession: (sessionId: string, updates: Partial<SessionInfo>) =>
+    initSessions: (sessions: Session[]) => set({ sessions }),
+    updateSession: (sessionId: string, updates: Partial<Session>) =>
       set(state => ({
         sessions: state.sessions.map(session =>
           session.id === sessionId ? { ...session, ...updates } : session,
@@ -113,7 +113,7 @@ export function createRealAppStore(): StoreApi<AppState> {
         console.error('Failed to refresh sessions:', error)
       }
     },
-    setFocusedSession: (session: SessionInfo | null) => set({ focusedSession: session }),
+    setFocusedSession: (session: Session | null) => set({ focusedSession: session }),
     focusNextSession: () =>
       set(state => {
         const { sessions, focusedSession } = state
@@ -154,12 +154,12 @@ export function createRealAppStore(): StoreApi<AppState> {
     },
 
     // Active Session Detail Actions
-    setActiveSessionDetail: (sessionId: string, session: SessionInfo, conversation: any[]) =>
+    setActiveSessionDetail: (sessionId: string, session: Session, conversation: any[]) =>
       set({
         activeSessionDetail: { session, conversation },
         activeSessionId: sessionId,
       }),
-    updateActiveSessionDetail: (updates: Partial<SessionInfo>) =>
+    updateActiveSessionDetail: (updates: Partial<Session>) =>
       set(state => ({
         activeSessionDetail: state.activeSessionDetail
           ? {

--- a/humanlayer-wui/src/stores/demo/animations/sequences.ts
+++ b/humanlayer-wui/src/stores/demo/animations/sequences.ts
@@ -1,27 +1,27 @@
 import { DemoAnimationStep } from '../composedDemoStore'
 import { SessionStatus } from '@/lib/daemon/types'
-import type { SessionInfo } from '@/lib/daemon/types'
+import type { Session } from '@/lib/daemon/types'
 
 // Helper to create realistic session data
 function createMockSession(
   id: string,
   query: string,
   status: SessionStatus,
-  overrides: Partial<SessionInfo> = {},
-): SessionInfo {
+  overrides: Partial<Session> = {},
+): Session {
   const now = new Date()
   return {
     id,
-    run_id: `run-${id}`,
-    claude_session_id: status !== SessionStatus.Starting ? `claude-${id}` : undefined,
+    runId: `run-${id}`,
+    claudeSessionId: status !== SessionStatus.Starting ? `claude-${id}` : undefined,
     status,
-    start_time: now.toISOString(),
-    last_activity_at: now.toISOString(),
+    createdAt: now,
+    lastActivityAt: now,
     query,
     summary: query,
     model: 'claude-3-5-sonnet-20241022',
-    working_dir: '/home/user/project',
-    auto_accept_edits: false,
+    workingDir: '/home/user/project',
+    autoAcceptEdits: false,
     ...overrides,
   }
 }
@@ -153,9 +153,7 @@ export const themeShowcaseSequence: DemoAnimationStep[] = [
         createMockSession('1', 'Build new feature', SessionStatus.Running),
         createMockSession('2', 'Fix production bug', SessionStatus.WaitingInput),
         createMockSession('3', 'Update documentation', SessionStatus.Completed),
-        createMockSession('4', 'Optimize performance', SessionStatus.Failed, {
-          error: 'Connection timeout',
-        }),
+        createMockSession('4', 'Optimize performance', SessionStatus.Failed),
       ],
     },
     themeState: { theme: 'solarized-dark' },

--- a/humanlayer-wui/src/stores/demo/demoAppStore.ts
+++ b/humanlayer-wui/src/stores/demo/demoAppStore.ts
@@ -1,12 +1,12 @@
 import { create, StoreApi } from 'zustand'
-import { SessionInfo, SessionStatus } from '@/lib/daemon/types'
+import { Session, SessionStatus } from '@/lib/daemon/types'
 import { Theme } from '@/contexts/ThemeContext'
 
 // Comprehensive app state for demo animations
 interface DemoAppState {
   // Session data
-  sessions: SessionInfo[]
-  focusedSession: SessionInfo | null
+  sessions: Session[]
+  focusedSession: Session | null
 
   // Launcher state
   launcherOpen: boolean
@@ -34,8 +34,8 @@ interface DemoAppState {
   searchQuery: string
 
   // Actions for demo control
-  setSessions: (sessions: SessionInfo[]) => void
-  setFocusedSession: (session: SessionInfo | null) => void
+  setSessions: (sessions: Session[]) => void
+  setFocusedSession: (session: Session | null) => void
   setLauncherOpen: (open: boolean) => void
   setLauncherMode: (mode: 'command' | 'search') => void
   setLauncherView: (view: 'menu' | 'input') => void
@@ -51,8 +51,8 @@ interface DemoAppState {
   setSearchQuery: (query: string) => void
 
   // Convenience actions
-  addSession: (session: SessionInfo) => void
-  updateSession: (id: string, updates: Partial<SessionInfo>) => void
+  addSession: (session: Session) => void
+  updateSession: (id: string, updates: Partial<Session>) => void
   removeSession: (id: string) => void
   clearSessions: () => void
 
@@ -185,18 +185,18 @@ export function createDemoAppStore(isDemo: boolean = false): StoreApi<DemoAppSta
 
         // Simulate delay and create session
         setTimeout(() => {
-          const newSession: SessionInfo = {
+          const newSession: Session = {
             id: `session-${Date.now()}`,
-            run_id: `run-${Date.now()}`,
-            claude_session_id: `claude-${Date.now()}`,
+            runId: `run-${Date.now()}`,
+            claudeSessionId: `claude-${Date.now()}`,
             status: SessionStatus.Starting,
-            start_time: new Date().toISOString(),
-            last_activity_at: new Date().toISOString(),
+            createdAt: new Date(),
+            lastActivityAt: new Date(),
             query: query,
             summary: query.length > 50 ? query.substring(0, 50) + '...' : query,
             model: 'claude-3-5-sonnet-20241022',
-            working_dir: '/demo/working/dir',
-            auto_accept_edits: false,
+            workingDir: '/demo/working/dir',
+            autoAcceptEdits: false,
           }
 
           set(currentState => ({
@@ -215,8 +215,8 @@ export function createDemoAppStore(isDemo: boolean = false): StoreApi<DemoAppSta
       if (!isDemo) {
         get().updateSession(sessionId, {
           status: SessionStatus.Completed,
-          end_time: new Date().toISOString(),
-          last_activity_at: new Date().toISOString(),
+          completedAt: new Date(),
+          lastActivityAt: new Date(),
         })
       }
     },
@@ -225,9 +225,9 @@ export function createDemoAppStore(isDemo: boolean = false): StoreApi<DemoAppSta
       if (!isDemo) {
         get().updateSession(sessionId, {
           status: SessionStatus.Failed,
-          end_time: new Date().toISOString(),
-          last_activity_at: new Date().toISOString(),
-          error: error,
+          completedAt: new Date(),
+          lastActivityAt: new Date(),
+          errorMessage: error,
         })
       }
     },

--- a/humanlayer-wui/src/stores/demo/export/index.tsx
+++ b/humanlayer-wui/src/stores/demo/export/index.tsx
@@ -15,7 +15,7 @@ import {
 import type { ComposedDemoStore as DemoStore } from '../composedDemoStore'
 import type { DemoAnimationStep as AnimationStep } from '../composedDemoStore'
 import { SessionStatus } from '@/lib/daemon/types'
-import type { SessionInfo } from '@/lib/daemon/types'
+import type { Session } from '@/lib/daemon/types'
 
 // Re-export core functionality
 export { Provider as DemoStoreProvider, useDemoStore }
@@ -38,21 +38,21 @@ export function createMockSession(
   id: string,
   query: string,
   status: SessionStatus = SessionStatus.Running,
-  overrides: Partial<SessionInfo> = {},
-): SessionInfo {
+  overrides: Partial<Session> = {},
+): Session {
   const now = new Date()
   return {
     id,
-    run_id: `run-${id}`,
-    claude_session_id: status !== SessionStatus.Starting ? `claude-${id}` : undefined,
+    runId: `run-${id}`,
+    claudeSessionId: status !== SessionStatus.Starting ? `claude-${id}` : undefined,
     status,
-    start_time: now.toISOString(),
-    last_activity_at: now.toISOString(),
+    createdAt: now,
+    lastActivityAt: now,
     query,
     summary: query,
     model: 'claude-3-5-sonnet-20241022',
-    working_dir: '/home/user/project',
-    auto_accept_edits: false,
+    workingDir: '/home/user/project',
+    autoAcceptEdits: false,
     ...overrides,
   }
 }
@@ -79,7 +79,7 @@ interface SequenceBuilder {
   steps: AnimationStep[]
   addStep(step: AnimationStep): SequenceBuilder
   addDelay(ms: number): SequenceBuilder
-  addSessions(sessions: SessionInfo[]): SequenceBuilder
+  addSessions(sessions: Session[]): SequenceBuilder
   openLauncher(mode?: 'command' | 'search'): SequenceBuilder
   closeLauncher(): SequenceBuilder
   setTheme(theme: string): SequenceBuilder
@@ -105,7 +105,7 @@ export function createSequence(): SequenceBuilder {
       return builder
     },
 
-    addSessions(sessions: SessionInfo[]) {
+    addSessions(sessions: Session[]) {
       steps.push({
         sessionState: { sessions },
         delay: 2000,

--- a/humanlayer-wui/src/stores/demo/slices/sessionSlice.ts
+++ b/humanlayer-wui/src/stores/demo/slices/sessionSlice.ts
@@ -1,18 +1,18 @@
 import { StateCreator } from 'zustand'
-import { SessionInfo } from '@/lib/daemon/types'
+import { Session } from '@/lib/daemon/types'
 
 export interface SessionSlice {
   // State
-  sessions: SessionInfo[]
-  focusedSession: SessionInfo | null
+  sessions: Session[]
+  focusedSession: Session | null
   searchQuery: string
 
   // Actions
-  setSessions: (sessions: SessionInfo[]) => void
-  setFocusedSession: (session: SessionInfo | null) => void
+  setSessions: (sessions: Session[]) => void
+  setFocusedSession: (session: Session | null) => void
   setSearchQuery: (query: string) => void
-  addSession: (session: SessionInfo) => void
-  updateSession: (id: string, updates: Partial<SessionInfo>) => void
+  addSession: (session: Session) => void
+  updateSession: (id: string, updates: Partial<Session>) => void
   removeSession: (id: string) => void
   clearSessions: () => void
 
@@ -21,7 +21,7 @@ export interface SessionSlice {
   focusPreviousSession: () => void
 
   // Utility actions
-  findSessionById: (id: string) => SessionInfo | undefined
+  findSessionById: (id: string) => Session | undefined
   getSessionCount: () => number
   hasSession: (id: string) => boolean
 }

--- a/humanlayer-wui/src/test-utils.ts
+++ b/humanlayer-wui/src/test-utils.ts
@@ -1,30 +1,27 @@
-import type { SessionInfo } from '@/lib/daemon/types'
+import type { Session } from '@/lib/daemon/types'
 import { SessionStatus } from '@/lib/daemon/types'
 
-export function createMockSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+export function createMockSession(overrides: Partial<Session> = {}): Session {
   const id = overrides.id || `session-${Math.random().toString(36).substring(7)}`
-  const timestamp = new Date().toISOString()
+  const timestamp = new Date()
 
   return {
     id,
-    run_id: `run-${id}`,
+    runId: `run-${id}`,
     summary: 'Test session',
     query: 'Test query',
     status: SessionStatus.Running,
-    working_dir: '/home/user/project',
+    workingDir: '/home/user/project',
     model: 'claude-3',
-    start_time: timestamp,
-    last_activity_at: timestamp,
+    createdAt: timestamp,
+    lastActivityAt: timestamp,
     archived: false,
-    auto_accept_edits: false,
+    autoAcceptEdits: false,
     ...overrides,
   }
 }
 
-export function createMockSessions(
-  count: number,
-  overrides: Partial<SessionInfo>[] = [],
-): SessionInfo[] {
+export function createMockSessions(count: number, overrides: Partial<Session>[] = []): Session[] {
   return Array.from({ length: count }, (_, index) => {
     const baseTime = new Date('2024-01-01T00:00:00Z')
     baseTime.setMinutes(index * 2)
@@ -37,9 +34,9 @@ export function createMockSessions(
       summary: `Session ${index + 1}`,
       query: `Test query ${index + 1}`,
       status: index < 2 ? SessionStatus.Running : SessionStatus.Completed,
-      working_dir: `/home/user/project${index + 1}`,
-      start_time: startTime,
-      last_activity_at: lastActivityTime,
+      workingDir: `/home/user/project${index + 1}`,
+      createdAt: new Date(startTime),
+      lastActivityAt: new Date(lastActivityTime),
       ...overrides[index],
     })
   })

--- a/humanlayer-wui/src/utils/enrichment.ts
+++ b/humanlayer-wui/src/utils/enrichment.ts
@@ -20,11 +20,11 @@ export interface ApprovalDisplayData {
 export function getDisplayDataForApproval(approval: Approval): ApprovalDisplayData {
   const baseData = {
     type: 'function' as const,
-    icon: getFunctionIcon(approval.tool_name),
-    color: getFunctionColor(approval.tool_name),
-    title: approval.tool_name,
-    description: getToolDescription(approval.tool_name, approval.tool_input),
-    fields: extractFieldsFromToolInput(approval.tool_name, approval.tool_input),
+    icon: getFunctionIcon(approval.toolName),
+    color: getFunctionColor(approval.toolName),
+    title: approval.toolName,
+    description: getToolDescription(approval.toolName, approval.toolInput),
+    fields: extractFieldsFromToolInput(approval.toolName, approval.toolInput),
   }
 
   return baseData


### PR DESCRIPTION
## What problem(s) was I solving?

The humanlayer-wui codebase was using a legacy type system with snake_case properties that was out of sync with the auto-generated SDK types. This created a maintenance burden with unnecessary transformation functions converting between camelCase SDK types and snake_case legacy types. The transformation layer was prone to errors (like the event timestamp parsing issue) and made the codebase harder to understand.

## What user-facing changes did I ship?

No user-facing changes - this is purely an internal refactoring. The UI continues to work exactly as before, but with cleaner, more maintainable code underneath.

## How I implemented it

### Phase 1: Updated Type System
- Replaced all legacy type definitions (`LegacySession`, `LegacyApproval`, `LegacyConversationEvent`) with SDK types (`Session`, `Approval`, `ConversationEvent`)
- Updated `types.ts` to directly export SDK types instead of mapping to legacy types
- Removed all transformation functions from `http-client.ts` that were converting between type formats

### Phase 2: Component Migration
- Updated ~40 files to use camelCase property access instead of snake_case
- Key changes:
  - `session.working_dir` → `session.workingDir`
  - `event.event_type` → `event.eventType`
  - `approval.tool_name` → `approval.toolName`
  - `event.approval_id` → `event.approvalId`
  - `session.parent_session_id` → `session.parentSessionId`

### Phase 3: Runtime Fixes
- Fixed event timestamp parsing in `http-client.ts` to handle string timestamps from the SDK
- Added handling for the `resolved` approval status in `eventToDisplayObject.tsx`

### Phase 4: Type Safety
- Removed references to `SessionStatus.Interrupting` which doesn't exist in the SDK
- Updated all TypeScript imports from `SessionInfo` to `Session`
- Ensured all date fields are properly converted from ISO strings to Date objects

## How to verify it

- [x] I have ensured `make check test` passes

Manual testing steps:
1. Launch the WUI: `cd humanlayer-wui && bun run dev`
2. Create a new session and verify it appears in the list
3. Open a session detail view and check:
   - Session metadata displays correctly (title, status, working directory)
   - Conversation events render properly
   - Approval flows work (if you have pending approvals)
   - Keyboard navigation works (j/k, x, e)
4. Archive/unarchive sessions to verify state updates work
5. Check the console logs - there should be no TypeScript errors or timestamp parsing errors

## Description for the changelog

Internal: Migrate WUI to use SDK types directly, removing legacy type transformation layer