### PR TITLE
feat(wui): Add keyboard shortcut hints for interrupting running sessions

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -622,6 +622,12 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
               className={`font-mono text-xs uppercase tracking-wider ${getStatusTextClass(session.status)}`}
             >
               {`${renderSessionStatus(session).toUpperCase()}${session.model ? ` / ${session.model}` : ''}`}
+              {(session.status === 'running' || session.status === 'starting') && (
+                <span className="ml-2 text-muted-foreground text-xs font-normal lowercase">
+                  (<kbd className="px-1 py-0.5 text-xs bg-muted/50 rounded normal-case">Ctrl+X</kbd> to
+                  interrupt)
+                </span>
+              )}
             </small>
             {session.working_dir && (
               <small className="font-mono text-xs text-muted-foreground">{session.working_dir}</small>
@@ -699,6 +705,12 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
               className={`font-mono text-xs uppercase tracking-wider ${getStatusTextClass(session.status)}`}
             >
               {`${renderSessionStatus(session).toUpperCase()}${session.model ? ` / ${session.model}` : ''}`}
+              {(session.status === 'running' || session.status === 'starting') && (
+                <span className="ml-2 text-muted-foreground text-xs font-normal lowercase">
+                  (<kbd className="px-1 py-0.5 text-xs bg-muted/50 rounded normal-case">Ctrl+X</kbd> to
+                  interrupt)
+                </span>
+              )}
             </small>
           </hgroup>
           <ForkViewModal

--- a/humanlayer-wui/src/components/internal/SessionDetail/utils/sessionStatus.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/utils/sessionStatus.tsx
@@ -20,11 +20,12 @@ export const getInputPlaceholder = (status: string): string => {
 
 export const getHelpText = (status: string): React.ReactNode => {
   if (status === 'failed') return 'Session failed - cannot continue'
-  const sendKey = navigator.platform.includes('Mac') ? '⌘+Enter' : 'Ctrl+Enter'
+  const isMac = navigator.platform.includes('Mac')
+  const sendKey = isMac ? '⌘+Enter' : 'Ctrl+Enter'
   if (status === 'running' || status === 'starting') {
     return (
       <>
-        <Kbd>{sendKey}</Kbd> to interrupt and send
+        <Kbd>Ctrl+X</Kbd> to interrupt • <Kbd>{sendKey}</Kbd> to interrupt and send
       </>
     )
   }


### PR DESCRIPTION
Display Ctrl+X keyboard hint in session header and help text when session is in running or starting state to improve discoverability of interrupt functionality

ENG-1739

## What problem(s) was I solving?

## What user-facing changes did I ship?

## How I implemented it

## How to verify it

- [ ] I have ensured `make check test` passes

## Description for the changelog

## A picture of a cute animal (not mandatory but encouraged)
