### PR TITLE
dexter/eng 1831 macos build broken post hldsdk typescript stuff

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Run repository setup
+        run: make setup
+
       - name: Install WUI dependencies
         working-directory: humanlayer-wui
         run: bun install

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,10 @@ Claude Code → MCP Protocol → hlyr → JSON-RPC → hld → HumanLayer Cloud 
 - `make check` - Run linting and type checking
 - `make test` - Run all test suites
 
+### GitHub Workflows
+- **Trigger macOS nightly build**: `gh workflow run "Build macOS Release Artifacts" --repo humanlayer/humanlayer`
+- Workflow definitions are located in `.github/workflows/`
+
 ### Python Development
 - Uses `uv` exclusively - never use pip directly
 - Tests are co-located with source as `*_test.py` files


### PR DESCRIPTION
## What problem(s) was I solving?

The macOS build workflow was failing because it couldn't find the `@humanlayer/hld-sdk` TypeScript module when building the humanlayer-wui application. The HLD SDK is a local dependency that needs to be built before the WUI can be compiled, but the workflow was missing the setup step that builds all necessary dependencies.

## What user-facing changes did I ship?

None - this is a CI/CD fix that ensures the macOS release artifacts can be built successfully. The actual application functionality remains unchanged.

## How I implemented it

Added a single step to the GitHub Actions workflow (`.github/workflows/release-macos.yml`) that runs `make setup` before attempting to build the WUI application. The `make setup` command:
- Generates HLD mocks
- Installs NPM dependencies across the monorepo
- Builds the HLD TypeScript SDK (which resolves the missing module error)
- Installs WUI dependencies
- Builds other required components

Also updated CLAUDE.md with documentation about how to trigger the macOS nightly build workflow using the GitHub CLI.

## How to verify it

- [x] I have ensured `make check test` passes
- The workflow can be manually triggered to verify it completes successfully: `gh workflow run "Build macOS Release Artifacts" --repo humanlayer/humanlayer`

## Description for the changelog

Fixed macOS build workflow by adding missing setup step to build local dependencies