### PR TITLE
fix(wui): standardize keyboard shortcuts for message submission

### DIFF
--- a/humanlayer-wui/src/components/CommandInput.tsx
+++ b/humanlayer-wui/src/components/CommandInput.tsx
@@ -44,7 +44,7 @@ export default function CommandInput({
   }, [])
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
       e.preventDefault()
       onSubmit()
     }
@@ -52,6 +52,10 @@ export default function CommandInput({
     if (e.key === 'Escape') {
       promptRef.current?.blur()
     }
+  }
+
+  const getPlatformKey = () => {
+    return navigator.platform.includes('Mac') ? '⌘' : 'Ctrl'
   }
 
   const updateConfig = (updates: Partial<SessionConfig>) => {
@@ -88,6 +92,10 @@ export default function CommandInput({
           autoComplete="off"
           spellCheck={false}
         />
+        <p className="text-xs text-muted-foreground mt-1">
+          <kbd className="px-1 py-0.5 bg-muted/50 rounded">{getPlatformKey()}+Enter</kbd> to launch
+          session, <kbd className="ml-1 px-1 py-0.5 bg-muted/50 rounded">Enter</kbd> for new line
+        </p>
 
         {isLoading && (
           <div className="absolute right-3 top-1/2 -translate-y-1/2">

--- a/humanlayer-wui/src/components/HotkeyPanel.tsx
+++ b/humanlayer-wui/src/components/HotkeyPanel.tsx
@@ -24,6 +24,7 @@ const hotkeyData = [
   { category: 'Global', key: 'C', description: 'Create new session' },
   { category: 'Global', key: 'G', description: 'Navigation prefix (G+S for sessions)' },
   { category: 'Global', key: 'Ctrl+T', description: 'Toggle theme selector' },
+  { category: 'Global', key: '⌘+Enter', description: 'Submit text input' },
 
   // Session List
   { category: 'Session List', key: 'J', description: 'Move down' },

--- a/humanlayer-wui/src/components/SessionLauncher.tsx
+++ b/humanlayer-wui/src/components/SessionLauncher.tsx
@@ -86,7 +86,7 @@ export function SessionLauncher({ isOpen, onClose }: SessionLauncherProps) {
                   value={query}
                   onChange={setQuery}
                   onSubmit={handleSubmit}
-                  placeholder="Enter your prompt to start a session..."
+                  placeholder="Ask an agent..."
                   isLoading={isLaunching}
                   config={config}
                   onConfigChange={setConfig}

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/DenyForm.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/DenyForm.tsx
@@ -44,7 +44,7 @@ export function DenyForm({
     <form onSubmit={handleSubmit} className="flex gap-2 items-center">
       <Input
         type="text"
-        placeholder="Reason for denial... (Enter to submit)"
+        placeholder="Reason for denial..."
         value={reason}
         onChange={e => setReason(e.target.value)}
         onKeyDown={handleKeyDown}


### PR DESCRIPTION
## What problem(s) was I solving?

Users were experiencing inconsistent keyboard behavior when creating new sessions vs continuing existing ones. In new session creation, pressing Enter would immediately submit the prompt, preventing users from writing multiline messages. This was different from existing session messages where Cmd/Ctrl+Enter was required for submission. This inconsistency led to users accidentally launching sessions before finishing their prompts.

## What user-facing changes did I ship?

- **New session creation now requires Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux) to submit** - matching the behavior of existing session messages
- **Enter key now creates new lines** in the new session prompt, allowing multiline messages
- **Added help text** below the prompt input showing the keyboard shortcuts: "⌘+Enter to launch session, Enter for new line"
- **Updated placeholder text** from "Enter your prompt to start a session..." to "Ask an agent..." to avoid implying Enter submits
- **Fixed misleading placeholder** in the deny form that suggested Enter would submit
- **Added documentation** in the hotkey panel (?) showing "⌘+Enter" as the universal submit shortcut

## How I implemented it

1. **Modified CommandInput component** (`humanlayer-wui/src/components/CommandInput.tsx`):
   - Changed keyboard handler from checking `!e.shiftKey` to checking `(e.metaKey || e.ctrlKey)`
   - Added `getPlatformKey()` function to detect Mac vs Windows/Linux for displaying the correct modifier key
   - Added help text below the textarea using `<kbd>` elements for visual consistency

2. **Updated placeholder texts**:
   - SessionLauncher: Changed to "Ask an agent..." to be more generic and avoid key references
   - DenyForm: Removed "(Enter to submit)" suffix from placeholder

3. **Updated documentation**:
   - Added "⌘+Enter" entry to the Global section of HotkeyPanel for discoverability

## How to verify it

- [x] I have ensured `make check test` passes

**Manual testing steps:**
1. Open the WUI and press 'C' or Cmd+K to create a new session
2. Type a multiline prompt using Enter for line breaks - verify Enter creates new lines
3. Press Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux) - verify session is created
4. Check that help text shows the correct platform-specific key (⌘ on Mac, Ctrl on others)
5. In an existing session, verify Cmd/Ctrl+Enter still works for responses (unchanged)
6. Trigger an approval and press 'D' to deny - verify placeholder no longer mentions Enter
7. Press '?' to open hotkey panel - verify "⌘+Enter" is listed under Global shortcuts

## Description for the changelog

fix(wui): standardize keyboard shortcuts for message submission - new sessions now use Cmd/Ctrl+Enter to submit (matching existing sessions), allowing Enter to create multiline prompts