### PR TITLE
List only archived sessions when flipping to archived view

### DIFF
--- a/hld/sdk/typescript/src/client.ts
+++ b/hld/sdk/typescript/src/client.ts
@@ -9,7 +9,8 @@ import {
     CreateSessionResponse,
     CreateSessionResponseData,
     EventFromJSON,
-    RecentPath
+    RecentPath,
+    ListSessionsRequest
 } from './generated';
 
 export interface HLDClientOptions {
@@ -57,7 +58,7 @@ export class HLDClient {
         return response.data;
     }
 
-    async listSessions(params?: { leafOnly?: boolean; includeArchived?: boolean }): Promise<Session[]> {
+    async listSessions(params?: ListSessionsRequest): Promise<Session[]> {
         const response = await this.sessionsApi.listSessions(params);
         return response.data;
     }

--- a/humanlayer-wui/src/lib/daemon/http-client.ts
+++ b/humanlayer-wui/src/lib/daemon/http-client.ts
@@ -166,7 +166,8 @@ export class HTTPDaemonClient implements IDaemonClient {
     // The SDK's listSessions with leafOnly=true is equivalent
     const response = await this.client!.listSessions({
       leafOnly: true,
-      includeArchived: request?.include_archived || request?.archived_only,
+      includeArchived: request?.include_archived,
+      archivedOnly: request?.archived_only,
     })
     return {
       sessions: response,


### PR DESCRIPTION
## What problem(s) was I solving?

The archive tab in the session management UI was incorrectly showing both archived and non-archived sessions. When users clicked on the "Archived" tab, they expected to see only archived sessions, but the view was including all sessions regardless of their archive status. This created confusion and made it difficult to properly manage archived sessions separately from active ones.

## What user-facing changes did I ship?

Users will now see only archived sessions when they switch to the "Archived" tab in the session management interface. This provides a clean separation between active and archived sessions, making it easier to:
- View only archived sessions when needed
- Keep the main session list focused on active sessions
- Properly manage session lifecycle states

## How I implemented it

The fix involved updating the session listing logic to properly handle the `archivedOnly` filter:

1. **Updated the TypeScript SDK client**: Modified the `listSessions` method in `hld/sdk/typescript/src/client.ts` to accept the full `ListSessionsRequest` type instead of an inline parameter object. This ensures all filtering options from the generated API are available.

2. **Fixed the WUI daemon client**: Updated the `getSessionLeaves` method in `humanlayer-wui/src/lib/daemon/http-client.ts` to correctly pass the `archivedOnly` parameter to the SDK. Previously, the `archived_only` flag from the request wasn't being properly mapped to the new `archivedOnly` parameter in the API.

The change maintains backward compatibility while adding the new filtering capability. The `includeArchived` parameter continues to work as before (showing both archived and non-archived sessions), while the new `archivedOnly` parameter enables showing only archived sessions.

## How to verify it

- [x] I have ensured `make check test` passes

Manual verification steps:
1. Open the HumanLayer WUI
2. Create or have some active sessions
3. Archive some sessions using the archive functionality
4. Click on the "Archived" tab
5. Verify that only archived sessions appear in the list
6. Switch back to the main view and verify that archived sessions are not shown there (unless "include archived" is enabled)

## Description for the changelog

Fixed archive tab to show only archived sessions instead of all sessions