### PR TITLE
Justify end scroll something or other

### DIFF
--- a/humanlayer-wui/src-tauri/capabilities/default.json
+++ b/humanlayer-wui/src-tauri/capabilities/default.json
@@ -22,6 +22,7 @@
     "shell:allow-spawn",
     "shell:allow-execute",
     "shell:allow-kill",
+    "shell:allow-open",
     "store:default",
     "log:default"
   ]

--- a/humanlayer-wui/src/App.css
+++ b/humanlayer-wui/src/App.css
@@ -372,6 +372,34 @@
     }
   }
 
+  @keyframes slide-in-up {
+    0% {
+      visibility: visible;
+      transform: translate3d(0, 100%, 0);
+    }
+    100% {
+      transform: translate3d(0, 0, 0);
+    }
+  }
+
+  @keyframes slide-out-down {
+    0% {
+      visibility: visible;
+      transform: translate3d(0, 0, 0);
+    }
+    100% {
+      transform: translate3d(0, 100%, 0);
+    }
+  }
+
+  .animate-slide-in-up {
+    animation: slide-in-up 1s ease-in-out 0.25s 1;
+  }
+
+  .animate-slide-out-down {
+    animation: slide-out-down 1s ease-in-out 0.25s 1;
+  }
+
   .animate-spin-reverse {
     animation: spin-reverse 3s linear infinite;
   }

--- a/humanlayer-wui/src/components/HotkeyPanel.tsx
+++ b/humanlayer-wui/src/components/HotkeyPanel.tsx
@@ -70,6 +70,20 @@ const groupedHotkeys = hotkeyData.reduce(
   {} as Record<string, typeof hotkeyData>,
 )
 
+export const KeyboardShortcut = ({ keyString }: { keyString: string }) => {
+  return (
+    <kbd
+      className={cn(
+        'pointer-events-none inline-flex h-5 select-none items-center gap-1',
+        'rounded border bg-muted px-1.5 font-mono text-sm font-medium',
+        'text-muted-foreground',
+      )}
+    >
+      {keyString}
+    </kbd>
+  )
+}
+
 export function HotkeyPanel({ open, onOpenChange }: HotkeyPanelProps) {
   return (
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
@@ -114,15 +128,7 @@ export function HotkeyPanel({ open, onOpenChange }: HotkeyPanelProps) {
                         className="flex items-center justify-between"
                       >
                         <span className="text-sm">{hotkey.description}</span>
-                        <kbd
-                          className={cn(
-                            'pointer-events-none inline-flex h-5 select-none items-center gap-1',
-                            'rounded border bg-muted px-1.5 font-mono text-[10px] font-medium',
-                            'text-muted-foreground',
-                          )}
-                        >
-                          {hotkey.key}
-                        </kbd>
+                        <KeyboardShortcut keyString={hotkey.key} />
                       </CommandItem>
                     ))}
                   </CommandGroup>

--- a/humanlayer-wui/src/components/ThemeSelector.tsx
+++ b/humanlayer-wui/src/components/ThemeSelector.tsx
@@ -16,6 +16,7 @@ import {
 import { useHotkeys, useHotkeysContext } from 'react-hotkeys-hook'
 import { SessionTableHotkeysScope } from './internal/SessionTable'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { KeyboardShortcut } from './HotkeyPanel'
 
 const themes: { value: Theme; label: string; icon: React.ComponentType<{ className?: string }> }[] = [
   { value: 'solarized-dark', label: 'Solarized Dark', icon: Moon },
@@ -140,7 +141,9 @@ export function ThemeSelector() {
           </button>
         </TooltipTrigger>
         <TooltipContent>
-          <p>Theme: {currentTheme?.label || 'Unknown'} (Ctrl+T)</p>
+          <p className="flex items-center gap-1">
+            Theme: {currentTheme?.label || 'Unknown'} <KeyboardShortcut keyString="Ctrl+T" />
+          </p>
         </TooltipContent>
       </Tooltip>
 

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -89,7 +89,7 @@ const ROBOT_VERBS = [
 function OmniSpinner({ randomVerb, spinnerType }: { randomVerb: string; spinnerType: number }) {
   // Select spinner based on random type
   const FancySpinner = (
-    <div className="relative w-10 h-10">
+    <div className="relative w-2 h-2">
       {/* Outermost orbiting particles */}
       <div className="absolute inset-0 animate-spin-slow">
         <div className="absolute top-0 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-primary/40 animate-pulse" />
@@ -131,7 +131,7 @@ function OmniSpinner({ randomVerb, spinnerType }: { randomVerb: string; spinnerT
   )
 
   const SimpleSpinner = (
-    <div className="relative w-10 h-10">
+    <div className="relative w-2 h-2">
       {/* Single spinning ring */}
       <div className="absolute inset-0 rounded-full border-2 border-primary/20 border-t-primary/60 animate-spin" />
 
@@ -157,13 +157,13 @@ function OmniSpinner({ randomVerb, spinnerType }: { randomVerb: string; spinnerT
   )
 
   const BarsSpinner = (
-    <div className="relative w-10 h-10 flex items-center justify-center gap-1">
+    <div className="relative w-10 h-2 flex items-center justify-center gap-1">
       {/* Five bouncing bars */}
-      <div className="w-1 h-6 bg-primary/40 rounded-full animate-bounce-slow" />
-      <div className="w-1 h-8 bg-primary/60 rounded-full animate-bounce-medium" />
-      <div className="w-1 h-5 bg-primary/80 rounded-full animate-bounce-fast" />
-      <div className="w-1 h-7 bg-primary/60 rounded-full animate-bounce-medium delay-150" />
-      <div className="w-1 h-4 bg-primary/40 rounded-full animate-bounce-slow delay-300" />
+      <div className="w-1 h-2 bg-primary/40 rounded-full animate-bounce-slow" />
+      <div className="w-1 h-3 bg-primary/60 rounded-full animate-bounce-medium" />
+      <div className="w-1 h-2 bg-primary/80 rounded-full animate-bounce-fast" />
+      <div className="w-1 h-1 bg-primary/60 rounded-full animate-bounce-medium delay-150" />
+      <div className="w-1 h-2 bg-primary/40 rounded-full animate-bounce-slow delay-300" />
     </div>
   )
 
@@ -225,6 +225,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
   const { shouldIgnoreMouseEvent, startKeyboardNavigation } = useKeyboardNavigationProtection()
 
   const isActivelyProcessing = ['starting', 'running', 'completing'].includes(session.status)
+  // const isActivelyProcessing = true
   const responseInputRef = useRef<HTMLTextAreaElement>(null)
   const confirmingArchiveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -659,6 +660,13 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
     }
   }, [session.status, events])
 
+  let cardVerticalPadding = isCompactView ? 'py-2' : 'py-4'
+
+  if (isActivelyProcessing) {
+    const cardLoadingLowerPadding = 'pb-12'
+    cardVerticalPadding = isCompactView ? `pt-2 ${cardLoadingLowerPadding}` : `pt-4 ${cardLoadingLowerPadding}`
+  }
+
   return (
     <section className={`flex flex-col h-full ${isCompactView ? 'gap-2' : 'gap-4'}`}>
       {!isCompactView && (
@@ -833,7 +841,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
       <div className={`flex flex-1 gap-4 ${isWideView ? 'flex-row' : 'flex-col'} min-h-0`}>
         {/* Conversation content and Loading */}
         <Card
-          className={`${isWideView ? 'flex-1' : 'w-full'} relative ${isCompactView ? 'py-2' : 'py-4'} flex flex-col min-h-0`}
+          className={`Conversation-Card ${isWideView ? 'flex-1' : 'w-full'} relative ${cardVerticalPadding} flex flex-col min-h-0`}
         >
           <CardContent className={`${isCompactView ? 'px-2' : 'px-4'} flex flex-col flex-1 min-h-0`}>
             <ConversationContent
@@ -860,15 +868,21 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
               expandedTasks={expandedTasks}
               toggleTaskGroup={toggleTaskGroup}
             />
-            <div
+            {/* <div
               className={`border border-terminal-accent/20 absolute bottom-4 left-8 backdrop-blur-xs rounded-2xl p-4 transition-all duration-300 ease-out ${
                 isActivelyProcessing ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0'
               }`}
             >
               <OmniSpinner randomVerb={randomVerb} spinnerType={spinnerType} />
-            </div>
+            </div> */}
           </CardContent>
-          {/* <div>If I type in here where does it show up</div> */}
+          {isActivelyProcessing && (
+            <div className={`absolute bottom-0 left-0 px-3 py-1.5 border-t border-border bg-secondary/30 w-full font-mono text-xs uppercase tracking-wider text-muted-foreground transition-all duration-300 ease-out ${
+                isActivelyProcessing ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0'
+              }`}>
+              <OmniSpinner randomVerb={randomVerb} spinnerType={spinnerType} />
+            </div>
+          )}
         </Card>
 
         {isWideView && lastTodo && (

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -87,8 +87,7 @@ const ROBOT_VERBS = [
 ]
 
 function OmniSpinner({ randomVerb, spinnerType }: { randomVerb: string; spinnerType: number }) {
-
-  spinnerType = 3;
+  spinnerType = 3
   // Select spinner based on random type
   const FancySpinner = (
     <div className="relative w-2 h-2">
@@ -174,9 +173,7 @@ function OmniSpinner({ randomVerb, spinnerType }: { randomVerb: string; spinnerT
   return (
     <div className="flex items-center gap-3 ">
       {spinners[spinnerType]}
-      <p className="text-muted-foreground opacity-80 animate-fade-pulse">
-        {randomVerb}
-      </p>
+      <p className="text-muted-foreground opacity-80 animate-fade-pulse">{randomVerb}</p>
     </div>
   )
 }
@@ -666,7 +663,9 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
 
   if (isActivelyProcessing) {
     const cardLoadingLowerPadding = 'pb-12'
-    cardVerticalPadding = isCompactView ? `pt-2 ${cardLoadingLowerPadding}` : `pt-4 ${cardLoadingLowerPadding}`
+    cardVerticalPadding = isCompactView
+      ? `pt-2 ${cardLoadingLowerPadding}`
+      : `pt-4 ${cardLoadingLowerPadding}`
   }
 
   return (
@@ -879,12 +878,33 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
             </div> */}
           </CardContent>
           {isActivelyProcessing && (
-            <div className={`absolute bottom-0 left-0 px-3 py-1.5 border-t border-border bg-secondary/30 w-full font-mono text-sm uppercase tracking-wider text-muted-foreground transition-all duration-300 ease-out ${
+            <div
+              className={`absolute bottom-0 left-0 px-3 py-1.5 border-t border-border bg-secondary/30 w-full font-mono text-sm uppercase tracking-wider text-muted-foreground transition-all duration-300 ease-out ${
                 isActivelyProcessing ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0'
-              }`}>
+              }`}
+            >
               <OmniSpinner randomVerb={randomVerb} spinnerType={spinnerType} />
             </div>
           )}
+          {/* Status bar for pending approvals */}
+          <div
+            className={`absolute bottom-0 left-0 right-0 p-2 cursor-pointer transition-all duration-300 ease-in-out ${
+              hasPendingApprovalsOutOfView
+                ? 'opacity-100 translate-y-0'
+                : 'opacity-0 translate-y-full pointer-events-none'
+            }`}
+            onClick={() => {
+              const container = document.querySelector('[data-conversation-container]')
+              if (container) {
+                container.scrollTop = container.scrollHeight
+              }
+            }}
+          >
+            <div className="flex items-center justify-center gap-1 font-mono text-xs uppercase tracking-wider text-muted-foreground bg-background/60 backdrop-blur-sm border-t border-border/50 py-1 shadow-sm hover:bg-background/80 transition-colors">
+              <span>Pending Approval</span>
+              <ChevronDown className="w-3 h-3 animate-bounce" />
+            </div>
+          </div>
         </Card>
 
         {isWideView && lastTodo && (

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -86,6 +86,99 @@ const ROBOT_VERBS = [
   'harmonizing',
 ]
 
+function OmniSpinner({ randomVerb, spinnerType }: { randomVerb: string; spinnerType: number }) {
+  // Select spinner based on random type
+  const FancySpinner = (
+    <div className="relative w-10 h-10">
+      {/* Outermost orbiting particles */}
+      <div className="absolute inset-0 animate-spin-slow">
+        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-primary/40 animate-pulse" />
+        <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-primary/40 animate-pulse delay-75" />
+        <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-1 rounded-full bg-primary/40 animate-pulse delay-150" />
+        <div className="absolute right-0 top-1/2 -translate-y-1/2 w-1 h-1 rounded-full bg-primary/40 animate-pulse delay-300" />
+      </div>
+
+      {/* Outer gradient ring */}
+      <div className="absolute inset-0 rounded-full bg-gradient-to-tr from-primary/0 via-primary/30 to-primary/0 animate-spin" />
+
+      {/* Mid rotating ring with gradient */}
+      <div className="absolute inset-1 rounded-full">
+        <div className="absolute inset-0 rounded-full bg-gradient-conic from-primary/10 via-primary/50 to-primary/10 animate-spin-reverse" />
+      </div>
+
+      {/* Inner wave ring */}
+      <div className="absolute inset-2 rounded-full overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-br from-primary/30 via-transparent to-primary/30 animate-wave" />
+      </div>
+
+      {/* Morphing core */}
+      <div className="absolute inset-3 animate-morph">
+        <div className="absolute inset-0 rounded-full bg-gradient-radial from-primary/60 to-primary/20 blur-sm" />
+        <div className="absolute inset-0 rounded-full bg-gradient-to-br from-primary/40 to-transparent" />
+      </div>
+
+      {/* Center glow */}
+      <div className="absolute inset-0 flex items-center justify-center">
+        <div className="relative">
+          <div className="absolute w-2 h-2 rounded-full bg-primary/80 animate-ping" />
+          <div className="relative w-2 h-2 rounded-full bg-primary animate-pulse-bright" />
+        </div>
+      </div>
+
+      {/* Random glitch effect */}
+      <div className="absolute inset-0 rounded-full opacity-20 animate-glitch" />
+    </div>
+  )
+
+  const SimpleSpinner = (
+    <div className="relative w-10 h-10">
+      {/* Single spinning ring */}
+      <div className="absolute inset-0 rounded-full border-2 border-primary/20 border-t-primary/60 animate-spin" />
+
+      {/* Pulsing center dot */}
+      <div className="absolute inset-0 flex items-center justify-center">
+        <div className="w-2 h-2 rounded-full bg-primary/50 animate-pulse" />
+      </div>
+
+      {/* Simple gradient overlay */}
+      <div className="absolute inset-0 rounded-full bg-gradient-to-br from-primary/10 to-transparent" />
+    </div>
+  )
+
+  const MinimalSpinner = (
+    <div className="relative w-10 h-10">
+      {/* Three dots rotating */}
+      <div className="absolute inset-0 animate-spin">
+        <div className="absolute top-1 left-1/2 -translate-x-1/2 w-1.5 h-1.5 rounded-full bg-primary/60" />
+        <div className="absolute bottom-1 left-2 w-1.5 h-1.5 rounded-full bg-primary/40" />
+        <div className="absolute bottom-1 right-2 w-1.5 h-1.5 rounded-full bg-primary/40" />
+      </div>
+    </div>
+  )
+
+  const BarsSpinner = (
+    <div className="relative w-10 h-10 flex items-center justify-center gap-1">
+      {/* Five bouncing bars */}
+      <div className="w-1 h-6 bg-primary/40 rounded-full animate-bounce-slow" />
+      <div className="w-1 h-8 bg-primary/60 rounded-full animate-bounce-medium" />
+      <div className="w-1 h-5 bg-primary/80 rounded-full animate-bounce-fast" />
+      <div className="w-1 h-7 bg-primary/60 rounded-full animate-bounce-medium delay-150" />
+      <div className="w-1 h-4 bg-primary/40 rounded-full animate-bounce-slow delay-300" />
+    </div>
+  )
+
+  const spinners = [FancySpinner, SimpleSpinner, MinimalSpinner, BarsSpinner]
+
+  return (
+    <div className="flex items-center gap-3 ">
+      {spinners[spinnerType]}
+      <p className="text-sm font-medium text-muted-foreground opacity-80 animate-fade-pulse">
+        {randomVerb}
+      </p>
+    </div>
+  )
+}
+
 function SessionDetail({ session, onClose }: SessionDetailProps) {
   const [isWideView, setIsWideView] = useState(false)
   const [isCompactView, setIsCompactView] = useState(false)
@@ -767,131 +860,15 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
               expandedTasks={expandedTasks}
               toggleTaskGroup={toggleTaskGroup}
             />
-            {isActivelyProcessing &&
-              (() => {
-                // Fancy complex spinner
-                const fancySpinner = (
-                  <div className="relative w-10 h-10">
-                    {/* Outermost orbiting particles */}
-                    <div className="absolute inset-0 animate-spin-slow">
-                      <div className="absolute top-0 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-primary/40 animate-pulse" />
-                      <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-primary/40 animate-pulse delay-75" />
-                      <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-1 rounded-full bg-primary/40 animate-pulse delay-150" />
-                      <div className="absolute right-0 top-1/2 -translate-y-1/2 w-1 h-1 rounded-full bg-primary/40 animate-pulse delay-300" />
-                    </div>
-
-                    {/* Outer gradient ring */}
-                    <div className="absolute inset-0 rounded-full bg-gradient-to-tr from-primary/0 via-primary/30 to-primary/0 animate-spin" />
-
-                    {/* Mid rotating ring with gradient */}
-                    <div className="absolute inset-1 rounded-full">
-                      <div className="absolute inset-0 rounded-full bg-gradient-conic from-primary/10 via-primary/50 to-primary/10 animate-spin-reverse" />
-                    </div>
-
-                    {/* Inner wave ring */}
-                    <div className="absolute inset-2 rounded-full overflow-hidden">
-                      <div className="absolute inset-0 bg-gradient-to-br from-primary/30 via-transparent to-primary/30 animate-wave" />
-                    </div>
-
-                    {/* Morphing core */}
-                    <div className="absolute inset-3 animate-morph">
-                      <div className="absolute inset-0 rounded-full bg-gradient-radial from-primary/60 to-primary/20 blur-sm" />
-                      <div className="absolute inset-0 rounded-full bg-gradient-to-br from-primary/40 to-transparent" />
-                    </div>
-
-                    {/* Center glow */}
-                    <div className="absolute inset-0 flex items-center justify-center">
-                      <div className="relative">
-                        <div className="absolute w-2 h-2 rounded-full bg-primary/80 animate-ping" />
-                        <div className="relative w-2 h-2 rounded-full bg-primary animate-pulse-bright" />
-                      </div>
-                    </div>
-
-                    {/* Random glitch effect */}
-                    <div className="absolute inset-0 rounded-full opacity-20 animate-glitch" />
-                  </div>
-                )
-
-                // Simple minimal spinner
-                const simpleSpinner = (
-                  <div className="relative w-10 h-10">
-                    {/* Single spinning ring */}
-                    <div className="absolute inset-0 rounded-full border-2 border-primary/20 border-t-primary/60 animate-spin" />
-
-                    {/* Pulsing center dot */}
-                    <div className="absolute inset-0 flex items-center justify-center">
-                      <div className="w-2 h-2 rounded-full bg-primary/50 animate-pulse" />
-                    </div>
-
-                    {/* Simple gradient overlay */}
-                    <div className="absolute inset-0 rounded-full bg-gradient-to-br from-primary/10 to-transparent" />
-                  </div>
-                )
-
-                // Ultra minimal spinner
-                const minimalSpinner = (
-                  <div className="relative w-10 h-10">
-                    {/* Three dots rotating */}
-                    <div className="absolute inset-0 animate-spin">
-                      <div className="absolute top-1 left-1/2 -translate-x-1/2 w-1.5 h-1.5 rounded-full bg-primary/60" />
-                      <div className="absolute bottom-1 left-2 w-1.5 h-1.5 rounded-full bg-primary/40" />
-                      <div className="absolute bottom-1 right-2 w-1.5 h-1.5 rounded-full bg-primary/40" />
-                    </div>
-                  </div>
-                )
-
-                // Bouncing bars spinner
-                const barsSpinner = (
-                  <div className="relative w-10 h-10 flex items-center justify-center gap-1">
-                    {/* Five bouncing bars */}
-                    <div className="w-1 h-6 bg-primary/40 rounded-full animate-bounce-slow" />
-                    <div className="w-1 h-8 bg-primary/60 rounded-full animate-bounce-medium" />
-                    <div className="w-1 h-5 bg-primary/80 rounded-full animate-bounce-fast" />
-                    <div className="w-1 h-7 bg-primary/60 rounded-full animate-bounce-medium delay-150" />
-                    <div className="w-1 h-4 bg-primary/40 rounded-full animate-bounce-slow delay-300" />
-                  </div>
-                )
-
-                // Select spinner based on random type
-                const spinner =
-                  spinnerType === 0
-                    ? fancySpinner
-                    : spinnerType === 1
-                      ? simpleSpinner
-                      : spinnerType === 2
-                        ? minimalSpinner
-                        : barsSpinner
-
-                return (
-                  <div className="flex items-center gap-3 mt-4 pl-4">
-                    {spinner}
-                    <p className="text-sm font-medium text-muted-foreground opacity-80 animate-fade-pulse">
-                      {randomVerb}
-                    </p>
-                  </div>
-                )
-              })()}
-
-            {/* Status bar for pending approvals */}
             <div
-              className={`absolute bottom-0 left-0 right-0 p-2 cursor-pointer transition-all duration-300 ease-in-out ${
-                hasPendingApprovalsOutOfView
-                  ? 'opacity-100 translate-y-0'
-                  : 'opacity-0 translate-y-full pointer-events-none'
+              className={`border border-terminal-accent/20 absolute bottom-4 left-8 backdrop-blur-xs rounded-2xl p-4 transition-all duration-300 ease-out ${
+                isActivelyProcessing ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0'
               }`}
-              onClick={() => {
-                const container = document.querySelector('[data-conversation-container]')
-                if (container) {
-                  container.scrollTop = container.scrollHeight
-                }
-              }}
             >
-              <div className="flex items-center justify-center gap-1 font-mono text-xs uppercase tracking-wider text-muted-foreground bg-background/60 backdrop-blur-sm border-t border-border/50 py-1 shadow-sm hover:bg-background/80 transition-colors">
-                <span>Pending Approval</span>
-                <ChevronDown className="w-3 h-3 animate-bounce" />
-              </div>
+              <OmniSpinner randomVerb={randomVerb} spinnerType={spinnerType} />
             </div>
           </CardContent>
+          {/* <div>If I type in here where does it show up</div> */}
         </Card>
 
         {isWideView && lastTodo && (

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -87,6 +87,8 @@ const ROBOT_VERBS = [
 ]
 
 function OmniSpinner({ randomVerb, spinnerType }: { randomVerb: string; spinnerType: number }) {
+
+  spinnerType = 3;
   // Select spinner based on random type
   const FancySpinner = (
     <div className="relative w-2 h-2">
@@ -172,7 +174,7 @@ function OmniSpinner({ randomVerb, spinnerType }: { randomVerb: string; spinnerT
   return (
     <div className="flex items-center gap-3 ">
       {spinners[spinnerType]}
-      <p className="text-sm font-medium text-muted-foreground opacity-80 animate-fade-pulse">
+      <p className="text-muted-foreground opacity-80 animate-fade-pulse">
         {randomVerb}
       </p>
     </div>
@@ -877,7 +879,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
             </div> */}
           </CardContent>
           {isActivelyProcessing && (
-            <div className={`absolute bottom-0 left-0 px-3 py-1.5 border-t border-border bg-secondary/30 w-full font-mono text-xs uppercase tracking-wider text-muted-foreground transition-all duration-300 ease-out ${
+            <div className={`absolute bottom-0 left-0 px-3 py-1.5 border-t border-border bg-secondary/30 w-full font-mono text-sm uppercase tracking-wider text-muted-foreground transition-all duration-300 ease-out ${
                 isActivelyProcessing ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0'
               }`}>
               <OmniSpinner randomVerb={randomVerb} spinnerType={spinnerType} />

--- a/humanlayer-wui/src/components/internal/SessionDetail/utils/sessionStatus.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/utils/sessionStatus.tsx
@@ -1,8 +1,12 @@
 import React from 'react'
 
-export const Kbd = ({ children, className = '' }: { children: React.ReactNode; className?: string }) => (
-  <kbd className={`px-1 py-0.5 bg-muted rounded ${className}`}>{children}</kbd>
-)
+export const Kbd = ({
+  children,
+  className = '',
+}: {
+  children: React.ReactNode
+  className?: string
+}) => <kbd className={`px-1 py-0.5 bg-muted rounded ${className}`}>{children}</kbd>
 
 export const getSessionStatusText = (status: string): string => {
   if (status === 'completed') return 'Continue this conversation with a new message'

--- a/humanlayer-wui/src/components/internal/SessionDetail/utils/sessionStatus.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/utils/sessionStatus.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const Kbd = ({ children, className = '' }: { children: React.ReactNode; className?: string }) => (
+export const Kbd = ({ children, className = '' }: { children: React.ReactNode; className?: string }) => (
   <kbd className={`px-1 py-0.5 bg-muted rounded ${className}`}>{children}</kbd>
 )
 

--- a/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
@@ -219,7 +219,7 @@ export function ConversationContent({
       <div
         ref={containerRef}
         data-conversation-container
-        className="overflow-y-auto flex-1 flex flex-col justify-end"
+        className="overflow-y-auto flex-1 flex flex-col"
       >
         <div>
           {nonEmptyDisplayObjects.map((displayObject, index) => (
@@ -333,7 +333,7 @@ export function ConversationContent({
     <div
       ref={containerRef}
       data-conversation-container
-      className="overflow-y-auto flex-1 flex flex-col justify-end"
+      className="overflow-y-auto flex-1 flex flex-col"
     >
       <div>
         {rootEvents

--- a/humanlayer-wui/src/components/ui/keyboard-shortcut.tsx
+++ b/humanlayer-wui/src/components/ui/keyboard-shortcut.tsx
@@ -23,16 +23,16 @@ const KeyboardShortcut = React.forwardRef<HTMLSpanElement, KeyboardShortcutProps
           // Size variants
           size === 'sm' && 'px-1.5 py-0.5 text-xs min-w-[1.25rem] h-5',
           size === 'md' && 'px-2 py-1 text-sm min-w-[1.5rem] h-6',
-          className
+          className,
         )}
         {...props}
       >
         {children}
       </span>
     )
-  }
+  },
 )
 
 KeyboardShortcut.displayName = 'KeyboardShortcut'
 
-export { KeyboardShortcut } 
+export { KeyboardShortcut }

--- a/humanlayer-wui/src/components/ui/keyboard-shortcut.tsx
+++ b/humanlayer-wui/src/components/ui/keyboard-shortcut.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface KeyboardShortcutProps extends React.HTMLAttributes<HTMLSpanElement> {
+  children: React.ReactNode
+  size?: 'sm' | 'md'
+}
+
+const KeyboardShortcut = React.forwardRef<HTMLSpanElement, KeyboardShortcutProps>(
+  ({ className, children, size = 'sm', ...props }, ref) => {
+    return (
+      <span
+        ref={ref}
+        className={cn(
+          // Base styles - emulating the chicklet appearance
+          'inline-flex items-center justify-center',
+          'bg-transparent', // Transparent background
+          'border border-border', // Use app's border color
+          'rounded-md', // Slightly rounded corners
+          'font-mono font-medium', // Clean typography
+          'text-muted-foreground', // Use muted text color like tooltips
+          'select-none', // Prevent text selection
+          // Size variants
+          size === 'sm' && 'px-1.5 py-0.5 text-xs min-w-[1.25rem] h-5',
+          size === 'md' && 'px-2 py-1 text-sm min-w-[1.5rem] h-6',
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </span>
+    )
+  }
+)
+
+KeyboardShortcut.displayName = 'KeyboardShortcut'
+
+export { KeyboardShortcut } 

--- a/humanlayer-wui/src/pages/SessionDetailPage.tsx
+++ b/humanlayer-wui/src/pages/SessionDetailPage.tsx
@@ -53,7 +53,7 @@ export function SessionDetailPage() {
 
   // Render SessionDetail even during loading so it can show its skeleton UI
   // Pass a minimal session object if still loading
-  const session = activeSessionDetail?.session?.id
+  let session = activeSessionDetail?.session?.id
     ? activeSessionDetail.session
     : {
         id: sessionId || '',


### PR DESCRIPTION
## What problem(s) was I solving?

- **UI flash when continuing sessions**: Users experienced a jarring flash of empty content when continuing a conversation, as the session data wasn't preserved during navigation
- **Inconsistent keyboard shortcut display**: Keyboard shortcuts in tooltips had different styling compared to the keyboard shortcut panel
- **Scrolling behavior issues**: The conversation view used `justify-end` which caused unexpected scrolling behavior
- **Missing loading indicator**: When sessions were actively processing, there was no clear visual indicator of the ongoing activity

## What user-facing changes did I ship?

- **Smooth session continuation**: Eliminated the loading flash when continuing sessions - the conversation now transitions seamlessly to the new session
- **Consistent keyboard shortcuts**: All keyboard shortcuts across the UI now use the same visual styling (chicklet-style with borders)
- **Improved scrolling**: Fixed conversation view scrolling to behave more naturally
- **Enhanced loading state**: Added a subtle loading indicator at the bottom of active sessions showing the processing status

## How I implemented it

- **Session continuation fix**: 
  - Pre-fetch the new session data before navigation in `useSessionActions`
  - Pass session state through React Router's navigation state
  - Update `activeSessionDetail` immediately in the Layout component when receiving continuation state
  - This ensures valid session data is available throughout the entire navigation flow

- **Keyboard shortcut consistency**:
  - Created a reusable `KeyboardShortcut` component that provides consistent chicklet-style rendering
  - Updated tooltips in `ThemeSelector` and `Layout` to use this component
  - Exported `KeyboardShortcut` from `HotkeyPanel` for use across the app

- **UI improvements**:
  - Changed conversation container from `justify-end` to regular flex layout
  - Added `OmniSpinner` component with multiple animation styles for loading states
  - Added Tauri capability `shell:allow-open` for future shell integration

## How to verify it

- [x] I have ensured `make check test` passes

**Manual testing steps:**
1. Open a completed session in CodeLayer
2. Type a message and continue the session
3. Verify there's no flash of empty content - the transition should be smooth
4. Check that keyboard shortcuts in tooltips match the style in the keyboard shortcut panel (Ctrl+K)
5. Verify conversation scrolling behaves naturally (content starts at top, not bottom)
6. Start a new Claude Code session and verify the loading indicator appears at the bottom while processing

## Description for the changelog

Fix UI flash when continuing sessions and improve keyboard shortcut display consistency