### PR TITLE
Sam/eng 1862 regression directories should be left truncated not right

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -434,20 +434,20 @@ export default function SessionTable({
                     <Tooltip>
                       <TooltipTrigger asChild>
                         {/* Sets direction RTL with ellipsis at the start, and uses an inner <bdo> LTR override to keep the entire path (slashes/tilde) in logical order*/}
-                      <span
-                        className="block truncate cursor-help text-sm"
-                        style={{
-                          direction: 'rtl',
-                          textAlign: 'left',
-                          overflow: 'hidden',
-                          whiteSpace: 'nowrap',
-                          textOverflow: 'ellipsis'
-                        }}
-                      >
-                        <bdo dir="ltr" style={{ unicodeBidi: 'bidi-override' }}>
-                          {session.workingDir || '-'}
-                        </bdo>
-                      </span>
+                        <span
+                          className="block truncate cursor-help text-sm"
+                          style={{
+                            direction: 'rtl',
+                            textAlign: 'left',
+                            overflow: 'hidden',
+                            whiteSpace: 'nowrap',
+                            textOverflow: 'ellipsis',
+                          }}
+                        >
+                          <bdo dir="ltr" style={{ unicodeBidi: 'bidi-override' }}>
+                            {session.workingDir || '-'}
+                          </bdo>
+                        </span>
                       </TooltipTrigger>
                       <TooltipContent className="max-w-[600px]">
                         <span className="font-mono text-sm">

--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -435,9 +435,17 @@ export default function SessionTable({
                       <TooltipTrigger asChild>
                         <span
                           className="block truncate cursor-help text-sm"
-                          style={{ textAlign: 'left' }}
+                          style={{
+                            direction: 'rtl',
+                            textAlign: 'left',
+                            overflow: 'hidden',
+                            whiteSpace: 'nowrap',
+                            textOverflow: 'ellipsis',
+                          }}
                         >
-                          {session.workingDir || '-'}
+                          <bdo dir="ltr" style={{ unicodeBidi: 'bidi-override' }}>
+                            {session.workingDir || '-'}
+                          </bdo>
                         </span>
                       </TooltipTrigger>
                       <TooltipContent className="max-w-[600px]">

--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -433,20 +433,21 @@ export default function SessionTable({
                   <TableCell className="max-w-[200px]">
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <span
-                          className="block truncate cursor-help text-sm"
-                          style={{
-                            direction: 'rtl',
-                            textAlign: 'left',
-                            overflow: 'hidden',
-                            whiteSpace: 'nowrap',
-                            textOverflow: 'ellipsis',
-                          }}
-                        >
-                          <bdo dir="ltr" style={{ unicodeBidi: 'bidi-override' }}>
-                            {session.workingDir || '-'}
-                          </bdo>
-                        </span>
+                        {/* Sets direction RTL with ellipsis at the start, and uses an inner <bdo> LTR override to keep the entire path (slashes/tilde) in logical order*/}
+                      <span
+                        className="block truncate cursor-help text-sm"
+                        style={{
+                          direction: 'rtl',
+                          textAlign: 'left',
+                          overflow: 'hidden',
+                          whiteSpace: 'nowrap',
+                          textOverflow: 'ellipsis'
+                        }}
+                      >
+                        <bdo dir="ltr" style={{ unicodeBidi: 'bidi-override' }}>
+                          {session.workingDir || '-'}
+                        </bdo>
+                      </span>
                       </TooltipTrigger>
                       <TooltipContent className="max-w-[600px]">
                         <span className="font-mono text-sm">


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change directory path display in `SessionTable.tsx` to left-truncate using RTL text direction and LTR override.
> 
>   - **Behavior**:
>     - Changes directory path display in `SessionTable.tsx` to be left-truncated using RTL text direction and LTR override.
>     - Affects `TableCell` for working directory display.
>   - **UI**:
>     - Uses `span` with `bdo` for logical order of path components.
>     - Ensures ellipsis appears at the start of the path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 94fb2d2fdd400b409a21efc9664cfc447fce037f. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->