### PR TITLE
Pre-fill session launcher directory picker with ~/ on first use

### DIFF
--- a/humanlayer-wui/CLAUDE.md
+++ b/humanlayer-wui/CLAUDE.md
@@ -29,6 +29,7 @@ For UI development, we use Radix UI components styled with Tailwind CSS. State m
 - DO provide a manual list of steps for a human to test new UI changes.
 
 ## Guidelines
+
 - In React 19, ref is now available as a standard prop for functional components, eliminating the need to wrap components with forwardRef.
 - forwardRef is now depricated, NEVER use it. use ref instead.
 

--- a/humanlayer-wui/CLAUDE.md
+++ b/humanlayer-wui/CLAUDE.md
@@ -28,6 +28,10 @@ For UI development, we use Radix UI components styled with Tailwind CSS. State m
 - DO verify your changes with `bun run lint` and `bun run typecheck`.
 - DO provide a manual list of steps for a human to test new UI changes.
 
+## Guidelines
+- In React 19, ref is now available as a standard prop for functional components, eliminating the need to wrap components with forwardRef.
+- forwardRef is now depricated, NEVER use it. use ref instead.
+
 ## Testing
 
 We use Bun's built-in test runner for unit tests. Run tests with `bun test`.

--- a/humanlayer-wui/src/components/CommandInput.tsx
+++ b/humanlayer-wui/src/components/CommandInput.tsx
@@ -34,11 +34,19 @@ export default function CommandInput({
   onConfigChange,
 }: CommandInputProps) {
   const promptRef = useRef<HTMLTextAreaElement>(null)
+  const directoryRef = useRef<HTMLInputElement>(null)
   const { paths: recentPaths } = useRecentPaths()
 
   useEffect(() => {
-    // focus on the prompt when the component mounts
-    if (promptRef.current) {
+    // Focus on directory field if it has the default value, otherwise focus on prompt
+    if (config.workingDir === '~/') {
+      // Focus on directory field when it has the default value
+      const directoryInput = directoryRef.current?.querySelector('input')
+      if (directoryInput) {
+        directoryInput.focus()
+      }
+    } else if (promptRef.current) {
+      // Focus on prompt field for normal usage
       promptRef.current.focus()
     }
   }, [])
@@ -70,6 +78,7 @@ export default function CommandInput({
       <div className="space-y-2">
         <Label>Working Directory</Label>
         <SearchInput
+          ref={directoryRef}
           value={config.workingDir}
           onChange={value => onConfigChange?.({ ...config, workingDir: value })}
           onSubmit={onSubmit}

--- a/humanlayer-wui/src/components/FuzzySearchInput.tsx
+++ b/humanlayer-wui/src/components/FuzzySearchInput.tsx
@@ -16,6 +16,7 @@ interface SearchInputProps {
   onSubmit?: () => void
   placeholder?: string
   recentDirectories?: RecentPath[]
+  ref?: React.RefObject<HTMLDivElement>
 }
 
 export function SearchInput({
@@ -24,6 +25,7 @@ export function SearchInput({
   onSubmit,
   placeholder = 'Type a directory path...',
   recentDirectories = [],
+  ref,
 }: SearchInputProps = {}) {
   // Use internal state if not controlled
   const [internalValue, setInternalValue] = useState('')
@@ -241,7 +243,7 @@ export function SearchInput({
   }
 
   return (
-    <div className="">
+    <div ref={ref} className="">
       <Popover open={dropdownOpen && isFocused} defaultOpen={false} modal={true}>
         <PopoverAnchor>
           <Input

--- a/humanlayer-wui/src/hooks/useSessionLauncher.ts
+++ b/humanlayer-wui/src/hooks/useSessionLauncher.ts
@@ -41,12 +41,18 @@ interface LauncherState {
 
 const LAST_WORKING_DIR_KEY = 'humanlayer-last-working-dir'
 
+// Helper function to get default working directory
+const getDefaultWorkingDir = (): string => {
+  const stored = localStorage.getItem(LAST_WORKING_DIR_KEY)
+  return stored || '~/' // Default to home directory on first launch
+}
+
 export const useSessionLauncher = create<LauncherState>((set, get) => ({
   isOpen: false,
   mode: 'command',
   view: 'menu',
   query: '',
-  config: { query: '', workingDir: localStorage.getItem(LAST_WORKING_DIR_KEY) || '' },
+  config: { query: '', workingDir: getDefaultWorkingDir() },
   isLaunching: false,
   gPrefixMode: false,
   selectedMenuIndex: 0,
@@ -65,7 +71,7 @@ export const useSessionLauncher = create<LauncherState>((set, get) => ({
       isOpen: false,
       view: 'menu',
       query: '',
-      config: { query: '', workingDir: localStorage.getItem(LAST_WORKING_DIR_KEY) || '' },
+      config: { query: '', workingDir: getDefaultWorkingDir() },
       selectedMenuIndex: 0,
       error: undefined,
       gPrefixMode: false,
@@ -169,7 +175,7 @@ export const useSessionLauncher = create<LauncherState>((set, get) => ({
     set({
       view: 'input',
       query: '',
-      config: { query: '', workingDir: localStorage.getItem(LAST_WORKING_DIR_KEY) || '' },
+      config: { query: '', workingDir: getDefaultWorkingDir() },
       error: undefined,
     })
   },
@@ -186,7 +192,7 @@ export const useSessionLauncher = create<LauncherState>((set, get) => ({
       mode: 'command',
       view: 'menu',
       query: '',
-      config: { query: '', workingDir: localStorage.getItem(LAST_WORKING_DIR_KEY) || '' },
+      config: { query: '', workingDir: getDefaultWorkingDir() },
       selectedMenuIndex: 0,
       isLaunching: false,
       error: undefined,


### PR DESCRIPTION
## What problem(s) was I solving?

First-time CodeLayer users were presented with an empty working directory field when launching Claude Code sessions, creating uncertainty about what to enter. Users had to manually type a path or leave it empty, which caused friction and confusion about the expected input format.

## What user-facing changes did I ship?

- The working directory field now defaults to `~/` (home directory) for first-time users
- When the default value is present, the focus automatically goes to the directory field instead of the prompt field, guiding users to set their preferred directory
- Once a user selects a directory, it's remembered for future sessions (existing behavior preserved)

## How I implemented it

1. Created a `getDefaultWorkingDir()` helper function in `useSessionLauncher.ts` that checks localStorage for a previously saved directory, falling back to `~/` if none exists
2. Added smart focus logic in `CommandInput.tsx` that detects when the directory field contains the default value and focuses it to encourage users to set their preferred path
3. Enhanced `FuzzySearchInput.tsx` to support ref forwarding using React 19's standard ref prop pattern (no forwardRef needed)
4. Applied the default consistently across all state initialization points (initial state, launcher close, new session, and reset)

## How to verify it

- [x] I have ensured `make check test` passes

**Manual testing steps:**
1. Clear localStorage (or use an incognito window) to simulate a first-time user
2. Open CodeLayer and press Cmd+K to open the session launcher
3. Verify the working directory field shows `~/` and has focus
4. Select a different directory and launch a session
5. Close and reopen the launcher - verify your chosen directory persists
6. Test that existing users with saved directories still see their saved path with focus on the prompt field

## Description for the changelog

Pre-fill session launcher directory picker with ~/ on first use - New users now see their home directory as the default working directory, with automatic focus to guide them to set their preferred location
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Pre-fill session launcher directory picker with `~/` for first-time users and focus directory field when default value is present.
> 
>   - **Behavior**:
>     - Default working directory set to `~/` for first-time users in `useSessionLauncher.ts`.
>     - Focus logic added in `CommandInput.tsx` to focus directory field if default value is `~/`.
>     - Directory selection persists across sessions.
>   - **Components**:
>     - `getDefaultWorkingDir()` function in `useSessionLauncher.ts` to fetch default directory.
>     - `SearchInput` in `FuzzySearchInput.tsx` updated to support ref forwarding.
>   - **Misc**:
>     - Updated `CLAUDE.md` to reflect React 19 ref usage guidelines.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 5aac54e8d78f78423d62690bead34f88f86ba1d6. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->