### PR TITLE
fix: resolve UI polish issues for bypass permissions dialog

### DIFF
--- a/humanlayer-wui/src/components/HotkeyPanel.tsx
+++ b/humanlayer-wui/src/components/HotkeyPanel.tsx
@@ -56,6 +56,7 @@ const hotkeyData = [
   { category: 'Session Detail', key: 'Shift+Tab', description: 'Toggle auto-accept edits' },
   { category: 'Session Detail', key: 'Enter', description: 'Focus response input' },
   { category: 'Session Detail', key: '⌘+Enter', description: 'Submit response' },
+  { category: 'Session Detail', key: '⌥+Y', description: 'Toggle bypass permissions' },
 ]
 
 // Group hotkeys by category

--- a/humanlayer-wui/src/components/internal/SessionDetail/DangerouslySkipPermissionsDialog.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/DangerouslySkipPermissionsDialog.tsx
@@ -13,6 +13,9 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Checkbox } from '@/components/ui/checkbox'
 import { AlertTriangle } from 'lucide-react'
+import { useStealHotkeyScope } from '@/hooks/useStealHotkeyScope'
+
+const DangerouslySkipPermissionsHotkeysScope = 'dangerously-skip-permissions-dialog'
 
 interface DangerouslySkipPermissionsDialogProps {
   open: boolean
@@ -20,22 +23,23 @@ interface DangerouslySkipPermissionsDialogProps {
   onConfirm: (timeoutMinutes: number | null) => void
 }
 
-export const DangerouslySkipPermissionsDialog: FC<DangerouslySkipPermissionsDialogProps> = ({
-  open,
-  onOpenChange,
-  onConfirm,
-}) => {
+// Inner component that uses the hotkey scope stealing
+const DangerouslySkipPermissionsDialogContent: FC<{
+  onOpenChange: (open: boolean) => void
+  onConfirm: (timeoutMinutes: number | null) => void
+}> = ({ onOpenChange, onConfirm }) => {
+  // Steal hotkey scope when this component mounts
+  useStealHotkeyScope(DangerouslySkipPermissionsHotkeysScope)
+
   const [timeoutMinutes, setTimeoutMinutes] = useState<number | ''>(15)
   const [useTimeout, setUseTimeout] = useState(true)
   const timeoutInputRef = useRef<HTMLInputElement>(null)
 
-  // Reset to default when dialog opens
+  // Reset to default when component mounts (dialog opens)
   React.useEffect(() => {
-    if (open) {
-      setTimeoutMinutes(15)
-      setUseTimeout(true)
-    }
-  }, [open])
+    setTimeoutMinutes(15)
+    setUseTimeout(true)
+  }, [])
 
   const handleConfirm = () => {
     const minutes = useTimeout ? (timeoutMinutes === '' ? 15 : timeoutMinutes) : null
@@ -44,91 +48,105 @@ export const DangerouslySkipPermissionsDialog: FC<DangerouslySkipPermissionsDial
   }
 
   return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2 text-[var(--terminal-error)] text-base font-bold">
+          <AlertTriangle className="h-4 w-4" />
+          Bypass Permissions
+        </DialogTitle>
+        <DialogDescription asChild>
+          <div className="space-y-2">
+            <p>
+              Bypassing permissions will <strong>automatically accept ALL tool calls</strong> without
+              your approval. This includes:
+            </p>
+            <ul className="list-disc list-inside space-y-1">
+              <li>File edits and writes</li>
+              <li>Running bash commands</li>
+              <li>Reading files</li>
+              <li>Spawning sub-tasks</li>
+              <li>All MCP tool calls</li>
+            </ul>
+            <p className="text-[var(--terminal-error)] font-semibold">Use with extreme caution!</p>
+          </div>
+        </DialogDescription>
+      </DialogHeader>
+      <div className="pb-0 pt-6">
+        <div className="flex items-center justify-end space-x-2 min-h-[36px]">
+          <Checkbox
+            id="use-timeout"
+            checked={useTimeout}
+            onCheckedChange={(checked: boolean) => {
+              setUseTimeout(checked)
+              if (checked) {
+                setTimeout(() => {
+                  if (timeoutInputRef.current) {
+                    timeoutInputRef.current.focus()
+                    const value = timeoutInputRef.current.value
+                    timeoutInputRef.current.setSelectionRange(value.length, value.length)
+                  }
+                }, 0)
+              }
+            }}
+          />
+          <Label htmlFor="use-timeout">Auto-disable after</Label>
+          {useTimeout ? (
+            <>
+              <Input
+                ref={timeoutInputRef}
+                id="timeout"
+                type="number"
+                min="1"
+                max="60"
+                value={timeoutMinutes}
+                onChange={e => {
+                  const value = e.target.value
+                  if (value === '') {
+                    setTimeoutMinutes('')
+                  } else {
+                    const parsed = parseInt(value)
+                    if (!isNaN(parsed) && parsed >= 0) {
+                      setTimeoutMinutes(parsed)
+                    }
+                  }
+                }}
+                className="w-20 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              />
+              <span>{timeoutMinutes === 1 ? 'minute' : 'minutes'}</span>
+            </>
+          ) : (
+            <span>timeout</span>
+          )}
+        </div>
+      </div>
+      <DialogFooter>
+        <Button variant="outline" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button
+          variant="outline"
+          onClick={handleConfirm}
+          disabled={useTimeout && (timeoutMinutes === '' || timeoutMinutes === 0)}
+          className="border-[var(--terminal-error)] text-[var(--terminal-error)] hover:bg-[var(--terminal-error)] hover:text-background disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Bypass Permissions
+        </Button>
+      </DialogFooter>
+    </>
+  )
+}
+
+export const DangerouslySkipPermissionsDialog: FC<DangerouslySkipPermissionsDialogProps> = ({
+  open,
+  onOpenChange,
+  onConfirm,
+}) => {
+  return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[475px]">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2 text-[var(--terminal-error)] text-base font-bold">
-            <AlertTriangle className="h-4 w-4" />
-            Bypass Permissions
-          </DialogTitle>
-          <DialogDescription asChild>
-            <div className="space-y-2">
-              <p>
-                Bypassing permissions will <strong>automatically accept ALL tool calls</strong> without
-                your approval. This includes:
-              </p>
-              <ul className="list-disc list-inside space-y-1">
-                <li>File edits and writes</li>
-                <li>Running bash commands</li>
-                <li>Reading files</li>
-                <li>Spawning sub-tasks</li>
-                <li>All MCP tool calls</li>
-              </ul>
-              <p className="text-[var(--terminal-error)] font-semibold">Use with extreme caution!</p>
-            </div>
-          </DialogDescription>
-        </DialogHeader>
-        <div className="pb-0 pt-6">
-          <div className="flex items-center justify-end space-x-2 min-h-[36px]">
-            <Checkbox
-              id="use-timeout"
-              checked={useTimeout}
-              onCheckedChange={(checked: boolean) => {
-                setUseTimeout(checked)
-                if (checked) {
-                  setTimeout(() => {
-                    if (timeoutInputRef.current) {
-                      timeoutInputRef.current.focus()
-                      const value = timeoutInputRef.current.value
-                      timeoutInputRef.current.setSelectionRange(value.length, value.length)
-                    }
-                  }, 0)
-                }
-              }}
-            />
-            <Label htmlFor="use-timeout">Auto-disable after</Label>
-            {useTimeout ? (
-              <>
-                <Input
-                  ref={timeoutInputRef}
-                  id="timeout"
-                  type="number"
-                  min="1"
-                  max="60"
-                  value={timeoutMinutes}
-                  onChange={e => {
-                    const value = e.target.value
-                    if (value === '') {
-                      setTimeoutMinutes('')
-                    } else {
-                      const parsed = parseInt(value)
-                      if (!isNaN(parsed) && parsed >= 0) {
-                        setTimeoutMinutes(parsed)
-                      }
-                    }
-                  }}
-                  className="w-20 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                />
-                <span>{timeoutMinutes === 1 ? 'minute' : 'minutes'}</span>
-              </>
-            ) : (
-              <span>timeout</span>
-            )}
-          </div>
-        </div>
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button
-            variant="outline"
-            onClick={handleConfirm}
-            disabled={useTimeout && (timeoutMinutes === '' || timeoutMinutes === 0)}
-            className="border-[var(--terminal-error)] text-[var(--terminal-error)] hover:bg-[var(--terminal-error)] hover:text-background disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Bypass Permissions
-          </Button>
-        </DialogFooter>
+        {open && (
+          <DangerouslySkipPermissionsDialogContent onOpenChange={onOpenChange} onConfirm={onConfirm} />
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/humanlayer-wui/src/components/ui/dialog.tsx
+++ b/humanlayer-wui/src/components/ui/dialog.tsx
@@ -58,6 +58,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
+            tabIndex={-1}
             className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />


### PR DESCRIPTION
## What problem(s) was I solving?

This PR fixes three UI polish issues discovered during testing of the bypass permissions feature (previously called "dangerous skip permissions"):

1. **Missing hotkey documentation**: The Option+Y hotkey for toggling bypass permissions mode was not discoverable through the keyboard shortcuts panel (accessed via '?')
2. **Keyboard navigation conflict**: When the bypass permissions dialog was open, the Shift+Tab hotkey was still being intercepted by the background hotkey handler, preventing users from using Shift+Tab to navigate backward through dialog form fields
3. **Dialog close button in tab flow**: The close button (X) in dialogs was included in the tab navigation flow, which is not standard behavior for dialog close buttons

## What user-facing changes did I ship?

- **Added Option+Y hotkey documentation**: Users can now discover the bypass permissions hotkey by pressing '?' to open the keyboard shortcuts panel
- **Fixed dialog keyboard navigation**: Users can now properly use Tab and Shift+Tab to navigate through the bypass permissions dialog fields without interference
- **Improved dialog accessibility**: The dialog close button is no longer included in keyboard navigation, following standard UI patterns

## How I implemented it

### 1. Added hotkey documentation
- Added a single line to `HotkeyPanel.tsx` to document the Option+Y hotkey in the Session Detail category
- Used the label "Toggle bypass permissions" for consistency with the rest of the UI

### 2. Fixed Shift+Tab navigation conflict
- Implemented proper hotkey scope management using the existing `useStealHotkeyScope` hook
- Created a dedicated hotkey scope for the bypass permissions dialog that steals all hotkey control when the dialog opens
- This follows the established pattern used by other modals in the codebase (ForkViewModal, ToolResultModal)
- This solution is more robust than a simple early return check as it handles ALL hotkeys, not just Shift+Tab

### 3. Made dialog close button non-tabbable
- Added `tabIndex={-1}` to the DialogPrimitive.Close component in `dialog.tsx`
- This removes the close button from tab navigation while keeping it clickable with mouse
- Applied to all dialogs in the application for consistency

## How to verify it

- [x] I have ensured `make check test` passes

### Manual verification steps:
1. Open a session detail view
2. Press '?' to open keyboard shortcuts panel and verify Option+Y is listed under Session Detail
3. Press Option+Y to open the bypass permissions dialog
4. Verify Tab navigates forward through dialog fields
5. Verify Shift+Tab navigates backward through dialog fields (this was previously broken)
6. Verify the close button (X) is skipped during tab navigation
7. Verify the close button can still be clicked with mouse
8. Press Escape to close the dialog and verify Shift+Tab toggles auto-accept edits as expected

## Description for the changelog

Fix UI polish issues for bypass permissions dialog including hotkey documentation, keyboard navigation conflicts, and dialog close button tab behavior
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes UI issues for bypass permissions dialog by adding hotkey documentation, resolving keyboard navigation conflicts, and adjusting dialog close button tab behavior.
> 
>   - **Hotkey Documentation**:
>     - Added `⌥+Y` hotkey documentation in `HotkeyPanel.tsx` for toggling bypass permissions.
>   - **Keyboard Navigation**:
>     - Used `useStealHotkeyScope` in `DangerouslySkipPermissionsDialog.tsx` to manage hotkey scope, resolving `Shift+Tab` navigation conflict.
>     - Created dedicated hotkey scope for bypass permissions dialog.
>   - **Dialog Close Button**:
>     - Set `tabIndex={-1}` for `DialogPrimitive.Close` in `dialog.tsx` to exclude close button from tab navigation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 12de89bd2daf0377fe9357146fe6cbd5759ecc1c. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->