### PR TITLE
sam/ENG-1756: - fix: preserve text selection when clicking on tool messages

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
@@ -14,6 +14,7 @@ import { useTaskGrouping } from '../hooks/useTaskGrouping'
 import { TaskGroup } from './TaskGroup'
 import { copyToClipboard } from '@/utils/clipboard'
 import { MessageContent } from '../components/MessageContent'
+import { hasTextSelection } from '@/utils/selection'
 
 // TODO(2): Extract keyboard navigation logic to a custom hook
 // TODO(2): Extract auto-scroll logic to a separate utility
@@ -239,6 +240,11 @@ export function ConversationContent({
                   setConfirmingApprovalId?.(null)
                 }}
                 onClick={() => {
+                  // Don't open modal if user has selected text
+                  if (hasTextSelection()) {
+                    return
+                  }
+
                   const event = events.find(e => e.id === displayObject.id)
                   if (event?.eventType === ConversationEventType.ToolCall) {
                     const toolResult = event.toolId
@@ -404,6 +410,11 @@ export function ConversationContent({
                       setConfirmingApprovalId?.(null)
                     }}
                     onClick={() => {
+                      // Don't open modal if user has selected text
+                      if (hasTextSelection()) {
+                        return
+                      }
+
                       const event = events.find(e => e.id === displayObject.id)
                       if (event?.eventType === ConversationEventType.ToolCall) {
                         const toolResult = event.toolId

--- a/humanlayer-wui/src/components/internal/SessionDetail/views/TaskGroup.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/TaskGroup.tsx
@@ -4,6 +4,7 @@ import { TaskEventGroup } from '../hooks/useTaskGrouping'
 import { truncate, formatAbsoluteTimestamp, formatTimestamp } from '@/utils/formatting'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { eventToDisplayObject } from '../eventToDisplayObject'
+import { hasTextSelection } from '@/utils/selection'
 
 interface TaskGroupProps {
   group: TaskEventGroup
@@ -209,6 +210,11 @@ export function TaskGroup({
                     setConfirmingApprovalId?.(null)
                   }}
                   onClick={() => {
+                    // Don't open modal if user has selected text
+                    if (hasTextSelection()) {
+                      return
+                    }
+
                     const event = subEvent
                     if (event?.eventType === ConversationEventType.ToolCall) {
                       const toolResult = event.toolId ? toolResultsByKey[event.toolId] : null

--- a/humanlayer-wui/src/utils/selection.ts
+++ b/humanlayer-wui/src/utils/selection.ts
@@ -1,0 +1,21 @@
+/**
+ * Checks if the user has selected text in the browser
+ * @returns true if text is selected, false otherwise
+ */
+export function hasTextSelection(): boolean {
+  const selection = window.getSelection()
+  if (!selection) return false
+
+  const selectedText = selection.toString().trim()
+  return selectedText.length > 0
+}
+
+/**
+ * Clears the current text selection
+ */
+export function clearTextSelection(): void {
+  const selection = window.getSelection()
+  if (selection) {
+    selection.removeAllRanges()
+  }
+}


### PR DESCRIPTION
## What problem(s) was I solving?

Users couldn't select and copy text from tool call/response messages in the WUI. When they tried to drag-select text and release the mouse button to copy it, the onClick handler would immediately trigger, opening the tool inspect modal and causing the text selection to be lost. This was particularly frustrating when users needed to copy file paths, error messages, or command outputs from tool responses.

The issue was reported in ENG-1756 with a Loom video demonstrating the problem. The root cause was that the onClick handlers for tool messages didn't differentiate between actual clicks (to inspect the tool) and the mouseup event that concludes a text selection operation.

## What user-facing changes did I ship?

- Users can now select and copy text from tool messages without triggering the inspect modal
- The inspect modal still opens when clicking on tool messages without selecting text
- Behavior is consistent across both main conversation view and sub-task views
- No visual or UX changes - just fixes the interaction bug

## How I implemented it

The fix follows Option 1 from the research document, implementing a simple text selection check before opening modals:

1. **Created a text selection utility** (`humanlayer-wui/src/utils/selection.ts`):
   - `hasTextSelection()` - Checks if the user has selected text using `window.getSelection()`
   - `clearTextSelection()` - Helper to clear text selection (for potential future use)

2. **Updated ConversationContent component** (`ConversationContent.tsx`):
   - Added text selection check to both onClick handlers (lines 243-246 and 413-416)
   - If text is selected, the click is ignored, preserving the selection
   - If no text is selected, the modal opens as expected

3. **Updated TaskGroup component** (`TaskGroup.tsx`):
   - Applied the same check to sub-task tool messages (lines 213-216)
   - Ensures consistent behavior across all tool message types

The solution is minimal and non-invasive - it simply adds a guard clause at the start of each onClick handler. This preserves all existing functionality while fixing the text selection issue.

## How to verify it

- [x] I have ensured `make check test` passes

**Manual testing steps:**
1. Open any session with tool calls in the WUI
2. Click and drag to select text within a tool message
3. Release the mouse - verify text remains selected (previously would open modal)
4. Press Cmd+C to copy - verify text is copied to clipboard
5. Click on a tool message without selecting text - verify modal opens as expected
6. Test with different tool types (Read, Edit, Write, Bash, etc.)
7. Test in both main conversation view and expanded sub-task views
8. Verify existing copy buttons still work with their stopPropagation

## Description for the changelog

Fixed an issue where users couldn't select and copy text from tool messages - the inspect modal would open when releasing the mouse, losing the text selection