### PR TITLE
sam/ENG-1913 - feat: add keyboard shortcut hints below text input

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/utils/sessionStatus.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/utils/sessionStatus.tsx
@@ -26,16 +26,19 @@ export const getHelpText = (status: string): React.ReactNode => {
   if (status === 'failed') return 'Session failed - cannot continue'
   const isMac = navigator.platform.includes('Mac')
   const sendKey = isMac ? '⌘+Enter' : 'Ctrl+Enter'
+  const skipKey = isMac ? 'Option+Y' : 'Alt+Y'
   if (status === 'running' || status === 'starting') {
     return (
       <>
-        <Kbd>Ctrl+X</Kbd> to interrupt • <Kbd>{sendKey}</Kbd> to interrupt and send
+        <Kbd>Ctrl+X</Kbd> to interrupt / <Kbd>{sendKey}</Kbd> to interrupt and send /{' '}
+        <Kbd>{skipKey}</Kbd> to bypass permissions / <Kbd>Shift+Tab</Kbd> for auto-accept edits
       </>
     )
   }
   return (
     <>
-      <Kbd>{sendKey}</Kbd> to send
+      <Kbd>{sendKey}</Kbd> to send / <Kbd>{skipKey}</Kbd> to bypass permissions / <Kbd>Shift+Tab</Kbd>{' '}
+      for auto-accept edits
     </>
   )
 }


### PR DESCRIPTION
## What problem(s) was I solving?

Users were not aware of two useful keyboard shortcuts while using the text input in the WUI:
- **Option+Y** (Alt+Y on Windows/Linux) - to bypass permissions and auto-approve tool calls
- **Shift+Tab** - to toggle auto-accept edits mode

These shortcuts were only documented in the keyboard shortcuts panel (accessible via `?` key), making them hard to discover during regular use. This lack of visibility meant users were missing out on productivity features that could significantly speed up their workflow.

## What user-facing changes did I ship?

Added keyboard shortcut hints directly below the text input area in SessionDetail that display:
- Platform-specific shortcut for bypassing permissions (Option+Y on Mac, Alt+Y on Windows/Linux)
- Shift+Tab shortcut for toggling auto-accept edits mode
- These hints appear alongside existing shortcuts (Ctrl+X to interrupt, Cmd/Ctrl+Enter to send)
- Used forward slashes (`/`) as separators between shortcuts for a cleaner, more compact display

The hints are styled consistently with existing keyboard shortcuts using the `<Kbd>` component and maintain the subtle, non-intrusive design of the help text area.

## How I implemented it

Modified the `getHelpText()` function in `humanlayer-wui/src/components/internal/SessionDetail/utils/sessionStatus.tsx` to:
1. Detect the platform (Mac vs Windows/Linux) to show the appropriate modifier key (Option vs Alt)
2. Add the new shortcuts to both the "running/starting" state and the default state help text
3. Use the existing `<Kbd>` component for consistent visual styling with other keyboard hints

The implementation is purely a UI text addition with no changes to the underlying functionality - both shortcuts continue to work exactly as before, they're just more discoverable now.

## How to verify it

- [x] I have ensured `make check test` passes

**Manual verification steps:**
1. Open the WUI and navigate to any session
2. Look at the help text below the text input area
3. Verify that "Option+Y to bypass permissions" appears on Mac (or "Alt+Y" on Windows/Linux)
4. Verify that "Shift+Tab for auto-accept edits" appears
5. Test that pressing Option+Y (or Alt+Y) still activates bypass permissions mode
6. Test that pressing Shift+Tab still toggles auto-accept edits mode
7. Verify the text styling matches other keyboard shortcuts in the UI

## Description for the changelog

**WUI**: Display Option+Y and Shift+Tab keyboard shortcuts below text input for better discoverability of bypass permissions and auto-accept edits features