### PR TITLE
feat: change rename session hotkey from Command+R to Shift+R

### DIFF
--- a/humanlayer-wui/src/components/HotkeyPanel.tsx
+++ b/humanlayer-wui/src/components/HotkeyPanel.tsx
@@ -37,7 +37,7 @@ const hotkeyData = [
   { category: 'Session List', key: 'Shift+K', description: 'Select upward' },
   { category: 'Session List', key: 'Enter', description: 'Open session' },
   { category: 'Session List', key: 'E', description: 'Archive/unarchive' },
-  { category: 'Session List', key: '⌘+R', description: 'Rename session' },
+  { category: 'Session List', key: 'Shift+R', description: 'Rename session' },
   { category: 'Session List', key: 'Tab', description: 'Toggle normal/archived view' },
   { category: 'Session List', key: 'Escape', description: 'Exit archived view' },
 
@@ -51,7 +51,7 @@ const hotkeyData = [
   { category: 'Session Detail', key: 'A', description: 'Approve' },
   { category: 'Session Detail', key: 'D', description: 'Deny' },
   { category: 'Session Detail', key: 'E', description: 'Archive session' },
-  { category: 'Session Detail', key: '⌘+R', description: 'Rename session' },
+  { category: 'Session Detail', key: 'Shift+R', description: 'Rename session' },
   { category: 'Session Detail', key: 'Ctrl+X', description: 'Interrupt session' },
   { category: 'Session Detail', key: 'P', description: 'Go to parent session' },
   { category: 'Session Detail', key: '⌘+Y', description: 'Toggle fork view' },

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -694,7 +694,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
 
   // Rename session hotkey
   useHotkeys(
-    'meta+r',
+    'shift+r',
     () => {
       startEditTitle()
     },

--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -362,7 +362,7 @@ export default function SessionTable({
 
   // Rename session hotkey
   useHotkeys(
-    'meta+r',
+    'shift+r',
     () => {
       if (focusedSession) {
         startEdit(focusedSession.id, focusedSession.title || '', focusedSession.summary || '')


### PR DESCRIPTION
## What problem(s) was I solving?

The Command+R (⌘+R) keyboard shortcut was being used to rename sessions in the HumanLayer WUI. However, Command+R is universally recognized as the "reload" shortcut across web browsers and applications. We wanted to reserve this hotkey for potential future use as a reload function in HumanLayer.

## What user-facing changes did I ship?

- Changed the session rename keyboard shortcut from **Command+R** to **Shift+R** in both:
  - Session list view (when a session is focused)
  - Session detail view (when viewing a specific session)
- Updated the keyboard shortcuts help panel (accessed via `?`) to reflect the new shortcut

## How I implemented it

Made minimal code changes to update the hotkey binding:
1. Updated `SessionTable.tsx` to bind `'shift+r'` instead of `'meta+r'` 
2. Updated `SessionDetail.tsx` to bind `'shift+r'` instead of `'meta+r'`
3. Updated `HotkeyPanel.tsx` documentation to display `'Shift+R'` instead of `'⌘+R'`

The `react-hotkeys-hook` library supports the `'shift+r'` syntax directly, making this a straightforward replacement.

## How to verify it

- [x] I have ensured `make check test` passes

**Manual testing steps:**
1. Open the HumanLayer WUI
2. In the session list view:
   - Focus a session using arrow keys or mouse hover
   - Press **Shift+R** → Should open the inline rename editor
   - Press **Command+R** → Should do nothing (no longer triggers rename)
3. In the session detail view:
   - Open any session
   - Press **Shift+R** → Should activate the title editor
   - Press **Command+R** → Should do nothing
4. Press **?** to open the keyboard shortcuts help:
   - Verify both "Session List" and "Session Detail" sections show **Shift+R** for "Rename session"

## Description for the changelog

Changed session rename keyboard shortcut from Command+R to Shift+R to reserve Command+R for future reload functionality