### PR TITLE
fix: use Option symbol (⌥) for consistency with other shortcuts

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/utils/sessionStatus.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/utils/sessionStatus.tsx
@@ -26,7 +26,7 @@ export const getHelpText = (status: string): React.ReactNode => {
   if (status === 'failed') return 'Session failed - cannot continue'
   const isMac = navigator.platform.includes('Mac')
   const sendKey = isMac ? '⌘+Enter' : 'Ctrl+Enter'
-  const skipKey = isMac ? 'Option+Y' : 'Alt+Y'
+  const skipKey = isMac ? '⌥+Y' : 'Alt+Y'
   if (status === 'running' || status === 'starting') {
     return (
       <>


### PR DESCRIPTION
Use the Option symbol (⌥) instead of text 'Option' to match how its displayed everywhere else.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces 'Option' with '⌥' in `getHelpText` in `sessionStatus.tsx` for Mac shortcut consistency.
> 
>   - **UI Consistency**:
>     - Replaces 'Option' with '⌥' in `getHelpText` function in `sessionStatus.tsx` for Mac keyboard shortcuts.
>     - Affects display of `skipKey` shortcut when `status` is 'running' or 'starting'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for c812f87c5175237d0c89378c82a3d2d5ab8883f6. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->