### PR TITLE
Add ANSI color code rendering for Bash tool outputs

### DIFF
--- a/humanlayer-wui/bun.lock
+++ b/humanlayer-wui/bun.lock
@@ -21,6 +21,7 @@
         "@tauri-apps/plugin-log": "^2.6.0",
         "@tauri-apps/plugin-notification": "^2.3.0",
         "@tauri-apps/plugin-opener": "^2",
+        "ansi-regex": "^6.1.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -37,6 +38,7 @@
         "react-syntax-highlighter": "^15.5.0",
         "remark-gfm": "^4.0.0",
         "sonner": "^2.0.5",
+        "strip-ansi": "^7.1.0",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.10",
         "zustand": "^5.0.5",
@@ -501,7 +503,7 @@
 
     "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
-    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -1165,7 +1167,7 @@
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
-    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -1301,8 +1303,6 @@
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
-    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
-
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@nuxt/opencollective/consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
@@ -1337,6 +1337,8 @@
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
+    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "concurrently/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
@@ -1357,6 +1359,8 @@
 
     "hastscript/space-separated-tokens": ["space-separated-tokens@1.1.5", "", {}, "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="],
 
+    "inquirer/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
@@ -1364,6 +1368,8 @@
     "mdast-util-mdx-jsx/parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "ora/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.1.0", "", {}, "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A=="],
 
@@ -1375,19 +1381,31 @@
 
     "rollup/@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 
+    "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "stringify-entities/character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@humanlayer/hld-sdk/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
-    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
-
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "hastscript/@types/hast/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "inquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "mdast-util-mdx-jsx/parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
@@ -1400,6 +1418,16 @@
     "mdast-util-mdx-jsx/parse-entities/is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
     "mdast-util-mdx-jsx/parse-entities/is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "ora/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "mdast-util-mdx-jsx/parse-entities/is-alphanumerical/is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
   }

--- a/humanlayer-wui/package.json
+++ b/humanlayer-wui/package.json
@@ -18,6 +18,8 @@
   "dependencies": {
     "@humanlayer/hld-sdk": "file:../hld/sdk/typescript",
     "@radix-ui/react-checkbox": "^1.3.2",
+    "ansi-regex": "^6.1.0",
+    "strip-ansi": "^7.1.0",
     "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/humanlayer-wui/src/App.css
+++ b/humanlayer-wui/src/App.css
@@ -57,6 +57,26 @@
   --terminal-success: #859900;
   --terminal-warning: #b58900;
   --terminal-error: #dc322f;
+
+  /* Standard colors (30-37, 40-47) - Official Solarized values */
+  --terminal-color-0: #073642; /* Black (base02) */
+  --terminal-color-1: #dc322f; /* Red */
+  --terminal-color-2: #859900; /* Green */
+  --terminal-color-3: #b58900; /* Yellow */
+  --terminal-color-4: #268bd2; /* Blue */
+  --terminal-color-5: #d33682; /* Magenta */
+  --terminal-color-6: #2aa198; /* Cyan */
+  --terminal-color-7: #eee8d5; /* White (base2) */
+
+  /* Bright colors (90-97, 100-107) - Official Solarized values */
+  --terminal-color-8: #002b36; /* Bright Black (base03) */
+  --terminal-color-9: #cb4b16; /* Bright Red (orange) */
+  --terminal-color-10: #586e75; /* Bright Green (base01) */
+  --terminal-color-11: #657b83; /* Bright Yellow (base00) */
+  --terminal-color-12: #839496; /* Bright Blue (base0) */
+  --terminal-color-13: #6c71c4; /* Bright Magenta (violet) */
+  --terminal-color-14: #93a1a1; /* Bright Cyan (base1) */
+  --terminal-color-15: #fdf6e3; /* Bright White (base3) */
 }
 
 /* Solarized Light */
@@ -71,6 +91,26 @@
   --terminal-success: #859900;
   --terminal-warning: #b58900;
   --terminal-error: #dc322f;
+
+  /* Standard colors - Official Solarized values (inverted for light theme) */
+  --terminal-color-0: #eee8d5; /* Black (base2) */
+  --terminal-color-1: #dc322f; /* Red */
+  --terminal-color-2: #859900; /* Green */
+  --terminal-color-3: #b58900; /* Yellow */
+  --terminal-color-4: #268bd2; /* Blue */
+  --terminal-color-5: #d33682; /* Magenta */
+  --terminal-color-6: #2aa198; /* Cyan */
+  --terminal-color-7: #073642; /* White (base02) */
+
+  /* Bright colors - Official Solarized values */
+  --terminal-color-8: #fdf6e3; /* Bright Black (base3) */
+  --terminal-color-9: #cb4b16; /* Bright Red (orange) */
+  --terminal-color-10: #93a1a1; /* Bright Green (base1) */
+  --terminal-color-11: #839496; /* Bright Yellow (base0) */
+  --terminal-color-12: #657b83; /* Bright Blue (base00) */
+  --terminal-color-13: #6c71c4; /* Bright Magenta (violet) */
+  --terminal-color-14: #586e75; /* Bright Cyan (base01) */
+  --terminal-color-15: #002b36; /* Bright White (base03) */
 }
 
 /* Cappuccino - Warm coffee theme */
@@ -85,6 +125,26 @@
   --terminal-success: #7b9171;
   --terminal-warning: #e9c46a;
   --terminal-error: #e63946;
+
+  /* Standard colors - Warm coffee-inspired palette */
+  --terminal-color-0: #2f1b14; /* Black (bg) */
+  --terminal-color-1: #e63946; /* Red */
+  --terminal-color-2: #7b9171; /* Green */
+  --terminal-color-3: #e9c46a; /* Yellow */
+  --terminal-color-4: #2a9d8f; /* Blue */
+  --terminal-color-5: #e76f51; /* Magenta/Orange */
+  --terminal-color-6: #264653; /* Cyan */
+  --terminal-color-7: #d4b895; /* White (fg) */
+
+  /* Bright colors - Lightened versions */
+  --terminal-color-8: #3d261a; /* Bright Black */
+  --terminal-color-9: #ff6b79; /* Bright Red */
+  --terminal-color-10: #93ab89; /* Bright Green */
+  --terminal-color-11: #f4d798; /* Bright Yellow */
+  --terminal-color-12: #5ab7a9; /* Bright Blue */
+  --terminal-color-13: #f4a261; /* Bright Magenta */
+  --terminal-color-14: #3a5a6a; /* Bright Cyan */
+  --terminal-color-15: #f5e6d3; /* Bright White */
 }
 
 /* Catppuccin Mocha - Popular pastel theme */
@@ -99,6 +159,26 @@
   --terminal-success: #a6e3a1;
   --terminal-warning: #f9e2af;
   --terminal-error: #f38ba8;
+
+  /* Standard colors - Official Catppuccin Mocha values */
+  --terminal-color-0: #45475a; /* Black (surface1) */
+  --terminal-color-1: #f38ba8; /* Red */
+  --terminal-color-2: #a6e3a1; /* Green */
+  --terminal-color-3: #f9e2af; /* Yellow */
+  --terminal-color-4: #89b4fa; /* Blue */
+  --terminal-color-5: #f5c2e7; /* Magenta (pink) */
+  --terminal-color-6: #94e2d5; /* Cyan (teal) */
+  --terminal-color-7: #bac2de; /* White (subtext1) */
+
+  /* Bright colors - Official Catppuccin Mocha values */
+  --terminal-color-8: #585b70; /* Bright Black (surface2) */
+  --terminal-color-9: #eba0ac; /* Bright Red (maroon) */
+  --terminal-color-10: #a6e3a1; /* Bright Green */
+  --terminal-color-11: #fab387; /* Bright Yellow (peach) */
+  --terminal-color-12: #89dceb; /* Bright Blue (sky) */
+  --terminal-color-13: #cba6f7; /* Bright Magenta (mauve) */
+  --terminal-color-14: #89dceb; /* Bright Cyan (sky) */
+  --terminal-color-15: #cdd6f4; /* Bright White (text) */
 }
 
 /* High Contrast - Sharp white on black */
@@ -113,6 +193,26 @@
   --terminal-success: #00ff00;
   --terminal-warning: #ffff00;
   --terminal-error: #ff0000;
+
+  /* Standard colors - Maximum contrast */
+  --terminal-color-0: #000000; /* Black */
+  --terminal-color-1: #ff0000; /* Red */
+  --terminal-color-2: #00ff00; /* Green */
+  --terminal-color-3: #ffff00; /* Yellow */
+  --terminal-color-4: #0000ff; /* Blue */
+  --terminal-color-5: #ff00ff; /* Magenta */
+  --terminal-color-6: #00ffff; /* Cyan */
+  --terminal-color-7: #c0c0c0; /* White (silver) */
+
+  /* Bright colors - Pure bright variants */
+  --terminal-color-8: #808080; /* Bright Black (gray) */
+  --terminal-color-9: #ff6060; /* Bright Red */
+  --terminal-color-10: #60ff60; /* Bright Green */
+  --terminal-color-11: #ffff60; /* Bright Yellow */
+  --terminal-color-12: #6060ff; /* Bright Blue */
+  --terminal-color-13: #ff60ff; /* Bright Magenta */
+  --terminal-color-14: #60ffff; /* Bright Cyan */
+  --terminal-color-15: #ffffff; /* Bright White */
 }
 
 /* Framer Dark - Inspired by Framer's dark theme */
@@ -127,6 +227,26 @@
   --terminal-success: #32ccdc;
   --terminal-warning: #fecb6e;
   --terminal-error: #fd886b;
+
+  /* Standard colors - Modern design-tool inspired */
+  --terminal-color-0: #181818; /* Black */
+  --terminal-color-1: #fd886b; /* Red */
+  --terminal-color-2: #32ccdc; /* Green/Teal */
+  --terminal-color-3: #fecb6e; /* Yellow */
+  --terminal-color-4: #20bcfc; /* Blue */
+  --terminal-color-5: #fd5799; /* Magenta */
+  --terminal-color-6: #00b8d4; /* Cyan */
+  --terminal-color-7: #999999; /* White */
+
+  /* Bright colors - Vibrant variants */
+  --terminal-color-8: #2f3439; /* Bright Black */
+  --terminal-color-9: #ff9580; /* Bright Red */
+  --terminal-color-10: #6edde5; /* Bright Green */
+  --terminal-color-11: #ffd98e; /* Bright Yellow */
+  --terminal-color-12: #60d0ff; /* Bright Blue */
+  --terminal-color-13: #ff7ab8; /* Bright Magenta */
+  --terminal-color-14: #4dd0e1; /* Bright Cyan */
+  --terminal-color-15: #eeeeee; /* Bright White */
 }
 
 /* Framer Light - Light counterpart to Framer Dark */
@@ -141,6 +261,26 @@
   --terminal-success: #22a06b;
   --terminal-warning: #cc7722;
   --terminal-error: #dc3545;
+
+  /* Standard colors - Clean professional palette */
+  --terminal-color-0: #f8f9fa; /* Black (light bg) */
+  --terminal-color-1: #dc3545; /* Red */
+  --terminal-color-2: #22a06b; /* Green */
+  --terminal-color-3: #cc7722; /* Yellow/Orange */
+  --terminal-color-4: #0066cc; /* Blue */
+  --terminal-color-5: #7b61ff; /* Magenta/Purple */
+  --terminal-color-6: #006bb3; /* Cyan */
+  --terminal-color-7: #333333; /* White (dark text) */
+
+  /* Bright colors - Muted variants */
+  --terminal-color-8: #e0e0e0; /* Bright Black */
+  --terminal-color-9: #e74856; /* Bright Red */
+  --terminal-color-10: #3db88b; /* Bright Green */
+  --terminal-color-11: #e6a045; /* Bright Yellow */
+  --terminal-color-12: #3399ff; /* Bright Blue */
+  --terminal-color-13: #9b81ff; /* Bright Magenta */
+  --terminal-color-14: #0099ff; /* Bright Cyan */
+  --terminal-color-15: #000000; /* Bright White (pure black) */
 }
 
 /* Gruvbox Dark - Material palette, medium contrast */
@@ -155,6 +295,26 @@
   --terminal-success: #a9b665;
   --terminal-warning: #d8a657;
   --terminal-error: #ea6962;
+
+  /* Standard colors - Official Gruvbox dark values */
+  --terminal-color-0: #282828; /* Black (bg0) */
+  --terminal-color-1: #cc241d; /* Red */
+  --terminal-color-2: #98971a; /* Green */
+  --terminal-color-3: #d79921; /* Yellow */
+  --terminal-color-4: #458588; /* Blue */
+  --terminal-color-5: #b16286; /* Magenta/Purple */
+  --terminal-color-6: #689d6a; /* Cyan/Aqua */
+  --terminal-color-7: #a89984; /* White (fg4) */
+
+  /* Bright colors - Official Gruvbox bright values */
+  --terminal-color-8: #928374; /* Bright Black (gray) */
+  --terminal-color-9: #fb4934; /* Bright Red */
+  --terminal-color-10: #b8bb26; /* Bright Green */
+  --terminal-color-11: #fabd2f; /* Bright Yellow */
+  --terminal-color-12: #83a598; /* Bright Blue */
+  --terminal-color-13: #d3869b; /* Bright Magenta */
+  --terminal-color-14: #8ec07c; /* Bright Cyan */
+  --terminal-color-15: #ebdbb2; /* Bright White (fg1) */
 }
 
 /* Gruvbox Light - Material palette, medium contrast */
@@ -169,6 +329,26 @@
   --terminal-success: #6c782e;
   --terminal-warning: #b47109;
   --terminal-error: #c14a4a;
+
+  /* Standard colors - Official Gruvbox light values */
+  --terminal-color-0: #fbf1c7; /* Black (bg0) */
+  --terminal-color-1: #cc241d; /* Red */
+  --terminal-color-2: #98971a; /* Green */
+  --terminal-color-3: #d79921; /* Yellow */
+  --terminal-color-4: #458588; /* Blue */
+  --terminal-color-5: #b16286; /* Magenta/Purple */
+  --terminal-color-6: #689d6a; /* Cyan/Aqua */
+  --terminal-color-7: #7c6f64; /* White (fg4) */
+
+  /* Bright colors - Official Gruvbox bright values */
+  --terminal-color-8: #928374; /* Bright Black (gray) */
+  --terminal-color-9: #9d0006; /* Bright Red (darkened) */
+  --terminal-color-10: #79740e; /* Bright Green (darkened) */
+  --terminal-color-11: #b57614; /* Bright Yellow (darkened) */
+  --terminal-color-12: #076678; /* Bright Blue (darkened) */
+  --terminal-color-13: #8f3f71; /* Bright Magenta (darkened) */
+  --terminal-color-14: #427b58; /* Bright Cyan (darkened) */
+  --terminal-color-15: #3c3836; /* Bright White (fg1) */
 }
 
 /* Monokai - Classic dark theme */
@@ -183,6 +363,26 @@
   --terminal-success: #a6e22e;
   --terminal-warning: #e6db74;
   --terminal-error: #f92672;
+
+  /* Standard colors - Classic Monokai palette */
+  --terminal-color-0: #272822; /* Black */
+  --terminal-color-1: #f92672; /* Red (pink) */
+  --terminal-color-2: #a6e22e; /* Green */
+  --terminal-color-3: #e6db74; /* Yellow */
+  --terminal-color-4: #66d9ef; /* Blue */
+  --terminal-color-5: #ae81ff; /* Magenta/Purple */
+  --terminal-color-6: #66d9ef; /* Cyan */
+  --terminal-color-7: #f8f8f2; /* White */
+
+  /* Bright colors - Intensified versions */
+  --terminal-color-8: #75715e; /* Bright Black (comment) */
+  --terminal-color-9: #fd5ff0; /* Bright Red/Pink */
+  --terminal-color-10: #b3e774; /* Bright Green */
+  --terminal-color-11: #feed6c; /* Bright Yellow */
+  --terminal-color-12: #81e7fc; /* Bright Blue */
+  --terminal-color-13: #c2a1ff; /* Bright Magenta */
+  --terminal-color-14: #81e7fc; /* Bright Cyan */
+  --terminal-color-15: #fcfcfa; /* Bright White */
 }
 
 /* Launch theme */
@@ -197,6 +397,26 @@
   --terminal-success: #458cc9;
   --terminal-warning: #ff6600;
   --terminal-error: #cc5200;
+
+  /* Standard colors - HN/minimalist palette */
+  --terminal-color-0: #f6f6ef; /* Black (bg) */
+  --terminal-color-1: #cc5200; /* Red */
+  --terminal-color-2: #458cc9; /* Green/Blue */
+  --terminal-color-3: #ff6600; /* Yellow/Orange */
+  --terminal-color-4: #458cc9; /* Blue */
+  --terminal-color-5: #828282; /* Magenta (gray) */
+  --terminal-color-6: #5a9fd4; /* Cyan */
+  --terminal-color-7: #000000; /* White (text) */
+
+  /* Bright colors - Duplicate for minimalist theme */
+  --terminal-color-8: #e0e0d7; /* Bright Black */
+  --terminal-color-9: #ff6600; /* Bright Red */
+  --terminal-color-10: #6ba3d0; /* Bright Green */
+  --terminal-color-11: #ff8833; /* Bright Yellow */
+  --terminal-color-12: #6ba3d0; /* Bright Blue */
+  --terminal-color-13: #999999; /* Bright Magenta */
+  --terminal-color-14: #7fb8e1; /* Bright Cyan */
+  --terminal-color-15: #333333; /* Bright White */
 }
 
 /* Rosé Pine - Soho vibes */
@@ -211,6 +431,26 @@
   --terminal-success: #9ccfd8;
   --terminal-warning: #f6c177;
   --terminal-error: #eb6f92;
+
+  /* Standard colors - Official Rosé Pine values */
+  --terminal-color-0: #191724; /* Black (base) */
+  --terminal-color-1: #eb6f92; /* Red (love) */
+  --terminal-color-2: #9ccfd8; /* Green (foam) */
+  --terminal-color-3: #f6c177; /* Yellow (gold) */
+  --terminal-color-4: #3e8fb0; /* Blue (pine) */
+  --terminal-color-5: #c4a7e7; /* Magenta (iris) */
+  --terminal-color-6: #ebbcba; /* Cyan (rose) */
+  --terminal-color-7: #e0def4; /* White (text) */
+
+  /* Bright colors - Official Rosé Pine values */
+  --terminal-color-8: #26233a; /* Bright Black (overlay) */
+  --terminal-color-9: #eb6f92; /* Bright Red (love) */
+  --terminal-color-10: #9ccfd8; /* Bright Green (foam) */
+  --terminal-color-11: #f6c177; /* Bright Yellow (gold) */
+  --terminal-color-12: #31748f; /* Bright Blue (pine dark) */
+  --terminal-color-13: #c4a7e7; /* Bright Magenta (iris) */
+  --terminal-color-14: #ebbcba; /* Bright Cyan (rose) */
+  --terminal-color-15: #e0def4; /* Bright White (text) */
 }
 
 /* Rosé Pine Dawn - Light theme with warm tones */
@@ -225,6 +465,26 @@
   --terminal-success: #56949f;
   --terminal-warning: #ea9d34;
   --terminal-error: #b4637a;
+
+  /* Standard colors - Official Rosé Pine Dawn values */
+  --terminal-color-0: #faf4ed; /* Black (base) */
+  --terminal-color-1: #b4637a; /* Red (love) */
+  --terminal-color-2: #56949f; /* Green (foam) */
+  --terminal-color-3: #ea9d34; /* Yellow (gold) */
+  --terminal-color-4: #286983; /* Blue (pine) */
+  --terminal-color-5: #907aa9; /* Magenta (iris) */
+  --terminal-color-6: #d7827e; /* Cyan (rose) */
+  --terminal-color-7: #575279; /* White (text) */
+
+  /* Bright colors - Official Rosé Pine Dawn values */
+  --terminal-color-8: #f2e9e1; /* Bright Black (surface) */
+  --terminal-color-9: #b4637a; /* Bright Red (love) */
+  --terminal-color-10: #56949f; /* Bright Green (foam) */
+  --terminal-color-11: #ea9d34; /* Bright Yellow (gold) */
+  --terminal-color-12: #286983; /* Bright Blue (pine) */
+  --terminal-color-13: #907aa9; /* Bright Magenta (iris) */
+  --terminal-color-14: #d7827e; /* Bright Cyan (rose) */
+  --terminal-color-15: #575279; /* Bright White (text) */
 }
 
 /* Rosé Pine Moon - Softer dark theme */
@@ -239,6 +499,26 @@
   --terminal-success: #9ccfd8;
   --terminal-warning: #f6c177;
   --terminal-error: #eb6f92;
+
+  /* Standard colors - Official Rosé Pine Moon values */
+  --terminal-color-0: #232136; /* Black (base) */
+  --terminal-color-1: #eb6f92; /* Red (love) */
+  --terminal-color-2: #9ccfd8; /* Green (foam) */
+  --terminal-color-3: #f6c177; /* Yellow (gold) */
+  --terminal-color-4: #3e8fb0; /* Blue (pine) */
+  --terminal-color-5: #c4a7e7; /* Magenta (iris) */
+  --terminal-color-6: #ebbcba; /* Cyan (rose) */
+  --terminal-color-7: #e0def4; /* White (text) */
+
+  /* Bright colors - Official Rosé Pine Moon values */
+  --terminal-color-8: #393552; /* Bright Black (overlay) */
+  --terminal-color-9: #eb6f92; /* Bright Red (love) */
+  --terminal-color-10: #9ccfd8; /* Bright Green (foam) */
+  --terminal-color-11: #f6c177; /* Bright Yellow (gold) */
+  --terminal-color-12: #3e8fb0; /* Bright Blue (pine) */
+  --terminal-color-13: #c4a7e7; /* Bright Magenta (iris) */
+  --terminal-color-14: #ebbcba; /* Bright Cyan (rose) */
+  --terminal-color-15: #e0def4; /* Bright White (text) */
 }
 @layer base {
   * {

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ToolResultModal.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ToolResultModal.tsx
@@ -7,6 +7,7 @@ import { useStealHotkeyScope } from '@/hooks/useStealHotkeyScope'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { getToolIcon } from '../eventToDisplayObject'
 import { CustomDiffViewer } from './CustomDiffViewer'
+import { AnsiText, hasAnsiCodes } from '@/utils/ansiParser'
 
 // TODO(3): Add keyboard navigation hints in the UI
 // TODO(2): Consider adding copy-to-clipboard functionality for tool results
@@ -126,7 +127,14 @@ export function ToolResultModal({
                 <div>
                   <h3 className="text-sm font-medium text-muted-foreground mb-2">Result</h3>
                   <pre className="font-mono text-sm whitespace-pre-wrap break-words">
-                    {toolResult.toolResultContent || 'No content'}
+                    {/* Only apply ANSI parsing to Bash tool output */}
+                    {toolCall?.toolName === 'Bash' &&
+                    typeof toolResult.toolResultContent === 'string' &&
+                    hasAnsiCodes(toolResult.toolResultContent) ? (
+                      <AnsiText content={toolResult.toolResultContent} />
+                    ) : (
+                      toolResult.toolResultContent || 'No content'
+                    )}
                   </pre>
                 </div>
               )}

--- a/humanlayer-wui/src/components/internal/SessionDetail/formatToolResult.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/formatToolResult.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { ConversationEvent } from '@/lib/daemon/types'
 import { truncate, parseMcpToolName } from '@/utils/formatting'
+import { hasAnsiCodes, AnsiText } from '@/utils/ansiParser'
 
 // TODO(2): Consider creating tool-specific formatters in separate files
 // TODO(2): Add unit tests for each tool formatter
@@ -80,7 +81,7 @@ export function formatToolResult(
     isError = hasErrorKeyword && !isFalsePositive
   }
 
-  let abbreviated: string
+  let abbreviated: string | React.ReactNode
 
   switch (toolName) {
     case 'Read': {
@@ -96,9 +97,34 @@ export function formatToolResult(
       if (!content || lines.length === 0) {
         abbreviated = 'Command completed'
       } else if (lines.length === 1) {
-        abbreviated = truncate(lines[0], 80)
+        // For single line, show with ANSI colors if present
+        const firstLine = lines[0]
+        if (hasAnsiCodes(firstLine)) {
+          // Always return colored version, let CSS handle truncation
+          return (
+            <span className="inline-block max-w-[60ch] overflow-hidden text-ellipsis whitespace-nowrap">
+              <AnsiText content={firstLine} />
+            </span>
+          )
+        } else {
+          abbreviated = truncate(firstLine, 80)
+        }
       } else {
-        abbreviated = `${truncate(lines[0], 60)} ... (${lines.length} lines)`
+        // Multiple lines - show first line with colors
+        const firstLine = lines[0]
+        if (hasAnsiCodes(firstLine)) {
+          // Return colored first line with line count, CSS handles truncation
+          return (
+            <>
+              <span className="inline-block max-w-[45ch] overflow-hidden text-ellipsis whitespace-nowrap align-bottom">
+                <AnsiText content={firstLine} />
+              </span>
+              <span> ... ({lines.length} lines)</span>
+            </>
+          )
+        } else {
+          abbreviated = `${truncate(firstLine, 60)} ... (${lines.length} lines)`
+        }
       }
       break
     }
@@ -352,7 +378,11 @@ export function formatToolResult(
   }
 
   // Also apply error styling for specific MultiEdit errors
-  if (toolName === 'MultiEdit' && abbreviated.includes('replace_all needed')) {
+  if (
+    toolName === 'MultiEdit' &&
+    typeof abbreviated === 'string' &&
+    abbreviated.includes('replace_all needed')
+  ) {
     return <span className="text-destructive">{abbreviated}</span>
   }
 

--- a/humanlayer-wui/src/utils/ansiParser.test.tsx
+++ b/humanlayer-wui/src/utils/ansiParser.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'bun:test'
+import { parseAnsiToSegments, hasAnsiCodes } from './ansiParser'
+
+describe('ANSI Parser', () => {
+  it('parses basic color codes', () => {
+    const input = '\x1b[31mRed text\x1b[0m Normal text'
+    const segments = parseAnsiToSegments(input)
+
+    expect(segments).toHaveLength(2)
+    expect(segments[0].text).toBe('Red text')
+    expect(segments[0].style?.color).toBe('var(--terminal-color-1)')
+    expect(segments[1].text).toBe(' Normal text')
+    expect(segments[1].style).toBeUndefined()
+  })
+
+  it('detects ANSI codes correctly', () => {
+    expect(hasAnsiCodes('\x1b[31mRed\x1b[0m')).toBe(true)
+    expect(hasAnsiCodes('Plain text')).toBe(false)
+    expect(hasAnsiCodes('Text with \x1b[32mgreen\x1b[0m inside')).toBe(true)
+  })
+
+  it('handles multiple color changes', () => {
+    const input = '\x1b[32mGreen\x1b[34mBlue\x1b[0mNormal'
+    const segments = parseAnsiToSegments(input)
+
+    expect(segments).toHaveLength(3)
+    expect(segments[0].style?.color).toBe('var(--terminal-color-2)')
+    expect(segments[1].style?.color).toBe('var(--terminal-color-4)')
+    expect(segments[2].style).toBeUndefined()
+  })
+
+  it('handles bright colors', () => {
+    const input = '\x1b[91mBright Red\x1b[0m'
+    const segments = parseAnsiToSegments(input)
+
+    expect(segments[0].style?.color).toBe('var(--terminal-color-9)')
+  })
+
+  it('handles text without ANSI codes', () => {
+    const input = 'Plain text without colors'
+    const segments = parseAnsiToSegments(input)
+
+    expect(segments).toHaveLength(1)
+    expect(segments[0].text).toBe(input)
+    expect(segments[0].style).toBeUndefined()
+  })
+})

--- a/humanlayer-wui/src/utils/ansiParser.tsx
+++ b/humanlayer-wui/src/utils/ansiParser.tsx
@@ -1,0 +1,98 @@
+import ansiRegex from 'ansi-regex'
+
+interface AnsiSegment {
+  text: string
+  style?: {
+    color?: string
+    className?: string
+  }
+}
+
+// Map ANSI codes to CSS variables
+const colorMap: Record<number, string> = {
+  30: 'var(--terminal-color-0)', // Black
+  31: 'var(--terminal-color-1)', // Red
+  32: 'var(--terminal-color-2)', // Green
+  33: 'var(--terminal-color-3)', // Yellow
+  34: 'var(--terminal-color-4)', // Blue
+  35: 'var(--terminal-color-5)', // Magenta
+  36: 'var(--terminal-color-6)', // Cyan
+  37: 'var(--terminal-color-7)', // White
+  90: 'var(--terminal-color-8)', // Bright Black
+  91: 'var(--terminal-color-9)', // Bright Red
+  92: 'var(--terminal-color-10)', // Bright Green
+  93: 'var(--terminal-color-11)', // Bright Yellow
+  94: 'var(--terminal-color-12)', // Bright Blue
+  95: 'var(--terminal-color-13)', // Bright Magenta
+  96: 'var(--terminal-color-14)', // Bright Cyan
+  97: 'var(--terminal-color-15)', // Bright White
+}
+
+export function parseAnsiToSegments(text: string): AnsiSegment[] {
+  const segments: AnsiSegment[] = []
+  const regex = ansiRegex()
+  let lastIndex = 0
+  let currentStyle: AnsiSegment['style'] = undefined
+
+  let match
+  while ((match = regex.exec(text)) !== null) {
+    // Add text before the escape sequence
+    if (match.index > lastIndex) {
+      segments.push({
+        text: text.slice(lastIndex, match.index),
+        style: currentStyle ? { ...currentStyle } : undefined,
+      })
+    }
+
+    // Parse the escape sequence
+    const sequence = match[0]
+    const codes = sequence.match(/\d+/g)?.map(Number) || []
+
+    for (const code of codes) {
+      if (code === 0) {
+        // Reset
+        currentStyle = undefined
+      } else if (colorMap[code]) {
+        // Foreground color
+        currentStyle = currentStyle || {}
+        currentStyle.color = colorMap[code]
+      }
+    }
+
+    lastIndex = regex.lastIndex
+  }
+
+  // Add remaining text
+  if (lastIndex < text.length) {
+    segments.push({
+      text: text.slice(lastIndex),
+      style: currentStyle ? { ...currentStyle } : undefined,
+    })
+  }
+
+  return segments
+}
+
+// Component for rendering ANSI text
+export function AnsiText({ content }: { content: string }) {
+  const segments = parseAnsiToSegments(content)
+
+  return (
+    <>
+      {segments.map((segment, i) => (
+        <span
+          key={i}
+          style={segment.style?.color ? { color: segment.style.color } : undefined}
+          className={segment.style?.className}
+        >
+          {segment.text}
+        </span>
+      ))}
+    </>
+  )
+}
+
+// Helper to check if content likely contains ANSI codes
+export function hasAnsiCodes(text: string): boolean {
+  return ansiRegex().test(text)
+}


### PR DESCRIPTION
## What problem(s) was I solving?

Bash command outputs in the WUI were displaying raw ANSI escape sequences (e.g., `\033[31mError\033[0m`) instead of rendering colored text. This made bash outputs difficult to read and created a poor user experience, especially for commands that rely on color to convey important information like test results, build failures, or git status.

## What user-facing changes did I ship?

- **Colored Bash Outputs**: Bash tool outputs now render with proper ANSI colors in both inline previews and full modal views
- **Theme-Aware Colors**: Each of the 14 UI themes now includes 16 terminal colors (standard + bright) that match the theme's design
- **Selective Rendering**: Only Bash tool outputs get color rendering - other tools preserve raw ANSI codes for debugging purposes
- **Preserved Truncation**: Long lines still truncate properly in inline previews while maintaining visible colors

## How I implemented it

1. **Added ANSI parsing dependencies**: `ansi-regex` and `strip-ansi` packages for reliable ANSI code detection and parsing

2. **Extended all 14 themes** with terminal color CSS variables (`--terminal-color-0` through `--terminal-color-15`):
   - Each theme got carefully selected colors matching its design language
   - Colors cover standard (0-7) and bright (8-15) ranges for full terminal compatibility

3. **Created ANSI parser utility** (`src/utils/ansiParser.tsx`):
   - `parseAnsiToSegments()`: Parses text into segments with color information
   - `AnsiText` component: Renders segments as styled spans using theme colors
   - `hasAnsiCodes()`: Helper to detect presence of ANSI codes

4. **Integrated color rendering** at display points:
   - Modified `formatToolResult.tsx` to render colors for Bash outputs in inline previews
   - Updated `ToolResultModal.tsx` to show colors in full view modal
   - Used CSS truncation to preserve colors even for long lines

## How to verify it

- [x] I have ensured `make check test` passes
- Run any bash command with color output (e.g., `ls --color=always`, `git status`, `npm test`)
- Verify colors appear in both the inline preview (⎿ line) and full modal view
- Test with different themes using Cmd+Shift+Y (Launch theme easter egg)
- Confirm non-Bash tools still show raw ANSI codes for debugging

## Description for the changelog

Added ANSI color code rendering for Bash tool outputs in the WUI, with theme-aware terminal colors for all 14 themes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add ANSI color code rendering for Bash tool outputs, integrating theme-aware colors and updating components to handle ANSI sequences.
> 
>   - **Behavior**:
>     - Bash tool outputs now render with ANSI colors in inline previews and full modal views.
>     - Only Bash outputs are color-rendered; other tools show raw ANSI codes.
>     - Long lines truncate properly while maintaining colors.
>   - **Themes**:
>     - Extended 14 themes with terminal color CSS variables (`--terminal-color-0` to `--terminal-color-15`).
>     - Colors match each theme's design, covering standard and bright ranges.
>   - **Utilities**:
>     - Added `ansi-regex` and `strip-ansi` dependencies in `package.json`.
>     - Created `ansiParser.tsx` with `parseAnsiToSegments()`, `AnsiText`, and `hasAnsiCodes()`.
>   - **Components**:
>     - Modified `ToolResultModal.tsx` to render ANSI colors for Bash outputs.
>     - Updated `formatToolResult.tsx` to handle ANSI colors in Bash output previews.
>   - **Tests**:
>     - Added `ansiParser.test.tsx` to test ANSI parsing and rendering functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for f48df11cb8309b9f039e19ef2d6f9497d1a0bab9. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->