### PR TITLE
Fix nightly release version format

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event.inputs.release_nightly }}" = "true" ]; then
             # For cron/scheduled runs or test mode, use YYYYMMDD-nightly format
-            echo "release_version=$(date +%Y%m%d)-nightly-test" >> $GITHUB_OUTPUT
+            echo "release_version=$(date +%Y%m%d)-nightly" >> $GITHUB_OUTPUT
           elif [ -z "${{ github.event.inputs.release_version }}" ]; then
             # For manual runs without specified version, use YYYYMMDD_HHmmss
             echo "release_version=$(date +%Y%m%d_%H%M%S)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Removed "-test" suffix from nightly version format in release workflow
- This ensures release notes correctly show `codelayer-nightly` in installation instructions

## Details
The conditional expressions in the release notes were already correct - they check if the version contains 'nightly' and add the appropriate suffix. However, the version was being set to `YYYYMMDD-nightly-test` instead of just `YYYYMMDD-nightly`, causing the condition to match incorrectly.

Fixes #ENG-1897

## Test plan
- [x] Verified the workflow change removes only the "-test" suffix
- [ ] Next nightly build should show correct `codelayer-nightly` in release notes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes nightly release version format by removing "-test" suffix in `release-macos.yml`.
> 
>   - **Behavior**:
>     - Removed "-test" suffix from nightly version format in `release-macos.yml`.
>     - Ensures release notes show `codelayer-nightly` correctly in installation instructions.
>   - **Files**:
>     - Modified `release-macos.yml` to set version as `YYYYMMDD-nightly` instead of `YYYYMMDD-nightly-test`.
>   - **Testing**:
>     - Verified workflow change removes only the "-test" suffix.
>     - Next nightly build should confirm correct version format in release notes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 44487997b923bf6574b5376f1dbea94563930f83. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->