### PR TITLE
sam/ENG-1745- fix: improve escape key handling and prevent modal stacking

### DIFF
--- a/humanlayer-wui/src/components/SessionLauncher.tsx
+++ b/humanlayer-wui/src/components/SessionLauncher.tsx
@@ -5,6 +5,9 @@ import { cn } from '@/lib/utils'
 import CommandInput from './CommandInput'
 import CommandPaletteMenu from './CommandPaletteMenu'
 import { useSessionLauncher } from '@/hooks/useSessionLauncher'
+import { useStealHotkeyScope } from '@/hooks/useStealHotkeyScope'
+
+const SessionLauncherHotkeysScope = 'session-launcher'
 
 interface SessionLauncherProps {
   isOpen: boolean
@@ -16,10 +19,22 @@ export function SessionLauncher({ isOpen, onClose }: SessionLauncherProps) {
   const { query, setQuery, config, setConfig, launchSession, isLaunching, error, mode, view, setView } =
     useSessionLauncher()
 
-  useHotkeys('escape', onClose, {
-    enabled: isOpen,
-    enableOnFormTags: false,
-  })
+  useHotkeys(
+    'escape',
+    e => {
+      e.preventDefault()
+      e.stopPropagation()
+      onClose()
+    },
+    {
+      enabled: isOpen,
+      enableOnFormTags: false,
+      scopes: SessionLauncherHotkeysScope,
+    },
+  )
+
+  // Only steal scope when actually open
+  useStealHotkeyScope(SessionLauncherHotkeysScope, isOpen)
 
   useEffect(() => {
     if (isOpen && view === 'input' && modalRef.current) {

--- a/humanlayer-wui/src/components/internal/SessionDetail/DangerouslySkipPermissionsDialog.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/DangerouslySkipPermissionsDialog.tsx
@@ -43,13 +43,13 @@ const DangerouslySkipPermissionsDialogContent: FC<{
     ev => {
       ev.preventDefault()
       ev.stopPropagation()
-      
+
       // If the timeout input is focused, blur it instead of closing
       if (timeoutInputRef.current && document.activeElement === timeoutInputRef.current) {
         timeoutInputRef.current.blur()
         return
       }
-      
+
       onOpenChange(false)
     },
     {

--- a/humanlayer-wui/src/components/internal/SessionDetail/DangerouslySkipPermissionsDialog.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/DangerouslySkipPermissionsDialog.tsx
@@ -14,6 +14,7 @@ import { Label } from '@/components/ui/label'
 import { Checkbox } from '@/components/ui/checkbox'
 import { AlertTriangle } from 'lucide-react'
 import { useStealHotkeyScope } from '@/hooks/useStealHotkeyScope'
+import { useHotkeys } from 'react-hotkeys-hook'
 
 const DangerouslySkipPermissionsHotkeysScope = 'dangerously-skip-permissions-dialog'
 
@@ -27,13 +28,37 @@ interface DangerouslySkipPermissionsDialogProps {
 const DangerouslySkipPermissionsDialogContent: FC<{
   onOpenChange: (open: boolean) => void
   onConfirm: (timeoutMinutes: number | null) => void
-}> = ({ onOpenChange, onConfirm }) => {
-  // Steal hotkey scope when this component mounts
-  useStealHotkeyScope(DangerouslySkipPermissionsHotkeysScope)
+  isOpen: boolean
+}> = ({ onOpenChange, onConfirm, isOpen }) => {
+  // Steal hotkey scope when this dialog is open
+  useStealHotkeyScope(DangerouslySkipPermissionsHotkeysScope, isOpen)
 
   const [timeoutMinutes, setTimeoutMinutes] = useState<number | ''>(15)
   const [useTimeout, setUseTimeout] = useState(true)
   const timeoutInputRef = useRef<HTMLInputElement>(null)
+
+  // Handle escape to close
+  useHotkeys(
+    'escape',
+    ev => {
+      ev.preventDefault()
+      ev.stopPropagation()
+      
+      // If the timeout input is focused, blur it instead of closing
+      if (timeoutInputRef.current && document.activeElement === timeoutInputRef.current) {
+        timeoutInputRef.current.blur()
+        return
+      }
+      
+      onOpenChange(false)
+    },
+    {
+      enabled: isOpen,
+      scopes: DangerouslySkipPermissionsHotkeysScope,
+      preventDefault: true,
+      enableOnFormTags: true,
+    },
+  )
 
   // Reset to default when component mounts (dialog opens)
   React.useEffect(() => {
@@ -143,9 +168,24 @@ export const DangerouslySkipPermissionsDialog: FC<DangerouslySkipPermissionsDial
 }) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[475px]">
+      <DialogContent
+        className="sm:max-w-[475px]"
+        onEscapeKeyDown={e => {
+          // Prevent the default Dialog escape handling
+          // Our custom escape handler will handle it
+          e.preventDefault()
+        }}
+        onPointerDownOutside={e => {
+          // Prevent closing when clicking outside
+          e.preventDefault()
+        }}
+      >
         {open && (
-          <DangerouslySkipPermissionsDialogContent onOpenChange={onOpenChange} onConfirm={onConfirm} />
+          <DangerouslySkipPermissionsDialogContent
+            onOpenChange={onOpenChange}
+            onConfirm={onConfirm}
+            isOpen={open}
+          />
         )}
       </DialogContent>
     </Dialog>

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -521,14 +521,18 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
     'alt+y',
     async () => {
       // Check if any modal scopes are active
-      const modalScopes = ['tool-result-modal', 'fork-view-modal', 'dangerously-skip-permissions-dialog']
+      const modalScopes = [
+        'tool-result-modal',
+        'fork-view-modal',
+        'dangerously-skip-permissions-dialog',
+      ]
       const hasModalOpen = activeScopes.some(scope => modalScopes.includes(scope))
-      
+
       // Don't trigger if other modals are open
       if (hasModalOpen || dangerousSkipPermissionsDialogOpen) {
         return
       }
-      
+
       if (dangerouslySkipPermissions) {
         // Disable dangerous skip permissions
         try {
@@ -644,16 +648,16 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
     'meta+y',
     e => {
       e.preventDefault()
-      
+
       // Check if any modal scopes are active
       const modalScopes = ['tool-result-modal', 'dangerously-skip-permissions-dialog']
       const hasModalOpen = activeScopes.some(scope => modalScopes.includes(scope))
-      
+
       // Don't trigger if other modals are open
       if (hasModalOpen) {
         return
       }
-      
+
       setForkViewOpen(!forkViewOpen)
     },
     {

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ForkViewModal.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ForkViewModal.tsx
@@ -260,6 +260,11 @@ export function ForkViewModal({
           // Prevent closing when clicking outside
           e.preventDefault()
         }}
+        onEscapeKeyDown={e => {
+          // Prevent the default Dialog escape handling
+          // Our custom escape handler in ForkViewModalContent will handle it
+          e.preventDefault()
+        }}
       >
         {isOpen && (
           <ForkViewModalContent

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ToolResultModal.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ToolResultModal.tsx
@@ -70,27 +70,47 @@ export function ToolResultModal({
   useHotkeys(
     'escape',
     ev => {
+      ev.preventDefault()
       ev.stopPropagation()
-      if (toolResult) {
+      if (toolResult || toolCall) {
         onClose()
       }
     },
-    { enabled: !!toolResult, scopes: ToolResultModalHotkeysScope },
+    {
+      enabled: !!(toolResult || toolCall),
+      scopes: ToolResultModalHotkeysScope,
+      preventDefault: true,
+    },
   )
 
-  useStealHotkeyScope(ToolResultModalHotkeysScope)
+  const isOpen = !!(toolResult || toolCall)
+  useStealHotkeyScope(ToolResultModalHotkeysScope, isOpen)
 
   // Show modal if we have either a tool result or just a tool call (unfinished)
-  if (!toolResult && !toolCall) return null
+  if (!isOpen) return null
 
   return (
     <Dialog
       open={!!(toolResult || toolCall)}
       onOpenChange={open => {
-        !open && onClose()
+        // Only close if Dialog is being closed by something other than escape
+        // Our custom escape handler will handle the escape key
+        if (!open) {
+          onClose()
+        }
       }}
     >
-      <DialogContent className="w-[90vw] max-w-[90vw] h-[85vh] p-0 sm:max-w-[90vw] flex flex-col overflow-hidden">
+      <DialogContent
+        className="w-[90vw] max-w-[90vw] h-[85vh] p-0 sm:max-w-[90vw] flex flex-col overflow-hidden"
+        onEscapeKeyDown={e => {
+          // Prevent the default Dialog escape handling
+          e.preventDefault()
+        }}
+        onPointerDownOutside={e => {
+          // Prevent closing when clicking outside
+          e.preventDefault()
+        }}
+      >
         <DialogHeader className="px-4 py-3 border-b bg-background flex-none">
           <DialogTitle className="text-sm font-mono">
             <div className="flex items-center gap-2">

--- a/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionActions.ts
+++ b/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionActions.ts
@@ -5,6 +5,7 @@ import { Session, ConversationEvent, ViewMode } from '@/lib/daemon/types'
 import { daemonClient } from '@/lib/daemon/client'
 import { notificationService } from '@/services/NotificationService'
 import { useStore } from '@/AppStore'
+import { SessionDetailHotkeysScope } from '../SessionDetail'
 
 interface UseSessionActionsProps {
   session: Session
@@ -139,21 +140,29 @@ export function useSessionActions({
   // Note: Escape key is handled in SessionDetail to manage confirmingApprovalId state
 
   // Ctrl+X to interrupt session
-  useHotkeys('ctrl+x', () => {
-    if (session.status === 'running' || session.status === 'starting') {
-      interruptSession(session.id)
-    }
-  })
+  useHotkeys(
+    'ctrl+x',
+    () => {
+      if (session.status === 'running' || session.status === 'starting') {
+        interruptSession(session.id)
+      }
+    },
+    { scopes: SessionDetailHotkeysScope },
+  )
 
   // R key - no longer needed since input is always visible
   // Keeping the hotkey registration but making it a no-op to avoid breaking anything
 
   // P key to navigate to parent session
-  useHotkeys('p', () => {
-    if (session.parentSessionId) {
-      handleNavigateToParent()
-    }
-  })
+  useHotkeys(
+    'p',
+    () => {
+      if (session.parentSessionId) {
+        handleNavigateToParent()
+      }
+    },
+    { scopes: SessionDetailHotkeysScope },
+  )
 
   return {
     responseInput,

--- a/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionApprovals.ts
+++ b/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionApprovals.ts
@@ -3,6 +3,7 @@ import { useHotkeys } from 'react-hotkeys-hook'
 import { ConversationEvent, ApprovalStatus } from '@/lib/daemon/types'
 import { daemonClient } from '@/lib/daemon/client'
 import { notificationService } from '@/services/NotificationService'
+import { SessionDetailHotkeysScope } from '../SessionDetail'
 
 interface UseSessionApprovalsProps {
   sessionId: string
@@ -104,6 +105,9 @@ export function useSessionApprovals({
         }
       }
     },
+    {
+      scopes: SessionDetailHotkeysScope,
+    },
     [
       events,
       focusedEventId,
@@ -140,6 +144,9 @@ export function useSessionApprovals({
       if (focusedEventId === pendingApprovalEvent.id) {
         handleStartDeny(pendingApprovalEvent.approvalId!)
       }
+    },
+    {
+      scopes: SessionDetailHotkeysScope,
     },
     [events, focusedEventId, handleStartDeny, setFocusedEventId, setFocusSource],
   )

--- a/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionClipboard.ts
+++ b/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionClipboard.ts
@@ -21,8 +21,8 @@ export function useSessionClipboard(focusedEvent: ConversationEvent | null, enab
       }
     },
     {
-      scopes: [SessionDetailHotkeysScope],
       enabled: enabled && !!focusedEvent,
+      scopes: SessionDetailHotkeysScope,
     },
   )
 }

--- a/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionNavigation.ts
+++ b/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionNavigation.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { ConversationEvent, ConversationEventType } from '@/lib/daemon/types'
+import { SessionDetailHotkeysScope } from '../SessionDetail'
 
 interface NavigableItem {
   id: number
@@ -131,8 +132,14 @@ export function useSessionNavigation({
   }, [focusedEventId, navigableItems, startKeyboardNavigation])
 
   // Keyboard navigation
-  useHotkeys('j, ArrowDown', focusNextEvent, { enabled: !expandedToolResult && !disabled })
-  useHotkeys('k, ArrowUp', focusPreviousEvent, { enabled: !expandedToolResult && !disabled })
+  useHotkeys('j, ArrowDown', focusNextEvent, {
+    enabled: !expandedToolResult && !disabled,
+    scopes: SessionDetailHotkeysScope,
+  })
+  useHotkeys('k, ArrowUp', focusPreviousEvent, {
+    enabled: !expandedToolResult && !disabled,
+    scopes: SessionDetailHotkeysScope,
+  })
 
   // I key to expand task groups or inspect tool results
   useHotkeys(
@@ -173,11 +180,13 @@ export function useSessionNavigation({
             )
           : null
 
+        // Clear focus when opening modal to prevent double escape handling
+        setFocusedEventId(null)
         setExpandedToolResult(toolResult || null)
         setExpandedToolCall(focusedEvent)
       }
     },
-    { enabled: !expandedToolResult && !disabled },
+    { enabled: !expandedToolResult && !disabled, scopes: SessionDetailHotkeysScope },
   )
 
   // Scroll focused element into view (only for keyboard navigation)

--- a/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
@@ -249,6 +249,8 @@ export function ConversationContent({
                         )
                       : null
                     if (setExpandedToolResult && setExpandedToolCall) {
+                      // Clear focus when opening modal to prevent double escape handling
+                      setFocusedEventId(null)
                       setExpandedToolResult(toolResult || null)
                       setExpandedToolCall(event)
                     }

--- a/humanlayer-wui/src/components/internal/SessionDetail/views/TaskGroup.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/TaskGroup.tsx
@@ -213,6 +213,8 @@ export function TaskGroup({
                     if (event?.eventType === ConversationEventType.ToolCall) {
                       const toolResult = event.toolId ? toolResultsByKey[event.toolId] : null
                       if (setExpandedToolResult && setExpandedToolCall) {
+                        // Clear focus when opening modal to prevent double escape handling
+                        setFocusedEventId(null)
                         setExpandedToolResult(toolResult || null)
                         setExpandedToolCall(event)
                       }

--- a/humanlayer-wui/src/hooks/useSessionLauncher.ts
+++ b/humanlayer-wui/src/hooks/useSessionLauncher.ts
@@ -219,6 +219,19 @@ export function useSessionLauncherHotkeys() {
     )
   }
 
+  // Check if a modal scope is active (indicating a modal is open)
+  const isModalScopeActive = () => {
+    // Only check for specific modals that should block global hotkeys
+    // Don't include all modals - for example, we want 'c' to work in SessionDetail
+    return activeScopes.some(
+      scope =>
+        scope === 'tool-result-modal' || // Tool result modal (opened with 'i')
+        scope === 'session-launcher' || // Session launcher itself
+        scope === 'fork-view-modal' || // Fork view modal
+        scope === 'dangerously-skip-permissions-dialog', // Permissions dialog
+    )
+  }
+
   return {
     handleKeyDown: (e: KeyboardEvent) => {
       // Cmd+K - Global command palette (shows menu)
@@ -233,14 +246,17 @@ export function useSessionLauncherHotkeys() {
       }
 
       // C - Create new session directly (bypasses command palette)
+      // Don't trigger if a modal is already open
       if (e.key === 'c' && !e.metaKey && !e.ctrlKey && !isTypingInInput()) {
-        e.preventDefault()
-        // Open launcher if not already open
-        if (!isOpen) {
-          open('command')
+        if (!isModalScopeActive()) {
+          e.preventDefault()
+          // Open launcher if not already open
+          if (!isOpen) {
+            open('command')
+          }
+          createNewSession()
+          return
         }
-        createNewSession()
-        return
       }
 
       // / - Search sessions and approvals (only when not typing)
@@ -251,7 +267,8 @@ export function useSessionLauncherHotkeys() {
         !e.metaKey &&
         !e.ctrlKey &&
         !isTypingInInput() &&
-        !activeScopes.includes(SessionTableHotkeysScope)
+        !activeScopes.includes(SessionTableHotkeysScope) &&
+        !isModalScopeActive()
       ) {
         e.preventDefault()
         open('search')
@@ -259,7 +276,7 @@ export function useSessionLauncherHotkeys() {
       }
 
       // G prefix navigation (prepare for Phase 2)
-      if (e.key === 'g' && !e.metaKey && !e.ctrlKey && !isTypingInInput()) {
+      if (e.key === 'g' && !e.metaKey && !e.ctrlKey && !isTypingInInput() && !isModalScopeActive()) {
         e.preventDefault()
         setGPrefixMode(true)
         setTimeout(() => setGPrefixMode(false), 2000)

--- a/humanlayer-wui/src/hooks/useStealHotkeyScope.ts
+++ b/humanlayer-wui/src/hooks/useStealHotkeyScope.ts
@@ -1,24 +1,44 @@
 import { useEffect, useRef } from 'react'
 import { useHotkeysContext } from 'react-hotkeys-hook'
-import { logger } from '@/lib/logging'
 
-export function useStealHotkeyScope(targetScope: string) {
+export function useStealHotkeyScope(targetScope: string, enabled: boolean = true) {
   const { activeScopes, enableScope, disableScope } = useHotkeysContext()
   const initialScopesRef = useRef<string[]>([])
+  const hasStolen = useRef(false)
 
   useEffect(() => {
-    initialScopesRef.current = activeScopes
-    logger.log('disabling scopes (storing initial)', activeScopes)
-    activeScopes.forEach(scope => disableScope(scope))
-    logger.log('activating target scope', targetScope)
-    enableScope(targetScope)
+    if (!enabled) {
+      // If not enabled but we previously stole scopes, restore them
+      if (hasStolen.current) {
+        disableScope(targetScope)
+        initialScopesRef.current.forEach(scope => enableScope(scope))
+        hasStolen.current = false
+      }
+      return
+    }
+
+    // Only steal if we haven't already
+    if (!hasStolen.current) {
+      // Capture scopes at this exact moment
+      const scopesToDisable = [...activeScopes]
+      initialScopesRef.current = scopesToDisable
+
+      scopesToDisable.forEach(scope => disableScope(scope))
+
+      enableScope(targetScope)
+      hasStolen.current = true
+    }
 
     return () => {
-      logger.log('disabling target scope', targetScope)
-      disableScope(targetScope)
+      if (hasStolen.current) {
+        disableScope(targetScope)
 
-      logger.log('enabling scopes', initialScopesRef.current)
-      initialScopesRef.current.forEach(scope => enableScope(scope))
+        // Add small delay to prevent race conditions
+        setTimeout(() => {
+          initialScopesRef.current.forEach(scope => enableScope(scope))
+        }, 0)
+        hasStolen.current = false
+      }
     }
-  }, [])
+  }, [enabled, targetScope, enableScope, disableScope])
 }

--- a/humanlayer-wui/src/main.tsx
+++ b/humanlayer-wui/src/main.tsx
@@ -13,7 +13,7 @@ attachConsole().catch(console.error)
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <ThemeProvider>
-      <HotkeysProvider initiallyActiveScopes={['none']}>
+      <HotkeysProvider>
         <RouterProvider router={router} />
       </HotkeysProvider>
     </ThemeProvider>


### PR DESCRIPTION
## What problem(s) was I solving?

The escape key behavior was unreliable and inconsistent across the application, particularly when dealing with modals and nested UI states. Users experienced issues where:
- ESC key would close both modals and the session detail view unexpectedly
- Clicking into text inputs in modals and pressing ESC would back out of multiple UI layers
- Modal stacking allowed multiple modals to open on top of each other (fork view, bypass permissions, tool results)
- Hotkeys from background components would still fire when modals were open, causing confusion
- The 'c' key for creating new sessions would sometimes get blocked by stuck modal scopes

## What user-facing changes did I ship?

- **Improved ESC key cascade behavior**: ESC now follows a predictable cascade: blur focused inputs → clear confirmation states → unfocus selected items → close modal → close view
- **Fixed modal input behavior**: When typing in modal inputs (like the bypass permissions timeout field), ESC first blurs the input instead of closing the entire modal
- **Prevented modal stacking**: Only one modal can be open at a time - pressing alt+y or cmd+y won't open new modals over existing ones
- **Better hotkey isolation**: When modals are open, background hotkeys are properly disabled to prevent accidental actions
- **More reliable keyboard navigation**: Fixed issues where hotkey scopes would get stuck, blocking global shortcuts like 'c' for creating new sessions

## How I implemented it

The implementation focused on three main areas:

1. **Hotkey Scope Management**: 
   - Added proper scope management to all SessionDetail hooks using `SessionDetailHotkeysScope`
   - Implemented scope stealing for modals using the `useStealHotkeyScope` hook
   - Fixed scope cleanup in ToolResultModal to prevent stuck states

2. **Modal Stacking Prevention**:
   - Added active scope checking before opening modals (alt+y for bypass permissions, cmd+y for fork view)
   - Check for conflicting modal scopes: `tool-result-modal`, `fork-view-modal`, `dangerously-skip-permissions-dialog`

3. **Escape Key Handling**:
   - Added custom escape handlers to each modal that prevent default Dialog behavior
   - Implemented input blur detection in DangerouslySkipPermissionsDialog
   - Created proper escape cascade in SessionDetail that checks modal states before processing

## How to verify it

- [ ] I have ensured `make check test` passes (Note: trailing whitespace needs fixing)
- [x] TypeScript compilation passes (`npm run typecheck`)
- [ ] Test ESC key behavior in bypass permissions modal with input focused
- [ ] Test that cmd+y doesn't open fork view when tool result modal is open
- [ ] Test that alt+y doesn't open bypass permissions when fork view is open
- [ ] Verify 'c' key creates new session when no modals are open
- [ ] Test ESC key cascade: input blur → confirmation clear → unfocus → close

## Description for the changelog

Fixed escape key handling reliability and prevented modal stacking issues in the UI. ESC key now follows a predictable cascade through UI states, modal inputs properly handle focus/blur, and hotkey scopes are correctly isolated when modals are open.