### PR TITLE
sam/eng-1930: removed connecting from list of robot words

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -78,7 +78,6 @@ const ROBOT_VERBS = [
   'transcribing',
   'receiving',
   'adhering',
-  'connecting',
   'sublimating',
   'balancing',
   'ionizing',


### PR DESCRIPTION
removed the word "connecting" from the list of words that cycle while waiting because it was misleading
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `connecting` from `ROBOT_VERBS` in `SessionDetail.tsx` to avoid misleading users.
> 
>   - **Behavior**:
>     - Removed the word `connecting` from `ROBOT_VERBS` in `SessionDetail.tsx` to prevent misleading users during wait cycles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 6c0030f3eafd866811877654700e0eecbc53bc2e. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->