### PR TITLE
Fix token counting for Claude sessions

### DIFF
--- a/hld/session/manager.go
+++ b/hld/session/manager.go
@@ -277,9 +277,25 @@ eventLoop:
 				}
 			}
 
-			// Capture Claude session ID
-			if event.SessionID != "" && claudeSessionID == "" {
-				claudeSessionID = event.SessionID
+			// Capture Claude session ID from either top-level or message session_id
+			if claudeSessionID == "" {
+				if event.SessionID != "" {
+					claudeSessionID = event.SessionID
+				} else if event.Message != nil && event.Message.ID != "" {
+					// For assistant/user messages, we can use the message itself as proof of session
+					// The actual claude session ID might be in the raw JSON
+					if eventJSON, err := json.Marshal(event); err == nil {
+						var rawEvent map[string]interface{}
+						if err := json.Unmarshal(eventJSON, &rawEvent); err == nil {
+							if sid, ok := rawEvent["session_id"].(string); ok && sid != "" {
+								claudeSessionID = sid
+							}
+						}
+					}
+				}
+			}
+
+			if claudeSessionID != "" {
 				// Note: Claude session ID captured for resume capability
 				slog.Debug("captured Claude session ID",
 					"session_id", sessionID,
@@ -593,7 +609,65 @@ func (m *Manager) updateSessionActivity(ctx context.Context, sessionID string) {
 
 // processStreamEvent processes a streaming event and stores it in the database
 func (m *Manager) processStreamEvent(ctx context.Context, sessionID string, claudeSessionID string, event claudecode.StreamEvent) error {
-	// Skip events without claude session ID
+	// Log the entire raw event JSON for debugging
+	if eventJSON, err := json.Marshal(event); err == nil {
+		slog.Debug("processing API event",
+			"session_id", sessionID,
+			"event_type", event.Type,
+			"raw_event_json", string(eventJSON))
+	}
+
+	// Process token updates from assistant messages even without claudeSessionID
+	if event.Type == "assistant" && event.Message != nil && event.Message.Role == "assistant" && event.Message.Usage != nil {
+		usage := event.Message.Usage
+		// Compute effective context tokens (what's actually in the context window)
+		// This includes ALL tokens that count toward the context limit
+		effective := usage.InputTokens + usage.OutputTokens + usage.CacheReadInputTokens + usage.CacheCreationInputTokens
+
+		now := time.Now()
+		update := store.SessionUpdate{
+			InputTokens:              &usage.InputTokens,
+			OutputTokens:             &usage.OutputTokens,
+			CacheCreationInputTokens: &usage.CacheCreationInputTokens,
+			CacheReadInputTokens:     &usage.CacheReadInputTokens,
+			EffectiveContextTokens:   &effective,
+			LastActivityAt:           &now,
+		}
+
+		if err := m.store.UpdateSession(ctx, sessionID, update); err != nil {
+			slog.Error("failed to update token usage",
+				"session_id", sessionID,
+				"error", err)
+		} else {
+			// Publish event to notify UI about token update
+			// The UI needs "new_status" field even though we're not changing status
+			if m.eventBus != nil {
+				// Get current session to include current status
+				session, _ := m.store.GetSession(ctx, sessionID)
+				currentStatus := "running"
+				if session != nil && session.Status != "" {
+					currentStatus = session.Status
+				}
+
+				slog.Debug("Publishing token update event",
+					"session_id", sessionID,
+					"status", currentStatus,
+					"effective_tokens", effective)
+
+				m.eventBus.Publish(bus.Event{
+					Type: bus.EventSessionStatusChanged,
+					Data: map[string]interface{}{
+						"session_id":  sessionID,
+						"new_status":  currentStatus,  // Required by UI handler
+						"old_status":  currentStatus,  // Status isn't changing, just tokens
+						"reason":      "token_update",
+					},
+				})
+			}
+		}
+	}
+
+	// Skip remaining event processing without claude session ID
 	if claudeSessionID == "" {
 		return nil
 	}
@@ -693,30 +767,7 @@ func (m *Manager) processStreamEvent(ctx context.Context, sessionID string, clau
 	case "assistant", "user":
 		// Messages contain the actual content
 		if event.Message != nil {
-			// Process usage data from assistant messages
-			if event.Message.Role == "assistant" && event.Message.Usage != nil {
-				usage := event.Message.Usage
-				// Compute effective context tokens (what's actually in the context window)
-				// This includes ALL tokens that count toward the context limit
-				effective := usage.InputTokens + usage.OutputTokens + usage.CacheReadInputTokens + usage.CacheCreationInputTokens
-
-				now := time.Now()
-				update := store.SessionUpdate{
-					InputTokens:              &usage.InputTokens,
-					OutputTokens:             &usage.OutputTokens,
-					CacheCreationInputTokens: &usage.CacheCreationInputTokens,
-					CacheReadInputTokens:     &usage.CacheReadInputTokens,
-					EffectiveContextTokens:   &effective,
-					LastActivityAt:           &now,
-				}
-
-				if err := m.store.UpdateSession(ctx, sessionID, update); err != nil {
-					slog.Error("failed to update token usage",
-						"session_id", sessionID,
-						"error", err)
-				}
-			}
-
+			// Token usage is already processed at the top of this function
 			// Process each content block
 			for _, content := range event.Message.Content {
 				switch content.Type {
@@ -897,14 +948,13 @@ func (m *Manager) processStreamEvent(ctx context.Context, sessionID string, clau
 		// Process usage data from result event
 		if event.Usage != nil {
 			usage := event.Usage
-			// Compute effective context tokens (what's actually in the context window)
-			effective := usage.InputTokens + usage.OutputTokens + usage.CacheReadInputTokens + usage.CacheCreationInputTokens
-
-			update.InputTokens = &usage.InputTokens
-			update.OutputTokens = &usage.OutputTokens
-			update.CacheCreationInputTokens = &usage.CacheCreationInputTokens
-			update.CacheReadInputTokens = &usage.CacheReadInputTokens
-			update.EffectiveContextTokens = &effective
+			// Skip updating token counts from result events - they appear to accumulate incorrectly
+			// Result events show cumulative cache reads across the entire session (bug)
+			// We only trust token counts from individual assistant messages
+			slog.Debug("Skipping result event token update due to API bug",
+				"session_id", sessionID,
+				"cache_read_tokens", usage.CacheReadInputTokens,
+				"reason", "result events report cumulative cache reads")
 		}
 
 		if event.Error != "" {

--- a/humanlayer-wui/src/components/Layout.tsx
+++ b/humanlayer-wui/src/components/Layout.tsx
@@ -66,6 +66,7 @@ export function Layout() {
   const addRecentResolvedApprovalToCache = useStore(state => state.addRecentResolvedApprovalToCache)
   const isRecentResolvedApproval = useStore(state => state.isRecentResolvedApproval)
   const setActiveSessionDetail = useStore(state => state.setActiveSessionDetail)
+  const updateActiveSessionDetail = useStore(state => state.updateActiveSessionDetail)
 
   // Set up single SSE subscription for all events
   useSessionSubscriptions(connected, {
@@ -76,6 +77,15 @@ export function Layout() {
       const previousStatus = targetSession?.status
       const sessionResponse = await daemonClient.getSessionState(data.session_id)
       const session = sessionResponse.session
+
+      // Always update the session in the sessions list
+      useStore.getState().updateSessionOptimistic(session_id, session)
+
+      // Update active session detail if this is the currently viewed session
+      const activeSessionId = useStore.getState().activeSessionDetail?.session?.id
+      if (activeSessionId === session_id) {
+        updateActiveSessionDetail(session)
+      }
 
       if (!nextStatus) {
         logger.warn('useSessionSubscriptions.onSessionStatusChanged: nextStatus is undefined', data)


### PR DESCRIPTION
## Summary
- Fixes incorrect token counting that showed 10x the actual context usage
- Ensures UI updates in real-time when token counts change
- Works around API bug where result events accumulate cache reads incorrectly

## Changes
- Extract session ID from assistant/user messages when not available at top level
- Process token updates even without Claude session ID to ensure early messages are counted
- Skip token updates from result events (they incorrectly accumulate cache reads)
- Update active session detail in UI when token counts change
- Publish token update events to keep UI synchronized

## Test plan
- [ ] Verify token counts update in real-time in the UI
- [ ] Confirm effective context tokens match actual usage (not 10x inflated)
- [ ] Check that token updates work for sessions without explicit session IDs
- [ ] Ensure UI reflects accurate token counts for active sessions

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes token counting and UI synchronization for Claude sessions, handling missing session IDs and skipping incorrect token updates.
> 
>   - **Behavior**:
>     - Fixes token counting error showing 10x actual usage in `manager.go`.
>     - Updates UI in real-time when token counts change in `Layout.tsx`.
>     - Skips token updates from result events due to API bug in `manager.go`.
>   - **Session Management**:
>     - Extracts session ID from messages if not available at top level in `manager.go`.
>     - Processes token updates without Claude session ID in `manager.go`.
>     - Publishes token update events to synchronize UI in `manager.go`.
>   - **UI Updates**:
>     - Updates active session detail in UI when token counts change in `Layout.tsx`.
>     - Adds `updateActiveSessionDetail` to `Layout.tsx` for session detail updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 6e5b82f36160b629e092ef046674e89eb4eeef94. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->