### PR TITLE
sam/ENG-1905 Fix archive view showing active sessions

### DIFF
--- a/humanlayer-wui/src/lib/daemon/http-client.ts
+++ b/humanlayer-wui/src/lib/daemon/http-client.ts
@@ -168,6 +168,7 @@ export class HTTPDaemonClient implements IDaemonClient {
     const response = await this.client!.listSessions({
       leafOnly: true,
       includeArchived: request?.include_archived,
+      archivedOnly: request?.archived_only,
     })
     logger.debug(
       'getSessionLeaves raw response sample:',


### PR DESCRIPTION
## What problem(s) was I solving?

Fixed a regression where active sessions were incorrectly appearing in the archive view. The archive filter wasn't working because the `archivedOnly` parameter was not being forwarded from the HTTP client adapter to the underlying SDK. This was the second occurrence of this regression - it was previously fixed in PR #394 but inadvertently reverted in commit 436e4a1.

## What user-facing changes did I ship?

- Archive view now correctly shows only archived sessions
- Active view no longer shows archived sessions mixed in with active ones
- View switching between active and archived sessions works as expected

## How I implemented it

Added the missing `archivedOnly` parameter to the SDK call in the HTTPDaemonClient's `getSessionLeaves` method. This was a one-line fix to restore functionality that was accidentally removed.

The fix forwards the `archived_only` parameter from the HTTP request to the SDK's `listSessions` method as `archivedOnly`:

```typescript
const response = await this.client!.listSessions({
  leafOnly: true,
  includeArchived: request?.include_archived,
  archivedOnly: request?.archived_only,  // Added this line
})
```

## How to verify it

- [x] I have ensured `make check test` passes

Manual verification:
1. Launch the HumanLayer Web UI
2. Create or have existing sessions (both active and archived)
3. Navigate to the archive view - should only show archived sessions
4. Navigate to the active view - should only show active sessions
5. Archive an active session - it should disappear from active view and appear in archive view
6. Unarchive a session - it should reappear in active view and disappear from archive view

## Description for the changelog

Fix archive view filter regression that caused active sessions to appear in archived view