### PR TITLE
fix: update expiry notification text to use 'bypass permissions' terminology

### DIFF
--- a/humanlayer-wui/src/components/DangerousSkipPermissionsMonitor.tsx
+++ b/humanlayer-wui/src/components/DangerousSkipPermissionsMonitor.tsx
@@ -38,7 +38,7 @@ export const DangerousSkipPermissionsMonitor = () => {
                 // Show notification using NotificationService
                 await notificationService.notify({
                   type: 'settings_changed',
-                  title: 'Dangerous skip permissions expired',
+                  title: 'Bypass permissions expired',
                   body: `Session: ${session.title || session.summary || 'Untitled'}`,
                   metadata: {
                     sessionId: session.id,

--- a/humanlayer-wui/src/components/internal/SessionDetail/AutoAcceptIndicator.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/AutoAcceptIndicator.tsx
@@ -40,7 +40,7 @@ export const SessionModeIndicator: FC<SessionModeIndicatorProps> = ({
           })
 
           // Show notification
-          toast.info('Dangerous skip permissions expired', {
+          toast.info('Bypass permissions expired', {
             description: 'Manual approval required for all tools',
             duration: 5000,
           })


### PR DESCRIPTION
Placeholder - updating description...