### PR TITLE
feat: add localStorage persistence for SessionLauncher draft prompts

### DIFF
--- a/humanlayer-wui/src/hooks/useSessionLauncher.ts
+++ b/humanlayer-wui/src/hooks/useSessionLauncher.ts
@@ -40,6 +40,7 @@ interface LauncherState {
 }
 
 const LAST_WORKING_DIR_KEY = 'humanlayer-last-working-dir'
+const SESSION_LAUNCHER_QUERY_KEY = 'session-launcher-query'
 
 // Helper function to get default working directory
 const getDefaultWorkingDir = (): string => {
@@ -47,12 +48,17 @@ const getDefaultWorkingDir = (): string => {
   return stored || '~/' // Default to home directory on first launch
 }
 
+// Helper function to get saved query
+const getSavedQuery = (): string => {
+  return localStorage.getItem(SESSION_LAUNCHER_QUERY_KEY) || ''
+}
+
 export const useSessionLauncher = create<LauncherState>((set, get) => ({
   isOpen: false,
   mode: 'command',
   view: 'menu',
-  query: '',
-  config: { query: '', workingDir: getDefaultWorkingDir() },
+  query: getSavedQuery(),
+  config: { query: getSavedQuery(), workingDir: getDefaultWorkingDir() },
   isLaunching: false,
   gPrefixMode: false,
   selectedMenuIndex: 0,
@@ -67,23 +73,27 @@ export const useSessionLauncher = create<LauncherState>((set, get) => ({
     }),
 
   close: () => {
+    const savedQuery = getSavedQuery()
     set({
       isOpen: false,
       view: 'menu',
-      query: '',
-      config: { query: '', workingDir: getDefaultWorkingDir() },
+      query: savedQuery,
+      config: { query: savedQuery, workingDir: getDefaultWorkingDir() },
       selectedMenuIndex: 0,
       error: undefined,
       gPrefixMode: false,
     })
   },
 
-  setQuery: query =>
-    set(state => ({
+  setQuery: query => {
+    // Save to localStorage on every change
+    localStorage.setItem(SESSION_LAUNCHER_QUERY_KEY, query)
+    return set(state => ({
       query,
       config: { ...state.config, query },
       error: undefined,
-    })),
+    }))
+  },
 
   setConfig: config => set({ config, error: undefined }),
 
@@ -152,6 +162,9 @@ export const useSessionLauncher = create<LauncherState>((set, get) => ({
         localStorage.setItem(LAST_WORKING_DIR_KEY, config.workingDir)
       }
 
+      // Clear the saved query after successful launch
+      localStorage.removeItem(SESSION_LAUNCHER_QUERY_KEY)
+
       // Navigate to new session (will be handled by parent component)
       window.location.hash = `#/sessions/${response.sessionId}`
 
@@ -171,11 +184,12 @@ export const useSessionLauncher = create<LauncherState>((set, get) => ({
   },
 
   createNewSession: () => {
+    const savedQuery = getSavedQuery()
     // Switch to input mode for session creation
     set({
       view: 'input',
-      query: '',
-      config: { query: '', workingDir: getDefaultWorkingDir() },
+      query: savedQuery,
+      config: { query: savedQuery, workingDir: getDefaultWorkingDir() },
       error: undefined,
     })
   },
@@ -186,18 +200,20 @@ export const useSessionLauncher = create<LauncherState>((set, get) => ({
     get().close()
   },
 
-  reset: () =>
-    set({
+  reset: () => {
+    const savedQuery = getSavedQuery()
+    return set({
       isOpen: false,
       mode: 'command',
       view: 'menu',
-      query: '',
-      config: { query: '', workingDir: getDefaultWorkingDir() },
+      query: savedQuery,
+      config: { query: savedQuery, workingDir: getDefaultWorkingDir() },
       selectedMenuIndex: 0,
       isLaunching: false,
       error: undefined,
       gPrefixMode: false,
-    }),
+    })
+  },
 }))
 
 // Helper hook for global hotkey management


### PR DESCRIPTION
## What problem(s) was I solving?

Users were losing their draft prompts when they accidentally closed the SessionLauncher (accessed via 'c' shortcut or Cmd+K). This was particularly frustrating when composing complex multi-line prompts or when accidentally hitting ESC or clicking outside the launcher. The SessionLauncher would reset the query to an empty string on close, forcing users to retype their entire prompt.

This issue was identified as ENG-1678 and marked as Urgent priority because it directly impacts the user experience when creating new Claude Code sessions.

## What user-facing changes did I ship?

- **Draft persistence**: Prompts typed in the SessionLauncher are now automatically saved to localStorage on every keystroke
- **Draft restoration**: When reopening the launcher (via 'c' shortcut or Cmd+K), any previously typed prompt is restored
- **Smart clearing**: Drafts are only cleared after successful session creation, not on cancel or error
- **Error recovery**: If session launch fails, the prompt is preserved so users can retry without retyping

This follows the exact same pattern already used in SessionDetail's ResponseInput component, ensuring consistency across the application.

## How I implemented it

The implementation adds localStorage persistence to the `useSessionLauncher` hook by:

1. **Added localStorage key constant**: `SESSION_LAUNCHER_QUERY_KEY = 'session-launcher-query'`
2. **Created helper function**: `getSavedQuery()` to retrieve saved drafts from localStorage
3. **Updated state initialization**: Query and config now initialize with saved values instead of empty strings
4. **Modified setQuery**: Saves to localStorage on every change (immediate, not debounced)
5. **Updated state management functions**: `close()`, `createNewSession()`, and `reset()` now preserve the saved query instead of resetting to empty
6. **Clear on success**: Added localStorage clearing after successful session launch

The changes are minimal (~30 lines) and follow established patterns from the ResponseInput component, ensuring maintainability and consistency.

## How to verify it

- [x] I have ensured `make check test` passes

**Manual testing steps:**
1. Open the SessionLauncher with 'c' shortcut
2. Type a test prompt (e.g., "Help me implement a new feature")
3. Press ESC to close the launcher
4. Press 'c' again to reopen
5. Verify the prompt is restored
6. Launch a session successfully
7. Press 'c' again
8. Verify the prompt is now empty (cleared after success)
9. Type another prompt and simulate an error (e.g., disconnect network)
10. Verify the prompt is preserved after error for retry

## Description for the changelog

**Feature**: Add localStorage persistence for SessionLauncher draft prompts - prevents loss of draft prompts when accidentally closing the launcher