### PR TITLE
feat: add meta+Enter keyboard shortcut to bypass permissions modal

### DIFF
--- a/humanlayer-wui/src/components/Layout.tsx
+++ b/humanlayer-wui/src/components/Layout.tsx
@@ -79,7 +79,8 @@ export function Layout() {
       const session = sessionResponse.session
 
       // Always update the session in the sessions list
-      useStore.getState().updateSessionOptimistic(session_id, session)
+      // Use updateSession (not updateSessionOptimistic) since this is data FROM the server
+      useStore.getState().updateSession(session_id, session)
 
       // Update active session detail if this is the currently viewed session
       const activeSessionId = useStore.getState().activeSessionDetail?.session?.id

--- a/humanlayer-wui/src/components/internal/SessionDetail/DangerouslySkipPermissionsDialog.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/DangerouslySkipPermissionsDialog.tsx
@@ -60,6 +60,26 @@ const DangerouslySkipPermissionsDialogContent: FC<{
     },
   )
 
+  // Add meta+enter to submit
+  useHotkeys(
+    'meta+enter, ctrl+enter',
+    ev => {
+      ev.preventDefault()
+      ev.stopPropagation()
+
+      // Only submit if the button would be enabled
+      if (!useTimeout || (timeoutMinutes !== '' && timeoutMinutes !== 0)) {
+        handleConfirm()
+      }
+    },
+    {
+      enabled: isOpen,
+      scopes: DangerouslySkipPermissionsHotkeysScope,
+      preventDefault: true,
+      enableOnFormTags: true,
+    },
+  )
+
   // Reset to default when component mounts (dialog opens)
   React.useEffect(() => {
     setTimeoutMinutes(15)
@@ -155,6 +175,11 @@ const DangerouslySkipPermissionsDialogContent: FC<{
           className="border-[var(--terminal-error)] text-[var(--terminal-error)] hover:bg-[var(--terminal-error)] hover:text-background disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Bypass Permissions
+          {!useTimeout || (timeoutMinutes !== '' && timeoutMinutes !== 0) ? (
+            <kbd className="ml-1 px-1 py-0.5 text-xs bg-muted/50 rounded">
+              {navigator.platform.toLowerCase().includes('mac') ? '⌘' : 'Ctrl'}+⏎
+            </kbd>
+          ) : null}
         </Button>
       </DialogFooter>
     </>

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -577,7 +577,12 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
         return
       }
 
-      if (dangerouslySkipPermissions) {
+      // Get the current value from the store directly to avoid stale closure
+      const currentSessionFromStore = useStore.getState().sessions.find(s => s.id === session.id)
+      const currentDangerouslySkipPermissions =
+        currentSessionFromStore?.dangerouslySkipPermissions ?? false
+
+      if (currentDangerouslySkipPermissions) {
         // Disable dangerous skip permissions
         try {
           await updateSessionOptimistic(session.id, {
@@ -597,7 +602,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
       preventDefault: true,
       scopes: SessionDetailHotkeysScope,
     },
-    [session.id, dangerouslySkipPermissions],
+    [session.id], // Remove dangerouslySkipPermissions from deps since we get it fresh each time
   )
 
   // Handle dialog confirmation


### PR DESCRIPTION
## What problem(s) was I solving?

The bypass permissions modal lacked keyboard navigation support, breaking the keyboard-first workflow pattern established throughout the application. Users had to use the mouse to click the "Bypass Permissions" button even after typing to change the timeout value, which was inconsistent with other forms in the app that support meta+Enter submission.

Additionally, there were state management issues where:
- Session state updates were using optimistic updates when receiving server data, leading to potential inconsistencies
- The meta+Y hotkey for toggling bypass permissions had a stale closure issue that could cause it to use outdated session state

## What user-facing changes did I ship?

- **Keyboard shortcut for bypass permissions modal**: Users can now press meta+Enter (Cmd+Enter on Mac, Ctrl+Enter on Windows/Linux) to submit the bypass permissions modal, matching the pattern used in other forms throughout the app
- **Visual keyboard hint**: The submit button now displays the keyboard shortcut (⌘+⏎ or Ctrl+⏎) when the form is valid, providing clear visual feedback about the available shortcut
- **Consistent terminology**: Updated notification text from "Dangerous skip permissions expired" to "Bypass permissions expired" for consistency
- **More reliable bypass permissions toggle**: The meta+Y hotkey now always uses the current session state, preventing toggle issues

## How I implemented it

1. **Added keyboard event handler** (`DangerouslySkipPermissionsDialog.tsx`):
   - Implemented `useHotkeys` handler for 'meta+enter, ctrl+enter' 
   - Validates form state before submission (respects timeout validation)
   - Uses proper event prevention and the existing hotkey scope system

2. **Added visual indicator** (`DangerouslySkipPermissionsDialog.tsx`):
   - Conditionally renders a `<kbd>` element showing the platform-appropriate shortcut
   - Only shows when the form is valid (matching the enabled state of the button)
   - Detects platform using `navigator.platform` to show ⌘ on Mac, Ctrl elsewhere

3. **Fixed session state management** (`Layout.tsx`, `SessionDetail.tsx`):
   - Changed from `updateSessionOptimistic` to `updateSession` when receiving server data
   - Fixed stale closure in meta+Y hotkey by reading state directly from store
   - Removed `dangerouslySkipPermissions` from dependency array to prevent stale closures

4. **Updated terminology** (`DangerousSkipPermissionsMonitor.tsx`, `AutoAcceptIndicator.tsx`):
   - Renamed notification text for consistency with the new "bypass permissions" terminology

## How to verify it

- [x] I have ensured `make check test` passes

**Manual testing steps:**
1. Open any session and press Alt+Y to open the bypass permissions modal
2. Verify meta+Enter (or Ctrl+Enter on Windows/Linux) submits the form with default timeout
3. Clear the timeout field and verify meta+Enter does NOT submit (validation works)
4. Uncheck "Auto-disable after" and verify meta+Enter submits successfully
5. Set timeout to 0 and verify meta+Enter does NOT submit
6. Verify the keyboard shortcut indicator appears/disappears based on form validity
7. Verify Escape key still closes the dialog without submitting
8. Test the meta+Y toggle to ensure it uses current session state

## Description for the changelog

Add keyboard shortcuts to bypass permissions modal (meta+Enter to submit) with visual indicators, fix session state update issues that could cause stale data in hotkeys, and update terminology to consistently use "bypass permissions" instead of "dangerous skip permissions".