### PR TITLE
feat: add 'i' key toggle to close expanded tool modal

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ToolResultModal.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ToolResultModal.tsx
@@ -84,6 +84,23 @@ export function ToolResultModal({
     },
   )
 
+  // Handle 'i' to close (toggle behavior)
+  useHotkeys(
+    'i',
+    ev => {
+      ev.preventDefault()
+      ev.stopPropagation()
+      if (toolResult || toolCall) {
+        onClose()
+      }
+    },
+    {
+      enabled: !!(toolResult || toolCall),
+      scopes: ToolResultModalHotkeysScope,
+      preventDefault: true,
+    },
+  )
+
   const isOpen = !!(toolResult || toolCall)
   useStealHotkeyScope(ToolResultModalHotkeysScope, isOpen)
 
@@ -167,7 +184,7 @@ export function ToolResultModal({
             <kbd>j/k</kbd> or <kbd>↓/↑</kbd> to scroll
           </span>
           <span className="text-xs text-muted-foreground">
-            <kbd>ESC</kbd> to close
+            <kbd>i</kbd> or <kbd>ESC</kbd> to close
           </span>
         </div>
       </DialogContent>


### PR DESCRIPTION
## What problem(s) was I solving?

The tool result modal could only be closed using the ESC key, which requires moving your hand away from the home row keys. This made it impossible to navigate through a session efficiently with one hand, as the user needed to use j/k for scrolling, 'i' to open tool modals, but then reach for ESC to close them. The lack of toggle behavior for the 'i' key broke the expected UX pattern where the same key that opens something should also close it.

## What user-facing changes did I ship?

- The 'i' key now toggles the tool result modal closed when it's open, creating a true toggle experience
- Updated the modal footer hint from "ESC to close" to "i or ESC to close" to make this feature discoverable
- Users can now navigate entire sessions with one hand using just j/k/i keys at their fingertips

## How I implemented it

The implementation was straightforward and followed the existing patterns in the codebase:

1. **Added 'i' hotkey handler**: Added a new `useHotkeys` hook in `ToolResultModal.tsx` that mirrors the existing ESC key handler. The handler uses the same hotkey scope (`ToolResultModalHotkeysScope`) and has identical behavior to the ESC handler - it calls `onClose()` when triggered.

2. **Updated visual hints**: Modified the footer text to show both keyboard shortcuts that can close the modal, making the feature discoverable for users.

The change leverages the existing hotkey scope stealing mechanism (`useStealHotkeyScope`) which ensures the 'i' key handler in the modal takes precedence over the background 'i' key handler that opens modals.

## How to verify it

- [x] I have ensured `make check test` passes

**Manual testing steps:**
1. Open the WUI and navigate to a session with tool calls
2. Use j/k keys to focus on a tool event
3. Press 'i' to open the tool result modal - verify it opens
4. Press 'i' again - verify the modal closes
5. Open the modal again with 'i', then press ESC - verify it still closes with ESC
6. Click on a tool to open the modal, press 'i' - verify it closes
7. Test rapid toggling (i, i, i) - verify no state issues or console errors
8. Inside the modal, verify j/k still work for scrolling

## Description for the changelog

Enable 'i' key to close tool result modal for better one-handed navigation (ENG-1943)