### PR TITLE
fix(wui): enable meta+enter submission from all fields in session launcher

### DIFF
--- a/humanlayer-wui/src/components/CommandInput.tsx
+++ b/humanlayer-wui/src/components/CommandInput.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react'
+import { useRef, useEffect } from 'react'
 import { Button } from './ui/button'
 import { SearchInput } from './FuzzySearchInput'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select'
@@ -52,17 +52,6 @@ export default function CommandInput({
     }
   }, [])
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-      e.preventDefault()
-      onSubmit()
-    }
-
-    if (e.key === 'Escape') {
-      promptRef.current?.blur()
-    }
-  }
-
   const getPlatformKey = () => {
     return navigator.platform.includes('Mac') ? '⌘' : 'Ctrl'
   }
@@ -109,15 +98,13 @@ export default function CommandInput({
           ref={promptRef}
           value={value}
           onChange={e => onChange(e.target.value)}
-          onKeyDown={handleKeyDown}
           placeholder={placeholder}
           disabled={isLoading}
           autoComplete="off"
           spellCheck={false}
         />
         <p className="text-xs text-muted-foreground mt-1">
-          <kbd className="px-1 py-0.5 bg-muted/50 rounded">{getPlatformKey()}+Enter</kbd> to launch
-          session, <kbd className="ml-1 px-1 py-0.5 bg-muted/50 rounded">Enter</kbd> for new line
+          <kbd className="px-1 py-0.5 bg-muted/50 rounded">Enter</kbd> for new line
         </p>
 
         {isLoading && (
@@ -159,7 +146,10 @@ export default function CommandInput({
                 Launching...
               </>
             ) : (
-              'Launch Session'
+              <>
+                Launch Session
+                <kbd className="ml-2 px-1 py-0.5 text-xs bg-muted/50 rounded">{getPlatformKey()}+⏎</kbd>
+              </>
             )}
           </Button>
         </div>

--- a/humanlayer-wui/src/components/SessionLauncher.tsx
+++ b/humanlayer-wui/src/components/SessionLauncher.tsx
@@ -33,6 +33,21 @@ export function SessionLauncher({ isOpen, onClose }: SessionLauncherProps) {
     },
   )
 
+  useHotkeys(
+    'meta+enter, ctrl+enter',
+    e => {
+      e.preventDefault()
+      e.stopPropagation()
+      handleSubmit()
+    },
+    {
+      enabled: isOpen,
+      enableOnFormTags: true, // Critical: allows the shortcut to work in form inputs
+      scopes: SessionLauncherHotkeysScope,
+      preventDefault: true,
+    },
+  )
+
   // Only steal scope when actually open
   useStealHotkeyScope(SessionLauncherHotkeysScope, isOpen)
 
@@ -115,8 +130,7 @@ export function SessionLauncher({ isOpen, onClose }: SessionLauncherProps) {
 
                 <div className="flex items-center justify-end text-xs text-muted-foreground">
                   <div className="flex items-center space-x-2">
-                    <span>↵ Launch</span>
-                    <span>⌘K Close</span>
+                    <span>ESC Close</span>
                   </div>
                 </div>
               </>


### PR DESCRIPTION
## What problem(s) was I solving?

Users reported that the meta+enter keyboard shortcut for submitting the session launcher only worked when the prompt textarea had focus (issue #443). When users typed a title and then wanted to quickly submit with meta+enter, nothing would happen - they had to click back into the prompt field first. This created an inconsistent and frustrating user experience.

## What user-facing changes did I ship?

- **Consistent keyboard submission**: Meta+enter (⌘+Enter on Mac, Ctrl+Enter on Windows/Linux) now works from ANY input field in the session launcher - title, directory, or prompt
- **Clearer visual hints**: Added keyboard shortcut indicator directly on the Launch button so users know the shortcut is available
- **Simplified help text**: Removed redundant/misleading keyboard hints from the textarea, keeping only the "Enter for new line" hint
- **Cleaner footer**: Simplified the modal footer to only show "ESC Close" instead of conflicting hints

## How I implemented it

Following the established pattern from `DangerouslySkipPermissionsDialog`, I moved the keyboard handling from individual inputs to the modal level:

1. **Added global hotkey handler** in `SessionLauncher.tsx` with `enableOnFormTags: true` to capture meta+enter from any form input
2. **Removed input-specific handler** from `CommandInput.tsx` to eliminate conflicts and ensure single source of truth
3. **Updated visual indicators** to show the keyboard shortcut on the Launch button itself, making it discoverable
4. **Cleaned up hints** to avoid confusion about which shortcuts work where

The solution uses the existing `useHotkeys` and `useStealHotkeyScope` infrastructure, maintaining consistency with other modals in the codebase.

## How to verify it

- [x] I have ensured `make check test` passes

**Manual testing steps:**
1. Open the session launcher (⌘K)
2. Click into the title field and type something
3. Press meta+enter without clicking elsewhere
4. ✅ Session should launch immediately
5. Repeat test from directory field
6. Verify ESC still closes from any field
7. Verify Enter (without meta) adds newlines in prompt field

## Description for the changelog

- Fix session launcher meta+enter shortcut to work from all input fields, not just the prompt textarea

## A picture of a cute animal (not mandatory but encouraged)

```
   /\_/\  
  ( o.o ) 
   > ^ <
```
(ASCII cat says keyboard shortcuts should work everywhere!)