### PR TITLE
Phase 1: Restore MCP stdio server in hlyr

### DIFF
--- a/hld/session/manager_test.go
+++ b/hld/session/manager_test.go
@@ -337,11 +337,25 @@ func TestLaunchSession_SetsMCPEnvironment(t *testing.T) {
 	}
 
 	// Verify MCP servers have the correct environment variables
-	if len(capturedMCPServers) != 1 {
-		t.Fatalf("Expected 1 MCP server, got %d", len(capturedMCPServers))
+	// Should have the test server plus injected codelayer
+	if len(capturedMCPServers) != 2 {
+		t.Fatalf("Expected 2 MCP servers (test + codelayer), got %d", len(capturedMCPServers))
 	}
 
-	server := capturedMCPServers[0]
+	// Find the test server (not codelayer)
+	var server store.MCPServer
+	var found bool
+	for _, s := range capturedMCPServers {
+		if s.Name == "test-server" {
+			server = s
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatal("Test server not found in MCP servers")
+	}
 
 	// Parse the environment JSON
 	var env map[string]string

--- a/hlyr/src/daemonClient.ts
+++ b/hlyr/src/daemonClient.ts
@@ -353,11 +353,13 @@ export class DaemonClient extends EventEmitter {
     runId: string,
     toolName: string,
     toolInput: unknown,
+    toolUseId?: string,
   ): Promise<{ approval_id: string }> {
     return this.call<{ approval_id: string }>('createApproval', {
       run_id: runId,
       tool_name: toolName,
       tool_input: toolInput,
+      ...(toolUseId && { tool_use_id: toolUseId }),
     })
   }
 

--- a/hlyr/src/index.ts
+++ b/hlyr/src/index.ts
@@ -10,6 +10,7 @@ import { launchCommand } from './commands/launch.js'
 import { alertCommand } from './commands/alert.js'
 import { thoughtsCommand } from './commands/thoughts.js'
 import { joinWaitlistCommand } from './commands/joinWaitlist.js'
+import { startClaudeApprovalsMCPServer } from './mcp.js'
 import {
   getDefaultConfigPath,
   resolveFullConfig,
@@ -66,7 +67,7 @@ async function authenticate(printSelectedProject: boolean = false) {
 
 program.name('humanlayer').description('HumanLayer, but on your command-line.').version(VERSION)
 
-const UNPROTECTED_COMMANDS = ['config', 'login', 'thoughts', 'join-waitlist', 'launch']
+const UNPROTECTED_COMMANDS = ['config', 'login', 'thoughts', 'join-waitlist', 'launch', 'mcp']
 
 program.hook('preAction', async (thisCmd, actionCmd) => {
   // Get the full command path by traversing up the command hierarchy
@@ -95,6 +96,13 @@ program
   .option('--app-base <url>', 'App base URL')
   .option('--config-file <path>', 'Path to config file')
   .action(loginCommand)
+
+const mcpCommand = program.command('mcp').description('MCP server functionality')
+
+mcpCommand
+  .command('claude_approvals')
+  .description('Start the Claude approvals MCP server for permission requests')
+  .action(startClaudeApprovalsMCPServer)
 
 program
   .command('launch <query>')

--- a/hlyr/src/mcp.ts
+++ b/hlyr/src/mcp.ts
@@ -1,0 +1,192 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import {
+  CallToolRequestSchema,
+  ErrorCode,
+  ListToolsRequestSchema,
+  McpError,
+} from '@modelcontextprotocol/sdk/types.js'
+import { resolveFullConfig } from './config.js'
+import { DaemonClient } from './daemonClient.js'
+import { logger } from './mcpLogger.js'
+
+/**
+ * Start the Claude approvals MCP server that provides request_permission functionality
+ * Returns responses in the format required by Claude Code SDK
+ *
+ * This uses local approvals through the daemon instead of HumanLayer API
+ */
+export async function startClaudeApprovalsMCPServer() {
+  // No auth validation needed - uses local daemon
+  logger.info('Starting Claude approvals MCP server')
+  logger.info('Environment variables', {
+    HUMANLAYER_DAEMON_SOCKET: process.env.HUMANLAYER_DAEMON_SOCKET,
+    HUMANLAYER_SESSION_ID: process.env.HUMANLAYER_SESSION_ID,
+  })
+
+  const server = new Server(
+    {
+      name: 'humanlayer-claude-local-approvals',
+      version: '1.0.0',
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    },
+  )
+
+  // Create daemon client with socket path from environment or config
+  // The daemon sets HUMANLAYER_DAEMON_SOCKET for MCP servers it launches
+  const resolvedConfig = resolveFullConfig({})
+  const socketPath = process.env.HUMANLAYER_DAEMON_SOCKET || resolvedConfig.daemon_socket
+  logger.info('Creating daemon client', { socketPath })
+  const daemonClient = new DaemonClient(socketPath)
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    logger.info('ListTools request received')
+    const tools = [
+      {
+        name: 'request_permission',
+        description: 'Request permission to perform an action',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            tool_name: { type: 'string' },
+            input: { type: 'object' },
+            tool_use_id: { type: 'string' }, // Added for Phase 2
+          },
+          required: ['tool_name', 'input', 'tool_use_id'],
+        },
+      },
+    ]
+    logger.info('Returning tools', { tools })
+    return { tools }
+  })
+
+  server.setRequestHandler(CallToolRequestSchema, async request => {
+    logger.debug('Received tool call request', { name: request.params.name })
+
+    if (request.params.name === 'request_permission') {
+      const toolName: string | undefined = request.params.arguments?.tool_name
+      const toolUseId: string | undefined = request.params.arguments?.tool_use_id // Phase 2
+
+      if (!toolName) {
+        logger.error('Invalid tool name in request_permission', request.params.arguments)
+        throw new McpError(ErrorCode.InvalidRequest, 'Invalid tool name requesting permissions')
+      }
+
+      const input: Record<string, unknown> = request.params.arguments?.input || {}
+
+      // Get session ID from environment (set by daemon)
+      const sessionId = process.env.HUMANLAYER_SESSION_ID
+      if (!sessionId) {
+        logger.error('HUMANLAYER_SESSION_ID not set in environment')
+        throw new McpError(ErrorCode.InternalError, 'HUMANLAYER_SESSION_ID not set')
+      }
+
+      logger.info('Processing approval request', { sessionId, toolName, toolUseId })
+
+      try {
+        // Connect to daemon
+        logger.debug('Connecting to daemon...')
+        await daemonClient.connect()
+        logger.debug('Connected to daemon')
+
+        // Create approval request with tool use ID (Phase 2)
+        logger.debug('Creating approval request...', { sessionId, toolName, toolUseId })
+        const createResponse = await daemonClient.createApproval(sessionId, toolName, input, toolUseId)
+        const approvalId = createResponse.approval_id
+        logger.info('Created approval', { approvalId })
+
+        // Poll for approval status
+        let approved = false
+        let comment = ''
+        let polling = true
+
+        while (polling) {
+          try {
+            // Get the specific approval by ID
+            logger.debug('Fetching approval status...', { approvalId })
+            const approval = (await daemonClient.getApproval(approvalId)) as {
+              id: string
+              status: string
+              comment?: string
+            }
+
+            logger.debug('Approval status', { status: approval.status })
+
+            if (approval.status !== 'pending') {
+              // Approval has been resolved
+              approved = approval.status === 'approved'
+              comment = approval.comment || ''
+              polling = false
+              logger.info('Approval resolved', {
+                approvalId,
+                status: approval.status,
+                approved,
+              })
+            } else {
+              // Still pending, wait and poll again
+              logger.debug('Approval still pending, polling again...')
+              await new Promise(resolve => setTimeout(resolve, 1000))
+            }
+          } catch (error) {
+            logger.error('Failed to get approval status', { error, approvalId })
+            // Re-throw the error since this is a critical failure
+            throw new McpError(ErrorCode.InternalError, 'Failed to get approval status')
+          }
+        }
+
+        if (!approved) {
+          logger.info('Approval denied', { approvalId, comment })
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  behavior: 'deny',
+                  message: comment || 'Request denied by human reviewer',
+                }),
+              },
+            ],
+          }
+        }
+
+        logger.info('Approval granted', { approvalId })
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                behavior: 'allow',
+                updatedInput: input,
+              }),
+            },
+          ],
+        }
+      } catch (error) {
+        logger.error('Failed to process approval', error)
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Failed to process approval: ${error instanceof Error ? error.message : String(error)}`,
+        )
+      } finally {
+        logger.debug('Closing daemon connection')
+        daemonClient.close()
+      }
+    }
+
+    throw new McpError(ErrorCode.InvalidRequest, 'Invalid tool name')
+  })
+
+  const transport = new StdioServerTransport()
+
+  try {
+    await server.connect(transport)
+    logger.info('MCP server connected and ready')
+  } catch (error) {
+    logger.error('Failed to start MCP server', error)
+    throw error
+  }
+}

--- a/humanlayer-wui/src/hooks/useSessionLauncher.ts
+++ b/humanlayer-wui/src/hooks/useSessionLauncher.ts
@@ -1,7 +1,6 @@
 import { create } from 'zustand'
 import { daemonClient } from '@/lib/daemon'
 import type { LaunchSessionRequest } from '@/lib/daemon/types'
-import { getDaemonUrl } from '@/lib/daemon/http-config'
 import { useHotkeysContext } from 'react-hotkeys-hook'
 import { SessionTableHotkeysScope } from '@/components/internal/SessionTable'
 import { exists } from '@tauri-apps/plugin-fs'
@@ -141,17 +140,7 @@ export const useSessionLauncher = create<LauncherState>((set, get) => ({
     try {
       set({ isLaunching: true, error: undefined })
 
-      // Build MCP config (approvals enabled by default)
-      // Use HTTP-based MCP server built into the daemon
-      const daemonUrl = await getDaemonUrl()
-      const mcpConfig = {
-        mcpServers: {
-          approvals: {
-            type: 'http',
-            url: `${daemonUrl}/api/v1/mcp`,
-          },
-        },
-      }
+      // MCP config is now injected by daemon
 
       const request: LaunchSessionRequest = {
         query: query.trim(),
@@ -159,8 +148,8 @@ export const useSessionLauncher = create<LauncherState>((set, get) => ({
         working_dir: config.workingDir || undefined,
         model: config.model || undefined,
         max_turns: config.maxTurns || undefined,
-        mcp_config: mcpConfig,
-        permission_prompt_tool: 'mcp__approvals__request_approval',
+        // MCP config is now injected by daemon
+        permission_prompt_tool: 'mcp__codelayer__request_permission',
       }
 
       const response = await daemonClient.launchSession(request)


### PR DESCRIPTION
## What problem(s) was I solving?

The MCP (Model Context Protocol) tool calls were experiencing timeouts and fetch failures (ENG-1958). The HTTP-based MCP server approach was causing reliability issues with Claude Code sessions. This PR implements Phase 1 of the fix by restoring the stdio-based MCP server in hlyr, which provides more stable bidirectional communication for approval requests.

## What user-facing changes did I ship?

- No breaking changes - existing Claude Code sessions continue to work
- Improved reliability for approval requests in Claude Code sessions
- MCP server configuration is now automatically injected by the daemon (users no longer need to manually configure it)
- The `hlyr mcp claude_approvals` command is now available for stdio-based MCP server functionality

## How I implemented it

### 1. Created stdio-based MCP server in hlyr (`hlyr/src/mcp.ts`)
- Implemented `startClaudeApprovalsMCPServer()` function that uses the official MCP SDK's stdio transport
- Provides a `request_permission` tool that Claude Code can call for approval workflows
- Connects to the daemon via socket (path from `HUMANLAYER_DAEMON_SOCKET` environment variable)
- Polls daemon for approval status with 1-second intervals until resolution
- Returns responses in Claude Code's expected format: `{behavior: "allow"|"deny", ...}`

### 2. Added tool_use_id correlation support (`hld/rpc/approval_handlers.go`)
- Extended `CreateApprovalRequest` to include optional `tool_use_id` field
- Added `CreateApprovalWithToolUseID()` method for better request tracking
- Maintains backward compatibility with existing approval creation logic

### 3. Automatic MCP server injection (`hld/session/manager.go`)
- Daemon now automatically injects the `codelayer` MCP server configuration into all Claude sessions
- Sets command as `hlyr mcp claude_approvals` with stdio transport
- Passes session ID and daemon socket path via environment variables
- Removed need for manual MCP configuration in launch commands

### 4. Updated launch commands (`hlyr/src/commands/launch.ts`, `humanlayer-wui/src/hooks/useSessionLauncher.ts`)
- Removed hardcoded HTTP MCP server configuration
- Changed permission tool name from `mcp__approvals__request_approval` to `mcp__codelayer__request_permission`
- Simplified launch logic as MCP config is now handled by daemon

### 5. Updated tests (`hld/session/continue_inheritance_test.go`, `hld/session/manager_test.go`)
- Updated test expectations to account for automatically injected `codelayer` MCP server
- Tests now verify that the codelayer server is properly configured with session ID and socket path
- Ensured parent session MCP servers are still inherited correctly alongside the injected server

## How to verify it

- [x] I have ensured `make check test` passes

## Description for the changelog

Restored stdio-based MCP server in hlyr to fix timeout issues with Claude Code approval requests. The daemon now automatically injects MCP configuration, eliminating manual setup and improving reliability.