### PR TITLE
main

### DIFF
--- a/humanlayer-wui/src/components/Layout.tsx
+++ b/humanlayer-wui/src/components/Layout.tsx
@@ -24,7 +24,7 @@ import { notificationService, type NotificationOptions } from '@/services/Notifi
 import { useTheme } from '@/contexts/ThemeContext'
 import { formatMcpToolName, getSessionNotificationText } from '@/utils/formatting'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { MessageCircle, Bug } from 'lucide-react'
+import { MessageCircle, Bug, HelpCircle } from 'lucide-react'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { DebugPanel } from '@/components/DebugPanel'
 import { notifyLogLocation } from '@/lib/log-notification'
@@ -456,7 +456,7 @@ export function Layout() {
                 href="https://github.com/humanlayer/humanlayer/issues/new?title=Feedback%20on%20CodeLayer&body=%23%23%23%20Problem%20to%20solve%20%2F%20Expected%20Behavior%0A%0A%0A%23%23%23%20Proposed%20solution"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center justify-center px-1.5 py-0.5 text-sm font-mono border border-border bg-background text-foreground hover:bg-accent/10 transition-colors"
+                className="inline-flex items-center justify-center px-1.5 py-0.5 text-xs font-mono border border-border bg-background text-foreground hover:bg-accent/10 transition-colors"
               >
                 <MessageCircle className="w-3 h-3" />
               </a>
@@ -467,12 +467,27 @@ export function Layout() {
               </p>
             </TooltipContent>
           </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => setHotkeyPanelOpen(true)}
+                className="inline-flex items-center justify-center px-1.5 py-0.5 text-xs font-mono border border-border bg-background text-foreground hover:bg-accent/10 transition-colors"
+              >
+                <HelpCircle className="w-3 h-3" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p className="flex items-center gap-1">
+                View all keyboard shortcuts <KeyboardShortcut keyString="?" />
+              </p>
+            </TooltipContent>
+          </Tooltip>
           {import.meta.env.DEV && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
                   onClick={() => setIsDebugPanelOpen(true)}
-                  className="px-1.5 py-0.5 text-xs font-mono border border-border bg-background text-foreground hover:bg-accent/10 transition-colors"
+                  className="inline-flex items-center justify-center px-1.5 py-0.5 text-xs font-mono border border-border bg-background text-foreground hover:bg-accent/10 transition-colors"
                 >
                   <Bug className="w-3 h-3" />
                 </button>


### PR DESCRIPTION
# Add Keyboard Shortcuts Indicator to Status Bar

## Summary
Adds a help icon button to the CodeLayer status bar that improves discoverability of the keyboard shortcuts panel. The button provides both visual indication and clickable access to the existing '?' hotkey functionality.

Fixes #449

## Problem Solved
Users were unaware that pressing '?' opens the keyboard shortcuts panel in CodeLayer. While the functionality existed and worked well (62 documented shortcuts available), there was no visual indicator in the UI to inform users about this feature, leading to poor discoverability.

## Solution Implemented
- Added a `HelpCircle` icon button to the status bar between the feedback button and theme selector
- Standardized button styling across all status bar elements for visual consistency
- Implemented tooltip that shows "View all keyboard shortcuts" with the '?' key indicator
- Button triggers the same `setHotkeyPanelOpen(true)` action as the '?' keyboard shortcut

### Technical Details
- Modified `humanlayer-wui/src/components/Layout.tsx`
- Imported `HelpCircle` icon from `lucide-react` library
- Ensured all status bar buttons use consistent styling:
  - `inline-flex items-center justify-center` for proper centering
  - `text-xs` font size (previously feedback button used `text-sm`)
  - `w-3 h-3` icon dimensions
  - Identical padding, borders, and hover effects

## Testing

### Automated Testing
- [x] TypeScript compilation passes: `make -C humanlayer-wui check`
- [x] Linting passes: `make -C humanlayer-wui lint`  
- [x] Build succeeds: `make -C humanlayer-wui build`
- [x] All repository tests pass: `make check test`

### Manual Testing Checklist
- [ ] Shortcuts button appears in status bar between feedback and theme buttons
- [ ] Clicking button opens HotkeyPanel  
- [ ] Tooltip appears on hover showing "View all keyboard shortcuts ?"
- [ ] `?` key still opens/closes HotkeyPanel
- [ ] Button styling matches other status bar buttons
- [ ] No layout shifts on different screen sizes
- [ ] Button looks correct in all 13 themes
- [ ] Button maintains proper spacing (gap-3) from adjacent elements

## User Impact
- **Improved Discoverability**: Users can now easily discover the keyboard shortcuts feature through the visible help icon
- **Dual Access**: Feature remains accessible via both keyboard (`?`) and mouse click
- **Consistent UI**: Button follows existing design patterns and terminal-inspired aesthetic

## Breaking Changes
None - this is a purely additive change with no breaking modifications to existing functionality.

## Changelog Entry
```
### Added
- Keyboard shortcuts indicator button in status bar for improved discoverability of the '?' hotkey panel
```

## Notes for Reviewers
- The implementation follows the research and planning documented in `thoughts/shared/research/2025-08-19_issue-449-codelayer-shortcuts-indicator.md`
- Button size was specifically adjusted to match other status bar icons after initial feedback
- Uses existing `HotkeyPanel` and `KeyboardShortcut` components without modification