### PR TITLE
Adjust spacing behavior of lists in stream

### DIFF
--- a/humanlayer-wui/src/components/DebugPanel.tsx
+++ b/humanlayer-wui/src/components/DebugPanel.tsx
@@ -118,7 +118,7 @@ export function DebugPanel({ open, onOpenChange }: DebugPanelProps) {
   async function handleConnectToCustom() {
     setConnectError(null)
 
-    let url = customUrl
+    let url = customUrl.trim()
 
     if (!isNaN(Number(url))) {
       url = `http://127.0.0.1:${url}`

--- a/humanlayer-wui/src/components/DebugPanel.tsx
+++ b/humanlayer-wui/src/components/DebugPanel.tsx
@@ -118,8 +118,14 @@ export function DebugPanel({ open, onOpenChange }: DebugPanelProps) {
   async function handleConnectToCustom() {
     setConnectError(null)
 
+    let url = customUrl
+
+    if (!isNaN(Number(url))) {
+      url = `http://127.0.0.1:${url}`
+    }
+
     try {
-      await daemonService.connectToExisting(customUrl)
+      await daemonService.connectToExisting(url)
       await reconnect()
       await loadDaemonInfo()
       setCustomUrl('')
@@ -221,7 +227,7 @@ export function DebugPanel({ open, onOpenChange }: DebugPanelProps) {
             <CardHeader>
               <CardTitle className="text-sm">Connect to Existing Daemon</CardTitle>
               <CardDescription className="text-xs">
-                Connect to a daemon running on a custom URL
+                Connect to a daemon running on a custom URL (or provide a port number).
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-2">

--- a/humanlayer-wui/src/components/Layout.tsx
+++ b/humanlayer-wui/src/components/Layout.tsx
@@ -296,6 +296,20 @@ export function Layout() {
     }
   })
 
+  // Prevent escape key from exiting full screen
+  // Might be worth guarding this specifically in macOS
+  // down-the-road
+  useHotkeys(
+    'escape',
+    () => {
+      // console.log('escape!', ev);
+    },
+    {
+      enableOnFormTags: true,
+      preventDefault: true,
+    },
+  )
+
   // Load sessions when connected
   useEffect(() => {
     if (connected) {

--- a/humanlayer-wui/src/styles/markdown-terminal.css
+++ b/humanlayer-wui/src/styles/markdown-terminal.css
@@ -102,6 +102,21 @@
 /* Custom bullets for unordered lists */
 .prose-terminal ul {
   list-style: none;
+
+  /* This is slightly a hack, we're making heavy use of `pre-wrap`
+  and we can potentially remove this in the future. For now it helps
+  make sure we're not rendering extra space around list items */
+  white-space: normal;
+
+  display: flex;
+  flex-direction: column;
+  gap: 0.75em;
+}
+
+.prose-terminal ul > li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75em;
 }
 
 .prose-terminal ul > li::before {


### PR DESCRIPTION
## What problem(s) was I solving?

Three separate UI issues in the HumanLayer Web UI:
1. Nested markdown lists had inconsistent and excessive vertical spacing, making them difficult to read in the terminal-style UI
2. Users had to type full URLs when connecting to a daemon on localhost, even when just specifying a port would suffice  
3. The escape key would inadvertently exit full-screen mode, disrupting the user experience

## What user-facing changes did I ship?

- **Improved markdown list rendering**: Nested lists now have consistent, compact spacing that looks clean in the terminal-style UI
- **Simplified daemon connection**: Users can now just type a port number (e.g., "8080") instead of the full URL when connecting to a local daemon
- **Escape key behavior**: Pressing escape no longer exits full-screen mode, preventing accidental exits during normal usage

## How I implemented it

1. **Markdown list spacing fix** (`markdown-terminal.css`):
   - Changed unordered lists to use flexbox layout with consistent gaps
   - Set `white-space: normal` to prevent extra spacing from `pre-wrap` inheritance
   - Applied `display: flex` with `flex-direction: column` and `gap: 0.75em` for uniform spacing

2. **Port number shorthand** (`DebugPanel.tsx`):
   - Added logic to detect if the input is a number
   - Automatically converts plain port numbers to `http://127.0.0.1:{port}` format
   - Updated the UI description to inform users they can provide just a port number

3. **Escape key prevention** (`Layout.tsx`):
   - Added a hotkey handler for the escape key with `preventDefault: true`
   - Enabled on form tags to ensure it works even when inputs are focused
   - Included a comment noting this might need to be macOS-specific in the future

## How to verify it

- [x] I have ensured `make check test` passes

Manual testing steps:
- [ ] Open the WUI and view a session with nested markdown lists - verify spacing looks correct and consistent
- [ ] Open Debug Panel and try connecting to a daemon using just a port number (e.g., "8080") - verify it connects successfully
- [ ] Enter full-screen mode in the WUI and press escape - verify it does not exit full-screen

## Description for the changelog

Fixed markdown list vertical spacing issues, added port number shorthand for daemon connections, and prevented escape key from exiting full-screen mode in the WUI
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves URL handling in `DebugPanel` and adjusts CSS for nested markdown lists.
> 
>   - **Behavior**:
>     - `DebugPanel.tsx`: Adjusts `handleConnectToCustom()` to prepend `http://127.0.0.1:` to numeric `customUrl` values, allowing port numbers as input.
>     - `Layout.tsx`: Adds a hotkey to prevent the escape key from exiting full screen.
>   - **Styles**:
>     - `markdown-terminal.css`: Updates `.prose-terminal ul` and `.prose-terminal ul > li` to use `flex` layout with `gap: 0.75em` for better spacing in nested lists.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 0e4c70dfa6120bc6910a2a28e05ad38fcd4fcb7a. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->