### PR TITLE
sam/ENG-1959: fix - context counting for subagent events

### DIFF
--- a/hld/session/manager.go
+++ b/hld/session/manager.go
@@ -668,50 +668,60 @@ func (m *Manager) processStreamEvent(ctx context.Context, sessionID string, clau
 
 	// Process token updates from assistant messages even without claudeSessionID
 	if event.Type == "assistant" && event.Message != nil && event.Message.Role == "assistant" && event.Message.Usage != nil {
-		usage := event.Message.Usage
-		// Compute effective context tokens (what's actually in the context window)
-		// This includes ALL tokens that count toward the context limit
-		effective := usage.InputTokens + usage.OutputTokens + usage.CacheReadInputTokens + usage.CacheCreationInputTokens
-
-		now := time.Now()
-		update := store.SessionUpdate{
-			InputTokens:              &usage.InputTokens,
-			OutputTokens:             &usage.OutputTokens,
-			CacheCreationInputTokens: &usage.CacheCreationInputTokens,
-			CacheReadInputTokens:     &usage.CacheReadInputTokens,
-			EffectiveContextTokens:   &effective,
-			LastActivityAt:           &now,
-		}
-
-		if err := m.store.UpdateSession(ctx, sessionID, update); err != nil {
-			slog.Error("failed to update token usage",
+		// QUICK FIX: Skip token updates for subagent events
+		// Subagents have parent_tool_use_id set at the event level
+		if event.ParentToolUseID != "" {
+			slog.Debug("skipping token update for subagent event",
 				"session_id", sessionID,
-				"error", err)
+				"parent_tool_use_id", event.ParentToolUseID)
+			// Continue processing the rest of the event, just skip token updates
 		} else {
-			// Publish event to notify UI about token update
-			// The UI needs "new_status" field even though we're not changing status
-			if m.eventBus != nil {
-				// Get current session to include current status
-				session, _ := m.store.GetSession(ctx, sessionID)
-				currentStatus := "running"
-				if session != nil && session.Status != "" {
-					currentStatus = session.Status
-				}
+			// Original token update logic for root-level events
+			usage := event.Message.Usage
+			// Compute effective context tokens (what's actually in the context window)
+			// This includes ALL tokens that count toward the context limit
+			effective := usage.InputTokens + usage.OutputTokens + usage.CacheReadInputTokens + usage.CacheCreationInputTokens
 
-				slog.Debug("Publishing token update event",
+			now := time.Now()
+			update := store.SessionUpdate{
+				InputTokens:              &usage.InputTokens,
+				OutputTokens:             &usage.OutputTokens,
+				CacheCreationInputTokens: &usage.CacheCreationInputTokens,
+				CacheReadInputTokens:     &usage.CacheReadInputTokens,
+				EffectiveContextTokens:   &effective,
+				LastActivityAt:           &now,
+			}
+
+			if err := m.store.UpdateSession(ctx, sessionID, update); err != nil {
+				slog.Error("failed to update token usage",
 					"session_id", sessionID,
-					"status", currentStatus,
-					"effective_tokens", effective)
+					"error", err)
+			} else {
+				// Publish event to notify UI about token update
+				// The UI needs "new_status" field even though we're not changing status
+				if m.eventBus != nil {
+					// Get current session to include current status
+					session, _ := m.store.GetSession(ctx, sessionID)
+					currentStatus := "running"
+					if session != nil && session.Status != "" {
+						currentStatus = session.Status
+					}
 
-				m.eventBus.Publish(bus.Event{
-					Type: bus.EventSessionStatusChanged,
-					Data: map[string]interface{}{
-						"session_id": sessionID,
-						"new_status": currentStatus, // Required by UI handler
-						"old_status": currentStatus, // Status isn't changing, just tokens
-						"reason":     "token_update",
-					},
-				})
+					slog.Debug("Publishing token update event",
+						"session_id", sessionID,
+						"status", currentStatus,
+						"effective_tokens", effective)
+
+					m.eventBus.Publish(bus.Event{
+						Type: bus.EventSessionStatusChanged,
+						Data: map[string]interface{}{
+							"session_id": sessionID,
+							"new_status": currentStatus, // Required by UI handler
+							"old_status": currentStatus, // Status isn't changing, just tokens
+							"reason":     "token_update",
+						},
+					})
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## What problem(s) was I solving?

When multiple subagents (Task tool instances) run in parallel, the context/token numbers displayed in the SessionDetail UI jump around erratically. This occurs because each subagent reports its own token usage via streaming events, and these were incorrectly updating the parent session's token counts in the database. Users would see the token count rapidly fluctuating between different values as each subagent's counts overwrote the parent's.

This made it impossible to track actual token usage during sessions with parallel subagents, causing confusion and making it difficult to monitor context window consumption.

## What user-facing changes did I ship?

- Token counts now remain stable and accurate when subagents are running
- The displayed context numbers reflect only the parent session's actual token usage
- No more jumping/flickering token values in the UI during parallel Task execution

## How I implemented it

Added a conditional check in `hld/session/manager.go` to filter out token updates from subagent events. The fix:

1. Checks if an event has `ParentToolUseID` set (indicating it's from a subagent)
2. If it's a subagent event, skips the token database update and event broadcast
3. Logs a debug message and continues processing other aspects of the event normally
4. Root-level events (without `ParentToolUseID`) continue to update tokens as before

This is a minimal, surgical fix that addresses the root cause without requiring any database schema changes or frontend modifications.

## How to verify it

- [x] I have ensured `make check test` passes

### Manual verification steps:
1. Start a Claude Code session
2. Run a command that spawns multiple parallel Task subagents (e.g., multiple concurrent searches)
3. Watch the token display in the SessionDetail UI
4. Verify that:
   - Token counts remain stable (no jumping)
   - Token updates still work for regular tool usage
   - Daemon logs show "skipping token update for subagent event" messages

## Description for the changelog

Fixed context token counting to ignore subagent events, preventing token display from jumping when parallel Task tools are running