### PR TITLE
sam/ENG-1956: fix: tool icon inconsistency between modal and message stream

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/eventToDisplayObject.tsx
@@ -73,7 +73,7 @@ export function eventToDisplayObject(
 
   // Tool Calls
   if (event.eventType === ConversationEventType.ToolCall) {
-    iconComponent = <Wrench className={iconClasses} />
+    iconComponent = getToolIcon(event.toolName, iconClasses)
 
     // Claude Code converts "LS" to "List"
     if (event.toolName === 'LS') {
@@ -187,7 +187,6 @@ export function eventToDisplayObject(
     }
 
     if (event.toolName === 'Write') {
-      iconComponent = <FilePenLine className={iconClasses} />
       const toolInput = JSON.parse(event.toolInputJson!)
       subject = (
         <span>
@@ -226,7 +225,6 @@ export function eventToDisplayObject(
     }
 
     if (event.toolName === 'WebSearch') {
-      iconComponent = <Globe className={iconClasses} />
       const toolInput = JSON.parse(event.toolInputJson!)
       subject = (
         <span>
@@ -637,36 +635,36 @@ export function eventToDisplayObject(
 }
 
 // Export icon mapping function for reuse in modal
-export function getToolIcon(toolName: string | undefined): React.ReactNode {
-  if (!toolName) return <Wrench className="w-3.5 h-3.5" />
+export function getToolIcon(toolName: string | undefined, className = 'w-3.5 h-3.5'): React.ReactNode {
+  if (!toolName) return <Wrench className={className} />
 
   // Handle MCP tools
   if (toolName.startsWith('mcp__')) {
-    return <Globe className="w-3.5 h-3.5" />
+    return <Globe className={className} />
   }
 
   // Handle regular tools
   switch (toolName) {
     case 'Edit':
     case 'MultiEdit':
-      return <FilePenLine className="w-3.5 h-3.5" />
+      return <FilePenLine className={className} />
     case 'Read':
-      return <FileText className="w-3.5 h-3.5" />
+      return <FileText className={className} />
     case 'Write':
-      return <FilePenLine className="w-3.5 h-3.5" />
+      return <FilePenLine className={className} />
     case 'Bash':
-      return <Terminal className="w-3.5 h-3.5" />
+      return <Terminal className={className} />
     case 'Grep':
-      return <Search className="w-3.5 h-3.5" />
+      return <Search className={className} />
     case 'TodoWrite':
-      return <ListTodo className="w-3.5 h-3.5" />
+      return <ListTodo className={className} />
     case 'WebSearch':
-      return <Globe className="w-3.5 h-3.5" />
+      return <Globe className={className} />
     case 'NotebookRead':
     case 'NotebookEdit':
-      return <FileText className="w-3.5 h-3.5" />
+      return <FileText className={className} />
     default:
-      return <Wrench className="w-3.5 h-3.5" />
+      return <Wrench className={className} />
   }
 }
 


### PR DESCRIPTION
## What problem(s) was I solving?

Tool icons were displaying inconsistently across the WUI interface. The Bash tool showed a terminal icon (>_) in the tool result modal but displayed a generic wrench icon in the message stream. This visual inconsistency confused users about which tool was being executed when reviewing session history.

The root cause was duplicate icon selection logic - the modal used a centralized `getToolIcon()` function while the message stream had inline conditionals that only handled specific tools (Write and WebSearch), defaulting all others to the wrench icon.

## What user-facing changes did I ship?

- Bash tool now consistently displays the terminal icon in both the modal and message stream views
- All tools now show their correct, specific icons throughout the interface:
  - Bash: Terminal icon
  - Edit/MultiEdit/Write: FilePenLine icon  
  - Read/NotebookRead/NotebookEdit: FileText icon
  - Grep: Search icon
  - TodoWrite: ListTodo icon
  - WebSearch: Globe icon
  - MCP tools: Globe icon
  - Unknown tools: Wrench icon (as fallback)

## How I implemented it

The fix involved refactoring the icon display system to use a single source of truth:

1. **Enhanced the `getToolIcon()` function** to accept an optional `className` parameter, allowing flexible styling while maintaining the default size
2. **Replaced inline icon logic** in `eventToDisplayObject()` with a call to the centralized `getToolIcon()` function
3. **Removed redundant icon overrides** for Write and WebSearch tools that were causing inconsistency
4. **Preserved all existing functionality** including dynamic styling (pulse animations for incomplete tools) and special subject formatting

The change ensures that adding new tools in the future will automatically get consistent icon display without requiring updates in multiple places.

## How to verify it

- [x] I have ensured `make check test` passes

### Manual testing steps:
1. Start the WUI development server: `make -C humanlayer-wui dev`
2. Open a session that uses various tools (especially Bash)
3. Verify the Bash tool shows terminal icon in the message stream
4. Click on any tool result to open the modal
5. Confirm the same icon appears in both views
6. Check that loading animations still work for incomplete tools

## Description for the changelog

Fix tool icon inconsistency in WUI - tools now display correct icons in both modal and message stream views