### PR TITLE
Fix focus preservation when closing modals with keyboard

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -502,13 +502,18 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
         return null
       }
 
-      // Don't process escape if fork view is open
+      // Don't process escape if modals are open
       if (forkViewOpen) {
         return
       }
 
       // Don't process escape if dangerous skip permissions dialog is open
       if (dangerousSkipPermissionsDialogOpen) {
+        return
+      }
+
+      // Don't process escape if tool result modal is open
+      if (expandedToolResult) {
         return
       }
 

--- a/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionNavigation.ts
+++ b/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionNavigation.ts
@@ -180,8 +180,7 @@ export function useSessionNavigation({
             )
           : null
 
-        // Clear focus when opening modal to prevent double escape handling
-        setFocusedEventId(null)
+        // Don't clear focus - the modal will preserve and restore it
         setExpandedToolResult(toolResult || null)
         setExpandedToolCall(focusedEvent)
       }

--- a/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/views/ConversationContent.tsx
@@ -255,8 +255,7 @@ export function ConversationContent({
                         )
                       : null
                     if (setExpandedToolResult && setExpandedToolCall) {
-                      // Clear focus when opening modal to prevent double escape handling
-                      setFocusedEventId(null)
+                      // Don't clear focus - the modal will preserve and restore it
                       setExpandedToolResult(toolResult || null)
                       setExpandedToolCall(event)
                     }


### PR DESCRIPTION
## What problem(s) was I solving?

When using keyboard navigation to close tool modals in the HumanLayer WUI, the previously focused row in the conversation view would lose focus. This created a jarring user experience where:

1. Pressing 'i' to open a tool result modal would work correctly
2. But pressing 'i' again (or escape) to close the modal would clear the row focus
3. Users would have to re-navigate to their previous position using keyboard navigation
4. Different behaviors occurred when opening modals via click vs keyboard

The root cause was that the code was explicitly clearing focus when opening modals (in two different places), preventing the focus preservation logic from capturing the element to restore.

## What user-facing changes did I ship?

- **Consistent focus preservation**: Row focus is now preserved when closing modals, regardless of how they were opened (click or keyboard) or closed (escape, 'i', or click-outside)
- **Click-outside dismissal enabled**: Users can now click outside modals to close them, matching common UX patterns
- **Improved keyboard navigation**: The flow of navigating with j/k, pressing 'i' to inspect, and pressing 'i' again to close now maintains context

## How I implemented it

The fix required changes across 5 files to create a unified focus preservation system:

### 1. **Added focus preservation logic to modals** (`ToolResultModal.tsx`, `ForkViewModal.tsx`)
   - Store `document.activeElement` when modal opens
   - Create unified `handleClose()` handler that restores focus after closing
   - Use `setTimeout(..., 0)` to avoid race conditions with React's render cycle

### 2. **Consolidated keyboard handlers** 
   - Combined escape and 'i' key handlers using `useHotkeys('escape, i', ...)` for consistent behavior
   - Added `stopImmediatePropagation()` to prevent event bubbling to background handlers

### 3. **Removed focus-clearing code**
   - `ConversationContent.tsx`: Removed `setFocusedEventId(null)` when clicking to open modal
   - `useSessionNavigation.ts`: Removed `setFocusedEventId(null)` when pressing 'i' to open modal
   - These were preventing the focus preservation logic from capturing the focused element

### 4. **Enabled click-outside dismissal**
   - Removed `onPointerDownOutside` and `onInteractOutside` prevention handlers
   - Dialog's `onOpenChange` now uses the unified close handler for all dismissal methods

### 5. **Added safety checks** (`SessionDetail.tsx`)
   - Added check for `expandedToolResult` in escape handler to prevent double-processing

## How to verify it

- [x] I have ensured `make check test` passes

### Manual testing scenarios:
1. **Keyboard flow**: Navigate with j/k → press 'i' on a tool → press 'i' again → verify row stays focused
2. **Click flow**: Click a tool result → press escape or 'i' → verify row stays focused  
3. **Click-outside**: Open any modal → click outside → verify modal closes and row focus preserved
4. **Mixed navigation**: Use combination of mouse and keyboard → verify consistent focus behavior

## Description for the changelog

Fix focus preservation when closing tool modals - maintains row focus when dismissing modals via keyboard (escape/'i') or click-outside, improving keyboard navigation flow in SessionDetail view
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes focus preservation when closing modals in HumanLayer WUI, ensuring consistent focus behavior across different modal interactions.
> 
>   - **Behavior**:
>     - Focus is preserved when closing modals (`ToolResultModal.tsx`, `ForkViewModal.tsx`) using `handleClose()` to restore `document.activeElement`.
>     - Click-outside dismissal enabled by removing `onPointerDownOutside` and `onInteractOutside` prevention handlers.
>     - Consolidated escape and 'i' key handlers using `useHotkeys('escape, i', ...)`.
>   - **Code Changes**:
>     - Removed `setFocusedEventId(null)` in `ConversationContent.tsx` and `useSessionNavigation.ts` to prevent focus clearing.
>     - Added safety checks in `SessionDetail.tsx` for `expandedToolResult` in escape handler.
>   - **Testing**:
>     - Manual testing scenarios include keyboard flow, click flow, click-outside, and mixed navigation to verify consistent focus behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 3ac5102d4da4748a4737b8300a8470ca5a5a48b6. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->