### PR TITLE
fix: improve session error logging in HLD manager

### DIFF
--- a/hld/session/manager.go
+++ b/hld/session/manager.go
@@ -463,8 +463,16 @@ eventLoop:
 			})
 		}
 	} else if err != nil {
+		slog.Error("claude process failed",
+			"session_id", sessionID,
+			"error", err.Error(),
+			"duration", endTime.Sub(startTime))
 		m.updateSessionStatus(ctx, sessionID, StatusFailed, err.Error())
 	} else if result != nil && result.IsError {
+		slog.Error("claude process failed with error result",
+			"session_id", sessionID,
+			"error", result.Error,
+			"duration", endTime.Sub(startTime))
 		m.updateSessionStatus(ctx, sessionID, StatusFailed, result.Error)
 	} else {
 		// No longer updating in-memory session
@@ -513,10 +521,21 @@ eventLoop:
 		}
 	}
 
-	slog.Info("session completed",
-		"session_id", sessionID,
-		"status", StatusCompleted,
-		"duration", endTime.Sub(startTime))
+	// Determine final status for logging
+	finalStatus := StatusCompleted
+	if err != nil || (result != nil && result.IsError) {
+		finalStatus = StatusFailed
+	} else if dbErr == nil && session != nil && session.Status == string(StatusInterrupting) {
+		finalStatus = StatusInterrupted
+	}
+
+	// Only log as info if completed successfully, already logged errors above
+	if finalStatus == StatusCompleted {
+		slog.Info("session completed",
+			"session_id", sessionID,
+			"status", finalStatus,
+			"duration", endTime.Sub(startTime))
+	}
 
 	// Clean up active process
 	m.mu.Lock()


### PR DESCRIPTION
## What problem(s) was I solving?

The HLD session manager was logging all session completions at the same log level (info), regardless of whether they succeeded or failed. This made it difficult to identify and debug session failures in production logs, as error cases weren't being logged with appropriate severity levels. Additionally, failed sessions weren't including important debugging context like duration and error details.

## What user-facing changes did I ship?

No direct user-facing changes. This is an internal logging improvement that will help with debugging and monitoring of Claude Code sessions. Users won't see any behavioral changes, but support teams and developers will have better visibility into session failures through improved error logging.

## How I implemented it

1. **Added explicit error logging**: When a Claude process fails (either through an error or an error result), the manager now logs these failures at the `error` level with full context including session ID, error message, and duration.

2. **Conditional completion logging**: Modified the session completion logging to only log at `info` level when the session actually completes successfully. This prevents misleading "session completed" messages for failed sessions.

3. **Introduced status determination logic**: Added logic to determine the final status (Completed, Failed, or Interrupted) before logging, ensuring the log message accurately reflects what happened.

4. **Preserved all error information**: The error logs include the same duration information that was previously only available in the completion log, making it easier to identify performance issues in failed sessions.

## How to verify it

- [x] I have ensured `make check test` passes

All checks and tests pass successfully:
- All Python, TypeScript, Go, and Rust checks pass
- All unit tests pass (309 HLD tests)
- All integration tests pass (43 HLD integration tests)
- Race detection tests pass

To manually verify the logging improvements:
1. Run the HLD daemon and trigger a failing Claude Code session
2. Check the logs to confirm error-level logging for failures
3. Run a successful session and confirm info-level logging for completions

## Description for the changelog

Improved error logging in HLD session manager to properly distinguish between successful and failed Claude Code sessions, adding error-level logs with full context for debugging failures.