### PR TITLE
fix: auto-dismiss approval notifications when approved

### DIFF
--- a/humanlayer-wui/src/components/Layout.tsx
+++ b/humanlayer-wui/src/components/Layout.tsx
@@ -34,7 +34,6 @@ import { logger } from '@/lib/logging'
 import { DangerousSkipPermissionsMonitor } from '@/components/DangerousSkipPermissionsMonitor'
 import { KeyboardShortcut } from '@/components/HotkeyPanel'
 import { DvdScreensaver } from '@/components/DvdScreensaver'
-import { clear } from '@tauri-apps/plugin-clipboard-manager'
 
 export function Layout() {
   const [approvals, setApprovals] = useState<any[]>([])

--- a/humanlayer-wui/src/components/Layout.tsx
+++ b/humanlayer-wui/src/components/Layout.tsx
@@ -34,6 +34,7 @@ import { logger } from '@/lib/logging'
 import { DangerousSkipPermissionsMonitor } from '@/components/DangerousSkipPermissionsMonitor'
 import { KeyboardShortcut } from '@/components/HotkeyPanel'
 import { DvdScreensaver } from '@/components/DvdScreensaver'
+import { clear } from '@tauri-apps/plugin-clipboard-manager'
 
 export function Layout() {
   const [approvals, setApprovals] = useState<any[]>([])
@@ -239,6 +240,7 @@ export function Layout() {
       addRecentResolvedApprovalToCache(data.approval_id)
       updateSessionStatus(data.session_id, SessionStatus.Running)
       await refreshActiveSessionConversation(data.session_id)
+      notificationService.clearNotificationByApprovalId(data.approval_id)
     },
     // CODEREVIEW: Why did this previously exist? Sundeep wants to talk about this do not merge.
     onSessionSettingsChanged: async (data: SessionSettingsChangedEventData) => {

--- a/humanlayer-wui/src/services/NotificationService.ts
+++ b/humanlayer-wui/src/services/NotificationService.ts
@@ -224,10 +224,18 @@ class NotificationService {
    * Show in-app notification using Sonner
    */
   private showInAppNotification(options: NotificationOptions) {
+    console.log('showInAppNotification', options)
+
     const toastOptions: ExternalToast = {
+      closeButton: true, // Always show close button for better UX
       description: options.body,
       duration: options.duration ?? 5000, // Default 5 seconds if undefined
-      closeButton: true, // Always show close button for better UX
+      position: 'top-right', // Position toast at top right corner
+    }
+
+    // control notification id when showing an approval (may expand later)
+    if (options.type === 'approval_required') {
+      toastOptions.id = `approval_required:${options.metadata.approvalId}`
     }
 
     // Add primary action if provided
@@ -365,6 +373,19 @@ class NotificationService {
    */
   isAppFocused(): boolean {
     return this.appFocused
+  }
+
+  /**
+   * Clear notification by approvalId
+   */
+
+  clearNotificationByApprovalId(approvalId: string) {
+    const matchingToasts = toast
+      .getToasts()
+      .filter(toast => toast.id === `approval_required:${approvalId}`)
+
+    logger.log('clearNotificationByApprovalId', matchingToasts)
+    matchingToasts.forEach(toDismiss => toast.dismiss(toDismiss.id))
   }
 }
 

--- a/humanlayer-wui/src/services/NotificationService.ts
+++ b/humanlayer-wui/src/services/NotificationService.ts
@@ -224,8 +224,6 @@ class NotificationService {
    * Show in-app notification using Sonner
    */
   private showInAppNotification(options: NotificationOptions) {
-    console.log('showInAppNotification', options)
-
     const toastOptions: ExternalToast = {
       closeButton: true, // Always show close button for better UX
       description: options.body,
@@ -235,7 +233,7 @@ class NotificationService {
 
     // control notification id when showing an approval (may expand later)
     if (options.type === 'approval_required') {
-      toastOptions.id = `approval_required:${options.metadata.approvalId}`
+      toastOptions.id = `${options.type}:${options.metadata.approvalId}`
     }
 
     // Add primary action if provided


### PR DESCRIPTION
## What problem(s) was I solving?

When users approve a request in the HumanLayer WUI, the approval notification toast remains visible on screen even after the approval has been processed. This creates confusion about whether the action was successful and clutters the UI with outdated notifications. Users have to manually dismiss notifications for actions they've already completed, which is poor UX.

## What user-facing changes did I ship?

- Approval notifications now automatically dismiss when the user approves the corresponding request
- Toast notifications are now consistently positioned in the top-right corner for better visibility
- Debug logging added to track notification lifecycle for troubleshooting

## How I implemented it

The solution involves two key changes:

1. **Unique notification IDs**: Modified `NotificationService.ts` to assign unique IDs to approval notifications using the pattern `approval_required:{approvalId}`. This allows the system to identify and target specific notifications for dismissal.

2. **Auto-dismissal on approval**: Added a call to `notificationService.clearNotificationByApprovalId()` in the `Layout.tsx` component's `onApprovalResolved` handler. When an approval is processed, the system now:
   - Finds all toast notifications matching the approval ID
   - Dismisses them programmatically using Sonner's toast API
   - Logs the dismissal for debugging purposes

The implementation also improves notification positioning by explicitly setting `position: 'top-right'` for consistency across all toast notifications.

## How to verify it

- [x] I have ensured `make check test` passes (claudecode-go test failure is unrelated to this PR)

To manually verify:
1. Start the HumanLayer WUI
2. Trigger an approval request that shows a notification
3. Approve the request through the UI
4. Observe that the notification automatically disappears
5. Check logs for "clearNotificationByApprovalId" entries confirming the dismissal

## Description for the changelog

fix: auto-dismiss approval notifications when approved in WUI - notifications now clear automatically when users complete the corresponding approval action