### PR TITLE
feat: add ErrorBoundary protection for TipTap ResponseEditor

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseEditorErrorBoundary.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseEditorErrorBoundary.tsx
@@ -11,7 +11,10 @@ interface ResponseEditorErrorBoundaryState {
   error: Error | null
 }
 
-export class ResponseEditorErrorBoundary extends Component<ResponseEditorErrorBoundaryProps, ResponseEditorErrorBoundaryState> {
+export class ResponseEditorErrorBoundary extends Component<
+  ResponseEditorErrorBoundaryProps,
+  ResponseEditorErrorBoundaryState
+> {
   constructor(props: ResponseEditorErrorBoundaryProps) {
     super(props)
     this.state = { hasError: false, error: null }
@@ -34,9 +37,7 @@ export class ResponseEditorErrorBoundary extends Component<ResponseEditorErrorBo
             <span>Editor unavailable</span>
           </div>
           {this.state.error && (
-            <div className="text-xs text-destructive">
-              {this.state.error.message}
-            </div>
+            <div className="text-xs text-destructive">{this.state.error.message}</div>
           )}
         </div>
       )

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseEditorErrorBoundary.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseEditorErrorBoundary.tsx
@@ -1,0 +1,47 @@
+import React, { Component, ReactNode } from 'react'
+import { AlertCircle } from 'lucide-react'
+import { logger } from '@/lib/logging'
+
+interface ResponseEditorErrorBoundaryProps {
+  children: ReactNode
+}
+
+interface ResponseEditorErrorBoundaryState {
+  hasError: boolean
+  error: Error | null
+}
+
+export class ResponseEditorErrorBoundary extends Component<ResponseEditorErrorBoundaryProps, ResponseEditorErrorBoundaryState> {
+  constructor(props: ResponseEditorErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    logger.error('ResponseEditor Error:', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col space-y-2 p-3 text-sm text-muted-foreground">
+          <div className="flex items-center space-x-2">
+            <AlertCircle className="w-4 h-4" />
+            <span>Editor unavailable</span>
+          </div>
+          {this.state.error && (
+            <div className="text-xs text-destructive">
+              {this.state.error.message}
+            </div>
+          )}
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseInput.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseInput.tsx
@@ -10,6 +10,7 @@ import { ResponseInputLocalStorageKey } from '@/components/internal/SessionDetai
 import { StatusBar } from './StatusBar'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { ResponseEditor } from './ResponseEditor'
+import { ResponseEditorErrorBoundary } from './ResponseEditorErrorBoundary'
 import { useStore } from '@/AppStore'
 import { logger } from '@/lib/logging'
 import { Content } from '@tiptap/react'
@@ -179,31 +180,33 @@ export const ResponseInput = forwardRef<{ focus: () => void; blur?: () => void }
 
           {/* Existing input area */}
           <div className="flex gap-2">
-            <ResponseEditor
-              ref={tiptapRef}
-              initialValue={initialValue}
-              onChange={(value: Content) => {
-                localStorage.setItem(
-                  `${ResponseInputLocalStorageKey}.${session.id}`,
-                  JSON.stringify(value),
-                )
-              }}
-              onSubmit={handleSubmit}
-              onToggleAutoAccept={onToggleAutoAccept}
-              onToggleDangerouslySkipPermissions={onToggleDangerouslySkipPermissions}
-              onToggleForkView={onToggleForkView}
-              disabled={isResponding}
-              placeholder={placeholder}
-              className={`flex-1 min-h-[2.5rem] ${isResponding ? 'opacity-50' : ''} ${textareaOutlineClass} ${
-                isDenying && isFocused ? 'caret-error' : isFocused ? 'caret-accent' : ''
-              }`}
-              onFocus={() => {
-                setIsFocused(true)
-              }}
-              onBlur={() => {
-                setIsFocused(false)
-              }}
-            />
+            <ResponseEditorErrorBoundary>
+              <ResponseEditor
+                ref={tiptapRef}
+                initialValue={initialValue}
+                onChange={(value: Content) => {
+                  localStorage.setItem(
+                    `${ResponseInputLocalStorageKey}.${session.id}`,
+                    JSON.stringify(value),
+                  )
+                }}
+                onSubmit={handleSubmit}
+                onToggleAutoAccept={onToggleAutoAccept}
+                onToggleDangerouslySkipPermissions={onToggleDangerouslySkipPermissions}
+                onToggleForkView={onToggleForkView}
+                disabled={isResponding}
+                placeholder={placeholder}
+                className={`flex-1 min-h-[2.5rem] ${isResponding ? 'opacity-50' : ''} ${textareaOutlineClass} ${
+                  isDenying && isFocused ? 'caret-error' : isFocused ? 'caret-accent' : ''
+                }`}
+                onFocus={() => {
+                  setIsFocused(true)
+                }}
+                onBlur={() => {
+                  setIsFocused(false)
+                }}
+              />
+            </ResponseEditorErrorBoundary>
           </div>
 
           {/* Keyboard shortcuts (condensed) */}

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseInput.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseInput.tsx
@@ -221,14 +221,12 @@ export const ResponseInput = forwardRef<{ focus: () => void; blur?: () => void }
               onClick={handleSubmit}
               disabled={isDisabled}
               variant={isDenying ? 'destructive' : 'default'}
-              className="h-auto py-0.5 px-2 text-xs"
+              className="h-auto py-0.5 px-2 text-xs transition-all duration-200"
             >
               {getSendButtonText()}
-              <kbd
-                className={`ml-1 px-1 py-0.5 text-xs bg-muted/50 rounded ${isDisabled ? 'invisible' : ''}`}
-              >
-                {sendKey}
-              </kbd>
+              {!isDisabled && (
+                <kbd className="ml-1 px-1 py-0.5 text-xs bg-muted/50 rounded">{sendKey}</kbd>
+              )}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## What problem(s) was I solving?

Fixed two critical UI issues with the ResponseEditor component:
1. TipTap editor crashes would break the entire session interface, requiring a page reload
2. Send button had visual dead space when disabled and lacked smooth transitions when toggling states

Related issues:
- [ENG-2044](https://linear.app/humanlayer/issue/ENG-2044): Slap error boundary on TipTap - better logging/rendering in UI

## What user-facing changes did I ship?

### Error Handling
- TipTap editor now gracefully handles errors instead of crashing the entire interface
- Shows "Editor unavailable" message with error details when the editor fails
- Users can still view sessions even if the editor encounters issues
- Error details are logged for debugging

### Send Button Improvements  
- Removed dead space when button is disabled (keyboard shortcut now completely hidden)
- Added smooth width animation (200ms transition) when button state changes
- Button smoothly expands/contracts as keyboard shortcut appears/disappears
- Cleaner, more polished interface with no wasted space

## How I implemented it

### Error Boundary Component (`ResponseEditorErrorBoundary.tsx`)
- Created React class component implementing Error Boundary pattern
- Catches errors from TipTap editor and prevents propagation
- Logs errors to console for debugging
- Displays user-friendly fallback UI with error message
- Uses AlertCircle icon to indicate editor unavailability

### ResponseInput Integration
- Wrapped ResponseEditor with ResponseEditorErrorBoundary component
- Maintains all existing functionality while adding error protection
- No changes to editor behavior when functioning normally

### Send Button Animation Fix
- Changed from `invisible` class (preserves space) to conditional rendering
- Added `transition-all duration-200` for smooth width animations
- Keyboard shortcut (`⌘+Enter` or `Ctrl+Enter`) only renders when button is enabled
- Button width smoothly animates between enabled/disabled states

## How to verify it

- [x] I have ensured `make check test` passes

### Manual Testing

1. Test Error Boundary:
   - Trigger an error in the TipTap editor (e.g., corrupt localStorage data)
   - Verify "Editor unavailable" message appears instead of white screen
   - Check that error details are logged to console
   - Confirm rest of session interface remains functional

2. Test Send Button Animation:
   - Type text in ResponseEditor to enable Send button
   - Verify keyboard shortcut smoothly appears with animation
   - Clear text to disable button
   - Confirm keyboard shortcut smoothly disappears without leaving empty space
   - Check button width transitions are smooth (200ms duration)

3. General Regression Testing:
   - Verify normal editor functionality works as before
   - Test sending messages with keyboard shortcut
   - Confirm all existing features still work

## Description for the changelog

Added error boundary protection for TipTap ResponseEditor to prevent crashes and improved Send button UX with smooth animations and proper space management when disabled.