### PR TITLE
sam/ENG-2060 - Fix title flag not being reflected in created sessions

### DIFF
--- a/hld/rpc/handlers.go
+++ b/hld/rpc/handlers.go
@@ -79,8 +79,7 @@ func (h *SessionHandlers) HandleLaunchSession(ctx context.Context, params json.R
 	// Build session config with daemon-level settings
 	config := session.LaunchSessionConfig{
 		SessionConfig: claudecode.SessionConfig{
-			Query: req.Query,
-			// Title:                req.Title, // TODO: Title field not available in claudecode.SessionConfig
+			Query:                req.Query,
 			MCPConfig:            req.MCPConfig,
 			PermissionPromptTool: req.PermissionPromptTool,
 			WorkingDir:           req.WorkingDir,
@@ -94,6 +93,7 @@ func (h *SessionHandlers) HandleLaunchSession(ctx context.Context, params json.R
 			OutputFormat:         claudecode.OutputStreamJSON, // Always use streaming JSON for monitoring
 		},
 		// Daemon-level settings (not passed to Claude Code)
+		Title:                             req.Title,
 		DangerouslySkipPermissions:        req.DangerouslySkipPermissions,
 		DangerouslySkipPermissionsTimeout: req.DangerouslySkipPermissionsTimeout,
 	}

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/StatusBar.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/StatusBar.tsx
@@ -92,7 +92,11 @@ export function StatusBar({
       <TokenUsageBadge
         effectiveContextTokens={effectiveContextTokens}
         contextLimit={contextLimit}
-        model={session.proxyEnabled && session.proxyModelOverride ? session.proxyModelOverride : model || session.model || 'DEFAULT'}
+        model={
+          session.proxyEnabled && session.proxyModelOverride
+            ? session.proxyModelOverride
+            : model || session.model || 'DEFAULT'
+        }
       />
 
       {/* Model Selector Modal */}


### PR DESCRIPTION
## What problem(s) was I solving?

Fixed the `--title` and `-t` flags in the `hlyr launch` command that were being ignored when creating new Claude Code sessions. The title parameter was being received correctly from the CLI but not being passed through to the session configuration due to a misconfiguration in the RPC handler.

Related issues:
- [ENG-2060](https://linear.app/humanlayer/issue/ENG-2060/title-flag-to-hlyr-launch-cli-not-reflected-in-created-session): --title flag to hlyr launch cli not reflected in created session

## What user-facing changes did I ship?

### Title Flag Support
- The `--title` flag now correctly sets the session title when launching Claude Code sessions
- The `-t` short flag also works as expected
- Session titles are now visible in the CodeLayer UI when sessions are created
- Both flags properly pass the title through to the created session

## How I implemented it

### RPC Handler Fix (`hld/rpc/handlers.go`)
Fixed the title assignment in the LaunchSession handler:
- Removed the incorrect TODO comment that claimed Title wasn't available in claudecode.SessionConfig
- Added `Title: req.Title` to the daemon-level settings in LaunchSessionConfig (line 97)
- The Title field was already properly defined in the LaunchSessionConfig struct and handled correctly downstream

The fix was simple - the Title field just needed to be assigned at the daemon level of the config struct rather than inside the nested SessionConfig.

## How to verify it

- [x] I have ensured `make check test` passes

### Manual Testing
1. Launch a session with the `--title` flag:
   ```bash
   hlyr launch --title "Test Title" "Write hello world"
   ```
   - Verify the title appears in CodeLayer UI
   - Check that the session shows "Test Title" in the session list

2. Launch a session with the `-t` short flag:
   ```bash
   hlyr launch -t "Short Flag Test" "Calculate 2 + 2"
   ```
   - Verify the short flag works identically to `--title`
   - Confirm the title is displayed correctly

3. Launch without a title flag:
   - Verify sessions still work normally without a title
   - Confirm no regression in default behavior

## Description for the changelog

Fixed `--title` and `-t` flags in `hlyr launch` command to properly set session titles in CodeLayer UI
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `--title` and `-t` flags in `hlyr launch` to set session titles in CodeLayer UI by updating `LaunchSessionConfig` in `handlers.go`.
> 
>   - **Behavior**:
>     - Fixes `--title` and `-t` flags in `hlyr launch` to set session titles in CodeLayer UI.
>     - Titles now visible in UI when sessions are created.
>   - **RPC Handler**:
>     - In `hld/rpc/handlers.go`, assigns `Title: req.Title` in `LaunchSessionConfig`.
>     - Removes incorrect TODO comment about `Title` field.
>   - **UI**:
>     - Minor formatting change in `StatusBar.tsx` for `TokenUsageBadge` model assignment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 718174afb203876ca871dfaa9d58c02d6adbe97b. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->