### PR TITLE
sam/ENG-2027 - Fix Write tool incorrectly reporting failures on successful operations

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/__tests__/formatToolResult.test.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/__tests__/formatToolResult.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'bun:test'
+import { render } from '@testing-library/react'
+import { formatToolResult } from '../formatToolResult'
+import { ConversationEvent } from '@/lib/daemon/types'
+
+describe('formatToolResult - Write Tool', () => {
+  it('should show success for empty content with isCompleted=true', () => {
+    const toolResult: Partial<ConversationEvent> = {
+      toolResultContent: '',
+      isCompleted: true,
+    }
+    const result = formatToolResult('Write', toolResult as ConversationEvent)
+    const { container } = render(<>{result}</>)
+    expect(container.textContent).toContain('File written')
+    expect(container.querySelector('.text-destructive')).toBeNull()
+  })
+
+  it('should show error for empty content with isCompleted=false', () => {
+    const toolResult: Partial<ConversationEvent> = {
+      toolResultContent: '',
+      isCompleted: false,
+    }
+    const result = formatToolResult('Write', toolResult as ConversationEvent)
+    const { container } = render(<>{result}</>)
+    expect(container.textContent).toContain('Write failed')
+  })
+
+  it('should show specific error for "file has not been read yet"', () => {
+    const toolResult: Partial<ConversationEvent> = {
+      toolResultContent: 'Error: File has not been read yet',
+      isCompleted: false,
+    }
+    const result = formatToolResult('Write', toolResult as ConversationEvent)
+    const { container } = render(<>{result}</>)
+    expect(container.textContent).toContain('File not read yet')
+  })
+
+  it('should detect error in content regardless of isCompleted', () => {
+    const toolResult: Partial<ConversationEvent> = {
+      toolResultContent: 'Error: Permission denied',
+      isCompleted: true, // Even if marked completed
+    }
+    const result = formatToolResult('Write', toolResult as ConversationEvent)
+    const { container } = render(<>{result}</>)
+    expect(container.textContent).toContain('Permission denied')
+  })
+
+  it('should treat non-error content as success', () => {
+    const toolResult: Partial<ConversationEvent> = {
+      toolResultContent: 'Some informational message',
+      isCompleted: true,
+    }
+    const result = formatToolResult('Write', toolResult as ConversationEvent)
+    const { container } = render(<>{result}</>)
+    expect(container.textContent).toContain('File written')
+    expect(container.querySelector('.text-destructive')).toBeNull()
+  })
+})
+
+describe('formatToolResult - Regression Tests for Other Tools', () => {
+  describe('Edit Tool', () => {
+    it('should show success for Edit with update pattern', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent:
+          "The file has been updated. Here's the result of running `cat -n` on a snippet of the edited file:",
+        isCompleted: true,
+      }
+      const result = formatToolResult('Edit', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      expect(container.textContent).toContain('File updated')
+      expect(container.querySelector('.text-destructive')).toBeNull()
+    })
+
+    it('should show error for Edit without read', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent: 'Error: File has not been read yet',
+        isCompleted: false,
+      }
+      const result = formatToolResult('Edit', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      expect(container.textContent).toContain('File not read yet')
+    })
+  })
+
+  describe('Read Tool', () => {
+    it('should show line count for Read tool', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent:
+          '     1→line one\n     2→line two\n     3→line three\n\n<system-reminder>\ntest\n</system-reminder>',
+        isCompleted: true,
+      }
+      const result = formatToolResult('Read', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      // Should count lines properly (total lines - 5 for system reminder)
+      expect(container.textContent).toContain('Read 2 lines')
+      expect(container.querySelector('.text-destructive')).toBeNull()
+    })
+
+    it('should handle empty Read content', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent: '',
+        isCompleted: true,
+      }
+      const result = formatToolResult('Read', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      expect(container.textContent).toContain('No output')
+    })
+  })
+
+  describe('Bash Tool', () => {
+    it('should show command output for Bash', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent: 'Hello World',
+        isCompleted: true,
+      }
+      const result = formatToolResult('Bash', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      expect(container.textContent).toContain('Hello World')
+      expect(container.querySelector('.text-destructive')).toBeNull()
+    })
+
+    it('should show command completed for empty Bash output', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent: '',
+        isCompleted: true,
+      }
+      const result = formatToolResult('Bash', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      expect(container.textContent).toContain('No output')
+    })
+
+    it('should show multiple lines count for Bash', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent: 'line1\nline2\nline3',
+        isCompleted: true,
+      }
+      const result = formatToolResult('Bash', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      expect(container.textContent).toContain('line1 ... (3 lines)')
+    })
+  })
+})

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/StatusBar.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/StatusBar.tsx
@@ -92,7 +92,11 @@ export function StatusBar({
       <TokenUsageBadge
         effectiveContextTokens={effectiveContextTokens}
         contextLimit={contextLimit}
-        model={session.proxyEnabled && session.proxyModelOverride ? session.proxyModelOverride : model || session.model || 'DEFAULT'}
+        model={
+          session.proxyEnabled && session.proxyModelOverride
+            ? session.proxyModelOverride
+            : model || session.model || 'DEFAULT'
+        }
       />
 
       {/* Model Selector Modal */}


### PR DESCRIPTION
## What problem(s) was I solving?

Fixed the Write tool incorrectly reporting failures when operations succeed. Database analysis of 622 Write operations showed 100% of successful writes return empty content, but the frontend was checking for "File created successfully" text that never appears, causing all successful writes to display as failures.

Related issue:
- [ENG-2027](https://linear.app/humanlayer/issue/ENG-2027/fix-write-tool-incorrectly-reporting-failures-on-successful-operations): Fix write tool incorrectly reporting failures on successful operations

## What user-facing changes did I ship?

### Write Tool Display
- Write operations now correctly show "File written" for successful operations
- Empty content with `isCompleted=true` is properly recognized as success
- Error detection improved to check for actual error text rather than absence of success pattern
- Specific error messages displayed when available (e.g., "File not read yet")
- Immediately fixes display for all 613 historical successful Write operations that were incorrectly showing as failures

## How I implemented it

### Pattern Matching Logic Update (`formatToolResult.tsx`)
- Changed from checking for "File created successfully" text (which never appears)
- Now uses `toolResult.isCompleted` field combined with content analysis:
  - Empty content with `isCompleted=true` → Success (98.6% accuracy from DB analysis)
  - Content with error indicators (error/failed/file has not been read) → Failure
- Special handling added for Write tool's empty content case to bypass early "No output" return

### Test Coverage (`__tests__/formatToolResult.test.tsx`)
- Added comprehensive test suite with 12 tests
- 5 Write tool specific tests covering:
  - Critical empty content success scenario (most common real-world case)
  - Empty content failure scenario
  - Specific error message detection
  - Error detection regardless of isCompleted flag
  - Non-error content treated as success
- 7 regression tests for Edit, Read, and Bash tools to ensure no side effects

### Minor Changes
- StatusBar.tsx: Auto-formatting changes only (prettier formatting)

## How to verify it

- [x] I have ensured `make check test` passes

### Automated Testing
- [x] TypeScript compilation passes
- [x] Linting passes
- [x] 5 Write tool specific tests covering all scenarios
- [x] 7 regression tests for other tools (Edit, Read, Bash)
- [x] All existing tests continue to pass

### Manual Testing
1. Create a new file with Write tool:
   - Should show "File written" not "Write failed"
   
2. Write without reading first:
   - Should show "File not read yet" error
   
3. Write after reading:
   - Should show "File written" as successful
   
4. Multiple write operations in sequence:
   - All should show correct status
   
5. Other tools (Edit, Read, Bash):
   - Should work unchanged (verified via regression tests)

## Description for the changelog

Fixed Write tool incorrectly displaying "Write failed" for all successful operations due to checking for non-existent success text. Now correctly uses isCompleted field to determine success, immediately fixing display for 613 historical successful writes.