### PR TITLE
Fix arrow key navigation in session launcher

### DIFF
--- a/humanlayer-wui/src/components/CommandPaletteMenu.tsx
+++ b/humanlayer-wui/src/components/CommandPaletteMenu.tsx
@@ -121,7 +121,7 @@ export default function CommandPaletteMenu() {
     () => {
       setSelectedMenuIndex(selectedMenuIndex > 0 ? selectedMenuIndex - 1 : menuOptions.length - 1)
     },
-    { enabled: true },
+    { enabled: true, enableOnFormTags: true, scopes: 'session-launcher' },
   )
 
   useHotkeys(
@@ -129,7 +129,7 @@ export default function CommandPaletteMenu() {
     () => {
       setSelectedMenuIndex(selectedMenuIndex < menuOptions.length - 1 ? selectedMenuIndex + 1 : 0)
     },
-    { enabled: true },
+    { enabled: true, enableOnFormTags: true, scopes: 'session-launcher' },
   )
 
   useHotkeys(
@@ -139,7 +139,7 @@ export default function CommandPaletteMenu() {
         menuOptions[selectedMenuIndex].action()
       }
     },
-    { enabled: true },
+    { enabled: true, enableOnFormTags: true, scopes: 'session-launcher' },
   )
 
   // Reset selection when options change


### PR DESCRIPTION
Fixes arrow key navigation in the CommandPaletteMenu component when the input field is focused.