### PR TITLE
Fix version display issue

### DIFF
--- a/hld/internal/version/version.go
+++ b/hld/internal/version/version.go
@@ -1,7 +1,5 @@
 package version
 
-import "fmt"
-
 var (
 	// Base version - can be overridden at build time
 	Version = "0.1.0"
@@ -13,7 +11,7 @@ var (
 // GetVersion returns the full version string
 func GetVersion() string {
 	if BuildVersion != "dev" && BuildVersion != "" {
-		return fmt.Sprintf("%s-%s", Version, BuildVersion)
+		return BuildVersion
 	}
 	return Version
 }


### PR DESCRIPTION
## What problem(s) was I solving?

## What user-facing changes did I ship?

## How I implemented it

## How to verify it

- [ ] I have ensured `make check test` passes

## Description for the changelog

## A picture of a cute animal (not mandatory but encouraged)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes version display by returning `BuildVersion` directly in `GetVersion()` if set.
> 
>   - **Behavior**:
>     - `GetVersion()` in `version.go` now returns `BuildVersion` directly if it's not "dev" or empty, instead of appending it to `Version`.
>   - **Misc**:
>     - Removed unused `fmt` import from `version.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for ae333f6098286b1b3efd5c4c91a9e7ace7280496. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->