### PR TITLE
[ENG-2104] Fix Shift+Enter to insert newlines in prompt input

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseEditor.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseEditor.tsx
@@ -681,6 +681,28 @@ export const ResponseEditor = forwardRef<{ focus: () => void }, ResponseEditorPr
           autocorrect: 'off',
           autocapitalize: 'off',
         },
+        handleKeyDown: (view, event) => {
+          // Only handle Shift+Enter in regular paragraphs, not in code blocks or other special nodes
+          if (event.key === 'Enter' && event.shiftKey) {
+            const { state } = view
+            const { $from } = state.selection
+            const node = $from.parent
+
+            // Only handle in paragraph nodes (not code blocks, etc.)
+            if (node.type.name === 'paragraph') {
+              event.preventDefault()
+
+              // Insert a paragraph break (same as pressing Enter)
+              const { dispatch } = view
+              const tr = state.tr.split($from.pos)
+              dispatch(tr)
+
+              return true
+            }
+          }
+
+          return false
+        },
       },
       onUpdate: ({ editor }) => onChangeRef.current?.(editor.getJSON()),
       editable: !disabled,


### PR DESCRIPTION
Added handleKeyDown to TipTap editor configuration to intercept Shift+Enter and make it behave like regular Enter key. The handler only applies to paragraph nodes, leaving code blocks and other special content unaffected.

Fixes ENG-2104

## What problem(s) was I solving?
Pressing `shift+enter` in the prompt / editor box does _nothing_. No newline, no hotkey. This is frustrating for slack, claude code, and other saas users familiar with markdown/markdownish editors that require `shift+enter` for a newline and `enter` to send/submit the message due to muscle memory.

## What user-facing changes did I ship?
Pressing `shift+enter` in the prompt box now inserts a newline as though the user had pressed `enter`.

## How I implemented it
added an event listener to the prompt box. Using TipTap's `hardBreak` was not a possible path since it uses `<br/>` which results in (a) a larger newline than a standard `enter` press creates, and (b) it breaks code blocks since it is not treated as a newline for the purposes of markdown formatting. Other markdown-rendered content like lists would also be broken by using `hardBreak`

## How to verify it
1. pull branch 
2. run `make humanlayer-dev`
3. create a new session
4. type `enter` in the prompt box a few times, and then `shift+enter` a few times. observe that the behavior is the same for both
5. create a code block with triple backticks, containing code; mix both `enter` and `shift+enter` keypresses for newlines
6. send the message
7. observe the codeblock and other output text is rendered properly

- [x] I have ensured `make check test` passes

## Description for the changelog
feature: `shift+enter` keypresses in the prompt box behave the same as regular `enter` keypresses

## A picture of a cute animal (not mandatory but encouraged)
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/b8a960d4-badc-40cd-a44c-f705a5770dd6" />
