### PR TITLE
feat(wui): implement cmd+shift+j hotkey to jump to most recent approval

### DIFF
--- a/humanlayer-wui/src/components/HotkeyPanel.tsx
+++ b/humanlayer-wui/src/components/HotkeyPanel.tsx
@@ -24,6 +24,7 @@ const hotkeyData = [
   { category: 'Global', key: 'G', description: 'Navigation prefix (G+S for sessions)' },
   { category: 'Global', key: 'Ctrl+T', description: 'Toggle theme selector' },
   { category: 'Global', key: '⌘+Enter', description: 'Submit text input' },
+  { category: 'Global', key: '⌘+⇧+J', description: 'Jump to most recent approval' },
 
   // Session List
   { category: 'Session List', key: 'J', description: 'Move down' },

--- a/humanlayer-wui/src/components/Layout.tsx
+++ b/humanlayer-wui/src/components/Layout.tsx
@@ -86,19 +86,12 @@ export function Layout() {
   useHotkeys(
     'mod+shift+j',
     async () => {
-      console.log('[HOTKEY-NAV] mod+shift+j pressed')
-
       try {
         // Get all visible toasts
         // @ts-ignore - getToasts might not be in type definitions
         const visibleToasts = toast.getToasts ? toast.getToasts() : []
         const approvalToasts = visibleToasts.filter(
           t => typeof t.id === 'string' && t.id.startsWith('approval_required:'),
-        )
-
-        console.log(
-          '[HOTKEY-NAV] Approval toasts:',
-          approvalToasts.map(t => t.id),
         )
 
         let targetApproval: { id: string; sessionId: string } | null = null
@@ -110,8 +103,6 @@ export function Layout() {
           const mostRecentToast = approvalToasts[approvalToasts.length - 1]
           const toastIdParts = (mostRecentToast.id as string).split(':')
           const approvalId = toastIdParts[1]
-
-          console.log('[HOTKEY-NAV] Using most recent toast approval:', approvalId)
 
           // Find which session this approval belongs to
           const sessions = await daemonClient.listSessions()
@@ -132,13 +123,7 @@ export function Layout() {
           }
         } else {
           // No visible toasts, fall back to fetching all approvals from daemon
-          console.log('[HOTKEY-NAV] No toasts visible, fetching from daemon')
-
           const sessions = await daemonClient.listSessions()
-          console.log(
-            '[HOTKEY-NAV] Sessions:',
-            sessions.map(s => ({ id: s.id, title: s.title })),
-          )
 
           // Collect all pending approvals from all sessions
           const pendingApprovals: Array<{
@@ -164,8 +149,6 @@ export function Layout() {
             }
           }
 
-          console.log('[HOTKEY-NAV] Pending approvals:', pendingApprovals)
-
           if (pendingApprovals.length > 0) {
             // Sort by createdAt timestamp (newest first)
             const sortedApprovals = [...pendingApprovals].sort((a, b) => {
@@ -182,8 +165,6 @@ export function Layout() {
           return
         }
 
-        console.log('[HOTKEY-NAV] Selected approval:', targetApproval)
-
         // Dismiss toast if it exists
         const toastId = `approval_required:${targetApproval.id}`
         if (visibleToasts.some(t => t.id === toastId)) {
@@ -193,7 +174,7 @@ export function Layout() {
         // Navigate to the session with approval parameter
         navigate(`/sessions/${targetApproval.sessionId}?approval=${targetApproval.id}`)
       } catch (error) {
-        console.error('[HOTKEY-NAV] Error:', error)
+        console.error('Failed to jump to approval:', error)
         toast.error('Failed to fetch approvals')
       }
     },

--- a/humanlayer-wui/src/components/internal/CodeLayerToastButtons.tsx
+++ b/humanlayer-wui/src/components/internal/CodeLayerToastButtons.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Button } from '../ui/button'
 
 interface ToastAction {
-  label: string
+  label: string | React.ReactNode
   onClick: (event?: React.MouseEvent<HTMLButtonElement>) => void
 }
 

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { useHotkeys, useHotkeysContext } from 'react-hotkeys-hook'
 import { toast } from 'sonner'
+import { useSearchParams } from 'react-router'
 
 import { ConversationEvent, Session, ApprovalStatus, SessionStatus } from '@/lib/daemon/types'
 import { Card, CardContent } from '@/components/ui/card'
@@ -401,6 +402,38 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
   // Use clipboard hook
   const focusedEvent = events.find(e => e.id === navigation.focusedEventId) || null
   useSessionClipboard(focusedEvent, !expandedToolResult && !forkViewOpen)
+
+  // Handle approval parameter from URL
+  const [searchParams, setSearchParams] = useSearchParams()
+  const targetApprovalId = searchParams.get('approval')
+  const processedApprovalRef = useRef<string | null>(null)
+
+  // Handle auto-focus when navigating with approval parameter
+  useEffect(() => {
+    // Only run when we actually have an approval ID to focus
+    if (!targetApprovalId || events.length === 0) {
+      return
+    }
+
+    // Skip if we've already processed this approval ID
+    if (processedApprovalRef.current === targetApprovalId) {
+      return
+    }
+
+    if (approvals.focusApprovalById) {
+      // Mark as processed before calling to prevent re-runs
+      processedApprovalRef.current = targetApprovalId
+
+      // Use the hook's focus method for consistency
+      // This will try to match the specific approval, or fallback to most recent pending
+      approvals.focusApprovalById(targetApprovalId)
+
+      // Clear the parameter after focusing
+      searchParams.delete('approval')
+      setSearchParams(searchParams, { replace: true })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [targetApprovalId, events.length > 0, approvals.focusApprovalById]) // Minimal deps to prevent constant re-runs
 
   // Add fork commit handler
   const handleForkCommit = useCallback(() => {

--- a/humanlayer-wui/src/services/NotificationService.tsx
+++ b/humanlayer-wui/src/services/NotificationService.tsx
@@ -21,7 +21,7 @@ export type NotificationType =
   | 'settings_changed'
 
 export interface NotificationAction {
-  label: string
+  label: string | React.ReactNode
   onClick: () => void
 }
 
@@ -50,6 +50,14 @@ class NotificationService {
   constructor() {
     logger.log('NotificationService: Constructor called')
     this.attachFocusListeners()
+  }
+
+  /**
+   * Get the platform-specific modifier key symbol
+   */
+  private getModifierKey(): string {
+    const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0
+    return isMac ? '⌘' : 'Ctrl'
   }
 
   private validateFocusState() {
@@ -440,7 +448,14 @@ class NotificationService {
       duration: Infinity, // Approval notifications should stick until dismissed
       actions: [
         {
-          label: 'Jump to Session',
+          label: (
+            <span className="flex items-center gap-1">
+              Jump to Session
+              <kbd className="ml-1 px-1.5 py-0.5 text-sm font-medium bg-background/50 rounded border border-border">
+                {this.getModifierKey()}⇧J
+              </kbd>
+            </span>
+          ),
           onClick: () => {
             window.location.hash = `/sessions/${sessionId}`
             // Dismiss the toast when user clicks to jump to session


### PR DESCRIPTION
Adds global hotkey to navigate to the most recent pending approval notification. When toasts are visible, jumps to the most recent toast. When no toasts are visible, falls back to fetching all approvals from the daemon and jumps to the newest by timestamp. Includes automatic toast dismissal and debug logging with [HOTKEY-NAV] prefix.

## What problem(s) was I solving?
"Session needs approval" toasts to not have a way to jump to the approval.

## What user-facing changes did I ship?
1. `Cmd + Shift + J` when there is a visible toast for an approval jumps to that session and auto-scrolls to the approval with focus so you can press `A` or `D` to manage it
2. `Cmd + Shift + J` will automatically jump you to the most recent pending approval in the _daemon's_ database when there are no visible approval toasts. Done since technically the daemon is the source-of-trust on approvals, but the toasts are the user-facing part so we want to prefer what the user can see to what is technically true in terms of "most recent still-visible approval message"
3. added the hotkey to jump to the approval to the button in the toast message
4. added the hotkey to jump to the approval to the hotkey tray opened by `?`

## How I implemented it
please read the ticket I almost had a stroke going in loops with opus for two hours since we were initially under-specified and I don't want to go into all of it here

## How to verify it
1. `make codelayer-dev`
2. create a session and trigger an approval e.g. `write a haiku to foo.txt`
3. exit and repeat 2+ more times
4. wait for multiple approvals to pop up (or don't) and press `Cmd+shift+J` as soon as an approval toast is visible
5. observe that you been jumped to the session and scrolled to + focused on the approval in question 

- [ ] I have ensured `make check test` passes

## Description for the changelog
feat(ui): add `Cmd + Shift + J` as hotkey to jump to pending approvals

## A picture of a cute animal (not mandatory but encouraged)
<img width="312" height="221" alt="Screenshot 2025-09-16 at 11 27 21 PM" src="https://github.com/user-attachments/assets/3b03fa27-e324-416c-8bd4-2c42550292d8" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `Cmd + Shift + J` hotkey to jump to the most recent pending approval, with fallback logic and toast management.
> 
>   - **Behavior**:
>     - Adds `Cmd + Shift + J` hotkey in `Layout.tsx` to jump to the most recent pending approval.
>     - If no visible approval toasts, fetches from daemon and navigates to the newest by timestamp.
>     - Automatically dismisses toast if it exists.
>   - **Components**:
>     - Updates `HotkeyPanel.tsx` to include new hotkey in the list.
>     - Modifies `SessionDetail.tsx` to handle URL approval parameter and auto-focus on approval.
>     - Adds `focusApprovalById` function in `useSessionApprovals.ts` for focusing specific approvals.
>   - **Notifications**:
>     - Updates `NotificationService.tsx` to include hotkey in approval notification action.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for f22bad5481aac9519a2e6e8e2721c8bed8260a76. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->