### PR TITLE
feat: enable multiple concurrent daemon/WUI instances (ENG-2114)

### DIFF
--- a/hack/port-utils.sh
+++ b/hack/port-utils.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Check if a port is available (returns 0 if available, 1 if in use)
+is_port_available() {
+    local port=$1
+    if command -v nc >/dev/null 2>&1; then
+        # Use netcat to check port (nc returns 0 if connection succeeds = port in use)
+        ! nc -z 127.0.0.1 "$port" 2>/dev/null
+    elif command -v lsof >/dev/null 2>&1; then
+        # Fallback to lsof (returns 0 if port found = in use)
+        ! lsof -i :"$port" >/dev/null 2>&1
+    else
+        # If neither tool available, assume port is available
+        return 0
+    fi
+}
+
+# Find available port using progressive prefix fallback
+find_available_port() {
+    local ticket_num=$1
+
+    # Try the ticket number directly first
+    if is_port_available "$ticket_num"; then
+        echo "$ticket_num"
+        return 0
+    fi
+
+    # Try with progressive prefixes (1-6)
+    for prefix in 1 2 3 4 5 6; do
+        local port="${prefix}${ticket_num}"
+        if is_port_available "$port"; then
+            echo "$port"
+            return 0
+        fi
+    done
+
+    # If all attempts fail, return error
+    echo "ERROR: Could not find available port for ticket $ticket_num" >&2
+    return 1
+}
+
+# Extract ticket number from ticket ID (e.g., ENG-2114 -> 2114)
+extract_ticket_number() {
+    local ticket=$1
+    echo "$ticket" | sed 's/.*-//'
+}
+
+# Find available Vite port (adds 10000 to ticket number and uses same fallback)
+find_available_vite_port() {
+    local ticket_num=$1
+    local vite_base=$((ticket_num + 10000))
+    find_available_port "$vite_base"
+}

--- a/humanlayer-wui/src-tauri/src/daemon.rs
+++ b/humanlayer-wui/src-tauri/src/daemon.rs
@@ -50,6 +50,44 @@ impl DaemonManager {
             }
         }
 
+        // Check if we should skip auto-launch
+        if env::var("HUMANLAYER_WUI_AUTOLAUNCH_DAEMON") == Ok("false".to_string()) {
+            // Don't auto-launch daemon, expect it to be managed externally
+            log::info!("[Tauri] Auto-launch disabled via HUMANLAYER_WUI_AUTOLAUNCH_DAEMON=false");
+
+            // Still need to return daemon info for external daemon
+            if let Ok(port_str) = env::var("HUMANLAYER_DAEMON_HTTP_PORT") {
+                if let Ok(port) = port_str.parse::<u16>() {
+                    let socket_path = env::var("HUMANLAYER_DAEMON_SOCKET")
+                        .unwrap_or_else(|_| format!("~/.humanlayer/daemon-{}.sock", port));
+                    let database_path = env::var("HUMANLAYER_DATABASE_PATH")
+                        .unwrap_or_else(|_| "~/.humanlayer/daemon.db".to_string());
+
+                    // Get branch from environment or git
+                    let branch_id = if let Ok(version) = env::var("HUMANLAYER_DAEMON_VERSION_OVERRIDE") {
+                        version
+                    } else {
+                        get_branch_id(is_dev, branch_override)
+                    };
+
+                    let info = DaemonInfo {
+                        port,
+                        pid: 0, // Unknown PID for pre-existing daemon
+                        database_path,
+                        socket_path,
+                        branch_id,
+                        is_running: true,
+                    };
+                    *self.info.lock().unwrap() = Some(info.clone());
+                    return Ok(info);
+                }
+            }
+            return Err(
+                "HUMANLAYER_WUI_AUTOLAUNCH_DAEMON=false but no HUMANLAYER_DAEMON_HTTP_PORT set"
+                    .to_string(),
+            );
+        }
+
         // Check if daemon is already running on a specific port
         if let Ok(port_str) = env::var("HUMANLAYER_DAEMON_HTTP_PORT") {
             if let Ok(port) = port_str.parse::<u16>() {
@@ -78,8 +116,11 @@ impl DaemonManager {
         fs::create_dir_all(&humanlayer_dir)
             .map_err(|e| format!("Failed to create .humanlayer directory: {e}"))?;
 
-        // Database path
-        let database_path = if is_dev {
+        // Database path - check environment variable first
+        let database_path = if let Ok(db_path) = env::var("HUMANLAYER_DATABASE_PATH") {
+            log::info!("[Tauri] Using database path from HUMANLAYER_DATABASE_PATH: {db_path}");
+            PathBuf::from(db_path)
+        } else if is_dev {
             // Copy dev database if it doesn't exist
             let dev_db = humanlayer_dir.join(format!("daemon-{branch_id}.db"));
             if !dev_db.exists() {
@@ -94,8 +135,11 @@ impl DaemonManager {
             humanlayer_dir.join("daemon.db")
         };
 
-        // Socket path
-        let socket_path = if is_dev {
+        // Socket path - check environment variable first
+        let socket_path = if let Ok(sock_path) = env::var("HUMANLAYER_DAEMON_SOCKET") {
+            log::info!("[Tauri] Using socket path from HUMANLAYER_DAEMON_SOCKET: {sock_path}");
+            PathBuf::from(sock_path)
+        } else if is_dev {
             humanlayer_dir.join(format!("daemon-{branch_id}.sock"))
         } else {
             humanlayer_dir.join("daemon.sock")
@@ -126,14 +170,8 @@ impl DaemonManager {
                 branch_id.clone(),
             ));
             // Enable debug logging for daemon in dev mode
-            env_vars.push((
-                "HUMANLAYER_DEBUG".to_string(),
-                "true".to_string(),
-            ));
-            env_vars.push((
-                "GIN_MODE".to_string(),
-                "debug".to_string(),
-            ));
+            env_vars.push(("HUMANLAYER_DEBUG".to_string(), "true".to_string()));
+            env_vars.push(("GIN_MODE".to_string(), "debug".to_string()));
         }
 
         // Start daemon with stdout capture and stderr logging
@@ -175,9 +213,15 @@ impl DaemonManager {
                             // In production, always log at info level or higher for visibility
                             if is_prod {
                                 // Check if it's an error or warning
-                                if line.contains("ERROR") || line.contains("error") || line.contains("Error") {
+                                if line.contains("ERROR")
+                                    || line.contains("error")
+                                    || line.contains("Error")
+                                {
                                     log::error!("[Daemon] {branch_id_clone}: {line}");
-                                } else if line.contains("WARN") || line.contains("warn") || line.contains("Warning") {
+                                } else if line.contains("WARN")
+                                    || line.contains("warn")
+                                    || line.contains("Warning")
+                                {
                                     log::warn!("[Daemon] {branch_id_clone}: {line}");
                                 } else {
                                     log::info!("[Daemon] {branch_id_clone}: {line}");
@@ -188,11 +232,21 @@ impl DaemonManager {
                                 let cleaned_line = remove_timestamp(&line);
 
                                 match level {
-                                    LogLevel::Error => log::error!("[Daemon] {branch_id_clone}: {cleaned_line}"),
-                                    LogLevel::Warn => log::warn!("[Daemon] {branch_id_clone}: {cleaned_line}"),
-                                    LogLevel::Info => log::info!("[Daemon] {branch_id_clone}: {cleaned_line}"),
-                                    LogLevel::Debug => log::debug!("[Daemon] {branch_id_clone}: {cleaned_line}"),
-                                    LogLevel::Trace => log::trace!("[Daemon] {branch_id_clone}: {cleaned_line}"),
+                                    LogLevel::Error => {
+                                        log::error!("[Daemon] {branch_id_clone}: {cleaned_line}")
+                                    }
+                                    LogLevel::Warn => {
+                                        log::warn!("[Daemon] {branch_id_clone}: {cleaned_line}")
+                                    }
+                                    LogLevel::Info => {
+                                        log::info!("[Daemon] {branch_id_clone}: {cleaned_line}")
+                                    }
+                                    LogLevel::Debug => {
+                                        log::debug!("[Daemon] {branch_id_clone}: {cleaned_line}")
+                                    }
+                                    LogLevel::Trace => {
+                                        log::trace!("[Daemon] {branch_id_clone}: {cleaned_line}")
+                                    }
                                 }
                             }
                         }
@@ -275,7 +329,9 @@ impl DaemonManager {
         match child.try_wait() {
             Ok(None) => log::info!("[Tauri] Daemon process still running after port read"),
             Ok(Some(status)) => {
-                return Err(format!("Daemon process exited immediately after starting! Status: {status:?}"));
+                return Err(format!(
+                    "Daemon process exited immediately after starting! Status: {status:?}"
+                ));
             }
             Err(e) => log::error!("[Tauri] Error checking daemon status: {e}"),
         }
@@ -448,7 +504,6 @@ fn get_daemon_path(app_handle: &AppHandle, is_dev: bool) -> Result<PathBuf, Stri
         Ok(resource_dir.join("bin").join("hld"))
     }
 }
-
 
 async fn check_daemon_health(port: u16) -> Result<(), String> {
     let client = reqwest::Client::new();

--- a/humanlayer-wui/src/components/DebugPanel.tsx
+++ b/humanlayer-wui/src/components/DebugPanel.tsx
@@ -174,13 +174,6 @@ export function DebugPanel({ open, onOpenChange }: DebugPanelProps) {
                 </div>
               </div>
 
-              {daemonType === 'external' && externalDaemonUrl && (
-                <div className="flex items-center justify-between">
-                  <span className="text-sm text-muted-foreground">External URL</span>
-                  <span className="text-sm font-mono">{externalDaemonUrl}</span>
-                </div>
-              )}
-
               {daemonInfo && (
                 <>
                   <div className="flex items-center justify-between">
@@ -193,6 +186,18 @@ export function DebugPanel({ open, onOpenChange }: DebugPanelProps) {
                   </div>
                 </>
               )}
+
+              {/* Display current daemon URL */}
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-muted-foreground">Daemon URL</span>
+                <span className="text-sm font-mono">
+                  {daemonType === 'external' && externalDaemonUrl
+                    ? externalDaemonUrl
+                    : daemonInfo
+                      ? `http://localhost:${daemonInfo.port}`
+                      : 'Not connected'}
+                </span>
+              </div>
 
               {daemonType === 'managed' ? (
                 <Button


### PR DESCRIPTION
## What problem(s) was I solving?

Enabled running multiple concurrent CodeLayer (daemon + WUI) instances to support parallel development workflows across different worktrees. Previously, developers had to shut down one instance before starting another, creating friction when working on multiple tickets simultaneously.

Related issues:
- [ENG-2114](https://linear.app/humanlayer/issue/ENG-2114/allow-booting-multiple-daemons-and-wuis-concurrently): Allow booting multiple daemons & WUIs concurrently

## What user-facing changes did I ship?

### Developer Experience
- `make codelayer-dev TICKET=ENG-2114` launches isolated instance with automatic port allocation
- Each ticket gets dedicated daemon port, Vite port, socket file, and database
- Progressive port fallback (2114 → 12114 → 22114) ensures conflicts are avoided
- Default mode (`make codelayer-dev`) preserved for backward compatibility
- Debug panel now displays daemon URL for better visibility

### Instance Isolation
- Multiple instances can run simultaneously, even on same git branch
- Each instance maintains separate state in `daemon-{TICKET}.db` and `daemon-{port}.sock`
- WUI correctly connects to ticket-specific daemon instance
- No cross-contamination between concurrent development sessions

## How I implemented it

### Port Allocation System (`hack/port-utils.sh`)
- Created utilities for checking port availability using `nc` or `lsof`
- Implemented progressive prefix fallback for both daemon and Vite ports
- Extract ticket numbers from ticket IDs (e.g., ENG-2114 → 2114)

### Makefile Targets
- Added `daemon-ticket` and `wui-ticket` targets for individual component launch
- Enhanced `codelayer-dev` to handle both default and ticket modes
- Orchestrates daemon and WUI processes with proper environment propagation
- Added `test-port-allocation` for debugging port allocation

### WUI Configuration (`humanlayer-wui/src-tauri/src/daemon.rs`)
- Added environment variable priority for socket and database paths
- Implemented auto-launch bypass when `HUMANLAYER_WUI_AUTOLAUNCH_DAEMON=false`
- Preserved backward compatibility with branch-based isolation
- Fixed handling of external daemon connections

### UI Enhancement (`humanlayer-wui/src/components/DebugPanel.tsx`)
- Added daemon URL display in debug panel for all daemon types
- Shows appropriate URL based on daemon type (managed vs external)

## How to verify it

- [x] I have ensured `make check test` passes

### Manual Testing
1. Launch multiple concurrent instances:
   ```bash
   # Terminal 1
   make codelayer-dev TICKET=ENG-2114

   # Terminal 2 (different worktree)
   make codelayer-dev TICKET=ENG-2115
   ```
   - Verify both instances run simultaneously
   - Check unique ports in console output
   - Confirm separate databases and sockets

2. Test port fallback:
   ```bash
   # Start something on port 2114, then:
   make test-port-allocation TICKET=ENG-2114
   # Should show fallback to 12114
   ```

3. Verify default mode still works:
   ```bash
   make codelayer-dev
   # Should launch with WUI managing daemon as before
   ```

4. Check debug panel:
   - Open debug panel in WUI (Cmd+Shift+D)
   - Verify daemon URL displays correctly
   - Confirm correct port shown for ticket instances

## Description for the changelog

Enabled multiple concurrent CodeLayer development instances with ticket-based port allocation and full isolation, allowing parallel work across different worktrees without conflicts.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>