### PR TITLE
fix: SHIFT+R hotkey and escape navigation for session title editing

### DIFF
--- a/humanlayer-wui/src/AppStore.ts
+++ b/humanlayer-wui/src/AppStore.ts
@@ -76,6 +76,8 @@ interface StoreState {
   setHotkeyPanelOpen: (open: boolean) => void
   isSettingsDialogOpen: boolean
   setSettingsDialogOpen: (open: boolean) => void
+  isEditingSessionTitle: boolean
+  setIsEditingSessionTitle: (editing: boolean) => void
 
   /* Auto-scroll State */
   autoScrollEnabled: boolean
@@ -819,6 +821,8 @@ export const useStore = create<StoreState>((set, get) => ({
   setHotkeyPanelOpen: (open: boolean) => set({ isHotkeyPanelOpen: open }),
   isSettingsDialogOpen: false,
   setSettingsDialogOpen: (open: boolean) => set({ isSettingsDialogOpen: open }),
+  isEditingSessionTitle: false,
+  setIsEditingSessionTitle: (editing: boolean) => set({ isEditingSessionTitle: editing }),
 
   // Auto-scroll state
   autoScrollEnabled: true, // Default to enabled

--- a/humanlayer-wui/src/components/Breadcrumbs.tsx
+++ b/humanlayer-wui/src/components/Breadcrumbs.tsx
@@ -126,7 +126,7 @@ export function Breadcrumbs() {
                     style={{
                       width: `${Math.max(20, editValue.length) * 0.7}em`,
                       minWidth: '20em',
-                      maxWidth: '80em'
+                      maxWidth: '80em',
                     }}
                     autoFocus
                   />

--- a/humanlayer-wui/src/components/Breadcrumbs.tsx
+++ b/humanlayer-wui/src/components/Breadcrumbs.tsx
@@ -1,7 +1,8 @@
 import { useLocation, useNavigate } from 'react-router-dom'
 import { Home, Pencil, Check, X } from 'lucide-react'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { toast } from 'sonner'
+import { useHotkeys } from 'react-hotkeys-hook'
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -12,11 +13,16 @@ import {
 } from '@/components/ui/breadcrumb'
 import { useStore } from '@/AppStore'
 import { daemonClient } from '@/lib/daemon/client'
+import { useStealHotkeyScope } from '@/hooks/useStealHotkeyScope'
+
+// Create a dedicated scope for title editing
+const TitleEditingHotkeysScope = 'title-editing'
 
 export function Breadcrumbs() {
   const location = useLocation()
   const navigate = useNavigate()
   const [editValue, setEditValue] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
 
   const pathSegments = location.pathname.split('/').filter(Boolean)
   const isHome = pathSegments.length === 0
@@ -27,6 +33,26 @@ export function Breadcrumbs() {
   const session = useStore(state => (sessionId ? state.sessions.find(s => s.id === sessionId) : null))
   const isEditingTitle = useStore(state => state.isEditingSessionTitle)
   const setIsEditingTitle = useStore(state => state.setIsEditingSessionTitle)
+
+  // Steal all hotkey scopes when editing
+  useStealHotkeyScope(TitleEditingHotkeysScope, isEditingTitle)
+
+  // Add escape handler with the dedicated scope
+  useHotkeys(
+    'escape',
+    e => {
+      e.preventDefault()
+      setEditValue(session?.title || session?.summary || '')
+      setIsEditingTitle(false)
+      inputRef.current?.blur()
+    },
+    {
+      scopes: [TitleEditingHotkeysScope],
+      enableOnFormTags: true,
+      preventDefault: true,
+    },
+    [isEditingTitle, session],
+  )
 
   const startEdit = () => {
     if (session) {
@@ -60,7 +86,7 @@ export function Breadcrumbs() {
   }, [isEditingTitle, session])
 
   return (
-    <Breadcrumb className="mb-4 font-mono text-sm uppercase tracking-wider">
+    <Breadcrumb className="mb-4 font-mono text-sm tracking-wider">
       <BreadcrumbList>
         <BreadcrumbItem>
           {isHome ? (
@@ -86,14 +112,22 @@ export function Breadcrumbs() {
               {isEditingTitle ? (
                 <div className="flex items-center gap-1">
                   <input
+                    ref={inputRef}
                     type="text"
                     value={editValue}
                     onChange={e => setEditValue(e.target.value)}
                     onKeyDown={e => {
-                      if (e.key === 'Enter') saveEdit()
-                      if (e.key === 'Escape') cancelEdit()
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        saveEdit()
+                      }
                     }}
                     className="px-1 py-0.5 text-sm bg-background border rounded font-mono"
+                    style={{
+                      width: `${Math.max(20, editValue.length) * 0.7}em`,
+                      minWidth: '20em',
+                      maxWidth: '80em'
+                    }}
                     autoFocus
                   />
                   <button onClick={saveEdit} className="p-0.5 hover:opacity-80">

--- a/humanlayer-wui/src/components/Breadcrumbs.tsx
+++ b/humanlayer-wui/src/components/Breadcrumbs.tsx
@@ -1,6 +1,6 @@
 import { useLocation, useNavigate } from 'react-router-dom'
 import { Home, Pencil, Check, X } from 'lucide-react'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { toast } from 'sonner'
 import {
   Breadcrumb,
@@ -16,7 +16,6 @@ import { daemonClient } from '@/lib/daemon/client'
 export function Breadcrumbs() {
   const location = useLocation()
   const navigate = useNavigate()
-  const [isEditingTitle, setIsEditingTitle] = useState(false)
   const [editValue, setEditValue] = useState('')
 
   const pathSegments = location.pathname.split('/').filter(Boolean)
@@ -24,8 +23,10 @@ export function Breadcrumbs() {
   const isSessionDetail = pathSegments[0] === 'sessions' && pathSegments[1]
   const sessionId = isSessionDetail ? pathSegments[1] : null
 
-  // Get session from store
+  // Get session and editing state from store
   const session = useStore(state => (sessionId ? state.sessions.find(s => s.id === sessionId) : null))
+  const isEditingTitle = useStore(state => state.isEditingSessionTitle)
+  const setIsEditingTitle = useStore(state => state.setIsEditingSessionTitle)
 
   const startEdit = () => {
     if (session) {
@@ -50,6 +51,13 @@ export function Breadcrumbs() {
     setIsEditingTitle(false)
     setEditValue('')
   }
+
+  // Watch for external triggers to start editing
+  useEffect(() => {
+    if (isEditingTitle && session && !editValue) {
+      setEditValue(session.title || session.summary || '')
+    }
+  }, [isEditingTitle, session])
 
   return (
     <Breadcrumb className="mb-4 font-mono text-sm uppercase tracking-wider">
@@ -85,7 +93,7 @@ export function Breadcrumbs() {
                       if (e.key === 'Enter') saveEdit()
                       if (e.key === 'Escape') cancelEdit()
                     }}
-                    className="px-1 py-0.5 text-sm bg-background border rounded font-mono uppercase tracking-wider"
+                    className="px-1 py-0.5 text-sm bg-background border rounded font-mono"
                     autoFocus
                   />
                   <button onClick={saveEdit} className="p-0.5 hover:opacity-80">

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -204,6 +204,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
   const [directoriesDropdownOpen, setDirectoriesDropdownOpen] = useState(false)
 
   const responseEditor = useStore(state => state.responseEditor)
+  const isEditingSessionTitle = useStore(state => state.isEditingSessionTitle)
   const setIsEditingSessionTitle = useStore(state => state.setIsEditingSessionTitle)
 
   // Keyboard navigation protection
@@ -502,6 +503,11 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
         return null
       }
 
+      // Don't process escape if editing session title
+      if (isEditingSessionTitle) {
+        return
+      }
+
       // Don't process escape if modals are open
       if (forkViewOpen) {
         return
@@ -554,6 +560,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
       scopes: SessionDetailHotkeysScope,
     },
     [
+      isEditingSessionTitle,
       previewEventIndex,
       confirmingArchive,
       forkViewOpen,

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -204,6 +204,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
   const [directoriesDropdownOpen, setDirectoriesDropdownOpen] = useState(false)
 
   const responseEditor = useStore(state => state.responseEditor)
+  const setIsEditingSessionTitle = useStore(state => state.setIsEditingSessionTitle)
 
   // Keyboard navigation protection
   const { shouldIgnoreMouseEvent, startKeyboardNavigation } = useKeyboardNavigationProtection()
@@ -881,6 +882,22 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
       enableOnFormTags: false,
     },
     [session.workingDir],
+  )
+
+  // Rename session hotkey
+  useHotkeys(
+    'shift+r',
+    e => {
+      e.preventDefault()
+      setIsEditingSessionTitle(true)
+    },
+    {
+      enabled: !approvals.confirmingApprovalId && !expandedToolResult,
+      scopes: SessionDetailHotkeysScope,
+      preventDefault: true,
+      enableOnFormTags: false,
+    },
+    [setIsEditingSessionTitle, approvals.confirmingApprovalId, expandedToolResult],
   )
 
   // Don't steal scope here - SessionDetail is the base layer

--- a/humanlayer-wui/src/components/ui/button.tsx
+++ b/humanlayer-wui/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-none text-sm font-mono font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:outline-2 focus-visible:outline-dashed focus-visible:outline-offset-2 focus-visible:outline-ring uppercase tracking-wider border",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-none text-sm font-mono font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:outline-2 focus-visible:outline-dashed focus-visible:outline-offset-2 focus-visible:outline-ring border",
   {
     variants: {
       variant: {

--- a/humanlayer-wui/src/components/ui/button.tsx
+++ b/humanlayer-wui/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-none text-sm font-mono font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:outline-2 focus-visible:outline-dashed focus-visible:outline-offset-2 focus-visible:outline-ring border",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-none text-sm font-mono font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:outline-2 focus-visible:outline-dashed focus-visible:outline-offset-2 focus-visible:outline-ring uppercase tracking-wider border",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## What problem(s) was I solving?

Fixed the broken SHIFT+R hotkey for renaming sessions in SessionDetail view and resolved escape key navigation issues during title editing. Also removed forced uppercase styling from session titles.

Related issues:
- [ENG-2117](https://linear.app/humanlayer/issue/ENG-2117/session-display-updates-broke-shiftr-hotkey-for-rename): Session Display updates broke `SHIFT+R` hotkey for rename session

## What user-facing changes did I ship?

### Session Title Editing
- **SHIFT+R hotkey now works in SessionDetail view** - Users can press SHIFT+R to rename the current session
- **Escape key properly cancels editing** - Pressing escape while editing no longer navigates back to session list
- **Normal case text display** - Session titles now display in their original case instead of forced uppercase
- **Dynamic input width** - The title edit input automatically adjusts width based on content (20-80em range)

### Technical Improvements
- Proper hotkey scope isolation during title editing using `useStealHotkeyScope`
- Global state management for title editing to coordinate between components
- Consistent behavior with SessionTable's existing rename functionality

## How I implemented it

### Global State Management (`AppStore.ts`)
Added global state for tracking when session title is being edited:
- `isEditingSessionTitle`: Boolean flag indicating edit mode
- `setIsEditingSessionTitle`: Setter function for coordinating between components

### Hotkey Implementation (`SessionDetail.tsx`)
- Added SHIFT+R hotkey handler that triggers title editing
- Added check in escape handler to prevent navigation when editing title
- Hotkey disabled when approvals or tool results are open

### Title Editing Enhancement (`Breadcrumbs.tsx`)
- Integrated with global editing state instead of local state
- Implemented `useStealHotkeyScope` to isolate editing from other hotkeys
- Added dedicated escape handler for clean edit cancellation
- Dynamic input width calculation: `width = max(20, textLength) * 0.7em`
- Removed forced uppercase CSS classes

### Styling Updates (`button.tsx`)
- Removed `uppercase tracking-wider` from button component base styles
- Allows buttons and text to display in their natural case

## How to verify it

- [x] Type checking passes: `bun run typecheck`
- [x] Linting passes (warnings only): `bun run lint`
- [ ] Format check passes: `bun run format:check` (requires prettier formatting)

### Manual Testing
1. Navigate to SessionDetail view:
   - Press SHIFT+R to start editing session title
   - Verify input field appears with current title
   - Type to modify the title and see input width adjust
   - Press Enter to save changes
   - Verify title updates in breadcrumb and persists

2. Test escape key behavior:
   - Press SHIFT+R to start editing
   - Press Escape to cancel
   - **Verify you remain in SessionDetail (no navigation)**
   - Verify original title is preserved

3. Visual verification:
   - Session titles display in normal case (not uppercase)
   - Input field width adjusts smoothly as you type
   - Pencil icon appears on hover for mouse editing

## Description for the changelog

Fixed SHIFT+R hotkey for renaming sessions in SessionDetail view and prevented unwanted escape key navigation during title editing. Removed forced uppercase styling from session titles and added dynamic width adjustment for title input field.

## Cute animal picture 
<img width="750" height="620" alt="image" src="https://github.com/user-attachments/assets/46ec06c4-b531-45ff-8462-3883ea1fb2c6" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes session title editing issues, including `SHIFT+R` hotkey, escape key behavior, and styling, with global state management and hotkey isolation.
> 
>   - **Behavior**:
>     - Fixes `SHIFT+R` hotkey in `SessionDetail.tsx` to enable session renaming.
>     - Escape key now cancels title editing without navigating away in `SessionDetail.tsx`.
>     - Session titles display in original case, not uppercase, in `Breadcrumbs.tsx`.
>     - Title input field dynamically adjusts width based on content in `Breadcrumbs.tsx`.
>   - **State Management**:
>     - Adds `isEditingSessionTitle` and `setIsEditingSessionTitle` to `AppStore.ts` for global state management.
>   - **Hotkey Handling**:
>     - Implements `useStealHotkeyScope` in `Breadcrumbs.tsx` to isolate hotkeys during editing.
>     - Disables hotkeys when modals are open in `SessionDetail.tsx`.
>   - **Styling**:
>     - Removes forced uppercase styling from session titles in `Breadcrumbs.tsx` and `button.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 72bf20f563c40cf6e7e6ebea2dc4913c1759f6dd. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->