### PR TITLE
fix(ENG-2114): Fix port calculation overflow for high ticket numbers

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./hack/spec_metadata.sh)",
+      "Bash(hack/spec_metadata.sh)",
+      "Bash(bash hack/spec_metadata.sh)"
+    ]
+  },
+  "enableAllProjectMcpServers": false
+}

--- a/Makefile
+++ b/Makefile
@@ -686,7 +686,7 @@ wui-ticket:
 	HUMANLAYER_DAEMON_SOCKET=~/.humanlayer/daemon-$$port.sock \
 	VITE_HUMANLAYER_DAEMON_URL=http://localhost:$$port \
 	VITE_PORT=$$vite_port \
-	bun tauri dev --config /tmp/tauri-config-$(TICKET).json
+	bun run tauri dev --config /tmp/tauri-config-$(TICKET).json
 
 # Run dev daemon with persistent dev database
 .PHONY: daemon-dev

--- a/humanlayer-wui/src/AppStore.ts
+++ b/humanlayer-wui/src/AppStore.ts
@@ -119,6 +119,10 @@ interface StoreState {
   responseEditor: Editor | null
   setResponseEditor: (responseEditor: Editor) => void
   removeResponseEditor: () => void
+
+  /* Title Editing State */
+  isEditingSessionTitle: boolean
+  setIsEditingSessionTitle: (editing: boolean) => void
 }
 
 export const useStore = create<StoreState>((set, get) => ({
@@ -131,6 +135,7 @@ export const useStore = create<StoreState>((set, get) => ({
   activeSessionDetail: null,
   claudeConfig: null,
   responseEditor: null,
+  isEditingSessionTitle: false,
   initSessions: (sessions: Session[]) => set({ sessions }),
   updateSession: (sessionId: string, updates: Partial<Session>) =>
     set(state => ({
@@ -917,6 +922,7 @@ export const useStore = create<StoreState>((set, get) => ({
     logger.log('AppStore.removeResponseEditor() - removing response editor')
     return set({ responseEditor: null })
   },
+  setIsEditingSessionTitle: (editing: boolean) => set({ isEditingSessionTitle: editing }),
 }))
 
 // Helper function to validate and clean up session state

--- a/humanlayer-wui/src/AppStore.ts
+++ b/humanlayer-wui/src/AppStore.ts
@@ -76,8 +76,6 @@ interface StoreState {
   setHotkeyPanelOpen: (open: boolean) => void
   isSettingsDialogOpen: boolean
   setSettingsDialogOpen: (open: boolean) => void
-  isEditingSessionTitle: boolean
-  setIsEditingSessionTitle: (editing: boolean) => void
 
   /* Auto-scroll State */
   autoScrollEnabled: boolean
@@ -137,7 +135,6 @@ export const useStore = create<StoreState>((set, get) => ({
   activeSessionDetail: null,
   claudeConfig: null,
   responseEditor: null,
-  isEditingSessionTitle: false,
   initSessions: (sessions: Session[]) => set({ sessions }),
   updateSession: (sessionId: string, updates: Partial<Session>) =>
     set(state => ({
@@ -826,8 +823,6 @@ export const useStore = create<StoreState>((set, get) => ({
   setHotkeyPanelOpen: (open: boolean) => set({ isHotkeyPanelOpen: open }),
   isSettingsDialogOpen: false,
   setSettingsDialogOpen: (open: boolean) => set({ isSettingsDialogOpen: open }),
-  isEditingSessionTitle: false,
-  setIsEditingSessionTitle: (editing: boolean) => set({ isEditingSessionTitle: editing }),
 
   // Auto-scroll state
   autoScrollEnabled: true, // Default to enabled
@@ -926,6 +921,9 @@ export const useStore = create<StoreState>((set, get) => ({
     logger.log('AppStore.removeResponseEditor() - removing response editor')
     return set({ responseEditor: null })
   },
+
+  // Title Editing State
+  isEditingSessionTitle: false,
   setIsEditingSessionTitle: (editing: boolean) => set({ isEditingSessionTitle: editing }),
 }))
 

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -204,6 +204,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
   const [directoriesDropdownOpen, setDirectoriesDropdownOpen] = useState(false)
 
   const responseEditor = useStore(state => state.responseEditor)
+  const isEditingSessionTitle = useStore(state => state.isEditingSessionTitle)
 
   // Keyboard navigation protection
   const { shouldIgnoreMouseEvent, startKeyboardNavigation } = useKeyboardNavigationProtection()
@@ -501,6 +502,11 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
         return null
       }
 
+      // Don't process escape if title is being edited
+      if (isEditingSessionTitle) {
+        return
+      }
+
       // Don't process escape if modals are open
       if (forkViewOpen) {
         return
@@ -557,12 +563,15 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
       confirmingArchive,
       forkViewOpen,
       dangerousSkipPermissionsDialogOpen,
+      directoriesDropdownOpen,
       expandedToolResult,
+      isEditingSessionTitle,
       approvals.confirmingApprovalId,
       approvals.setConfirmingApprovalId,
       navigation.focusedEventId,
       navigation.setFocusedEventId,
       onClose,
+      responseEditor,
       // actions.setResponseInput,
     ],
   )

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseEditor.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseEditor.tsx
@@ -680,6 +680,7 @@ export const ResponseEditor = forwardRef<{ focus: () => void }, ResponseEditorPr
           spellcheck: 'false',
           autocorrect: 'off',
           autocapitalize: 'off',
+          'data-prompt-input': 'true',
         },
         handleKeyDown: (view, event) => {
           // Only handle Shift+Enter in regular paragraphs, not in code blocks or other special nodes


### PR DESCRIPTION
## Summary
- Fixed critical bug in port calculation that caused "invalid port number" errors for tickets ≥ 1555
- Ensures all generated ports stay within valid range (1-65535)
- Implements smarter fallback strategies for Vite ports

## Problem
When running `make codelayer-dev TICKET=ENG-1937`, the command would fail with:
```
invalid port number: "http://localhost:111937"
```

The port fallback logic in `hack/port-utils.sh` was using string concatenation instead of arithmetic, causing it to generate invalid ports > 65535. For example, when Vite base port 11937 was unavailable, it would concatenate "1" + "11937" = "111937" instead of finding a valid alternative.

## Solution
1. **Added port validation** in `find_available_port()` to skip any ports exceeding 65535
2. **Rewrote `find_available_vite_port()`** with a smarter fallback strategy:
   - First tries base port (ticket + 10000) if valid
   - Falls back to 30000-65000 range for high tickets  
   - Secondary fallback to 40000-50000 range
   - All ports guaranteed to be within valid range

## Test plan
- [x] Tested with ENG-1937: Correctly allocates daemon port 1937, Vite port 11937
- [x] Tested with port conflicts: Properly falls back to valid alternatives
- [x] Validated edge cases: ENG-1555 (boundary), ENG-9999 (high ticket)
- [x] All generated ports verified to be ≤ 65535
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes port calculation overflow for high ticket numbers in `hack/port-utils.sh`, ensuring valid port ranges and smarter fallback strategies.
> 
>   - **Behavior**:
>     - Fixes port calculation overflow in `hack/port-utils.sh` for tickets ≥ 1555, ensuring ports stay within 1-65535.
>     - Implements smarter fallback strategies in `find_available_vite_port()` for Vite ports.
>   - **Makefile**:
>     - Updates `wui-ticket` target to use `bun run` instead of `bun tauri dev`.
>   - **Testing**:
>     - Validated with ENG-1937, port conflicts, and edge cases like ENG-1555 and ENG-9999.
>     - Ensures all generated ports are ≤ 65535.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 6e2f2b1a67795b6f1a808becb8e5aa997d1f5dcf. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->