### PR TITLE
Fix breadcrumb to display "Archived Sessions" when viewing archive

### DIFF
--- a/humanlayer-wui/src/components/Breadcrumbs.tsx
+++ b/humanlayer-wui/src/components/Breadcrumbs.tsx
@@ -14,6 +14,7 @@ import {
 import { useStore } from '@/AppStore'
 import { daemonClient } from '@/lib/daemon/client'
 import { useStealHotkeyScope } from '@/hooks/useStealHotkeyScope'
+import { ViewMode } from '@/lib/daemon/types'
 
 // Create a dedicated scope for title editing
 const TitleEditingHotkeysScope = 'title-editing'
@@ -29,8 +30,9 @@ export function Breadcrumbs() {
   const isSessionDetail = pathSegments[0] === 'sessions' && pathSegments[1]
   const sessionId = isSessionDetail ? pathSegments[1] : null
 
-  // Get session and editing state from store
+  // Get session, viewMode, and editing state from store
   const session = useStore(state => (sessionId ? state.sessions.find(s => s.id === sessionId) : null))
+  const viewMode = useStore(state => state.viewMode)
   const isEditingTitle = useStore(state => state.isEditingSessionTitle)
   const setIsEditingTitle = useStore(state => state.setIsEditingSessionTitle)
 
@@ -85,6 +87,9 @@ export function Breadcrumbs() {
     }
   }, [isEditingTitle, session])
 
+  // Determine breadcrumb text based on view mode
+  const breadcrumbText = viewMode === ViewMode.Archived ? 'Archived Sessions' : 'Sessions'
+
   return (
     <Breadcrumb className="mb-4 font-mono text-sm tracking-wider">
       <BreadcrumbList>
@@ -92,7 +97,7 @@ export function Breadcrumbs() {
           {isHome ? (
             <BreadcrumbPage className="flex items-center gap-1">
               <Home className="w-4 h-4" />
-              Sessions
+              {breadcrumbText}
             </BreadcrumbPage>
           ) : (
             <BreadcrumbLink
@@ -100,7 +105,7 @@ export function Breadcrumbs() {
               className="flex items-center gap-1 cursor-pointer"
             >
               <Home className="w-4 h-4" />
-              Sessions
+              {breadcrumbText}
             </BreadcrumbLink>
           )}
         </BreadcrumbItem>


### PR DESCRIPTION
## Summary
- Updated the Breadcrumbs component to check the current viewMode from the store
- When viewMode is set to Archived, the breadcrumb now displays "Archived Sessions" instead of "Sessions"
- This provides clearer visual feedback to users about which view they're currently in

## Test plan
- [x] Navigate to the sessions list view
- [x] Press Tab or use G+E hotkeys to switch to archived sessions view
- [x] Verify the breadcrumb at the top now says "Archived Sessions"
- [x] Switch back to normal view and verify it says "Sessions" again
- [x] All TypeScript and lint checks pass
- [x] UI tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `Breadcrumbs` component to display 'Archived Sessions' based on `viewMode` state.
> 
>   - **Behavior**:
>     - Updates `Breadcrumbs` component to display 'Archived Sessions' when `viewMode` is `Archived`.
>     - Uses `viewMode` from store to determine breadcrumb text.
>   - **Code Changes**:
>     - Adds `viewMode` state retrieval in `Breadcrumbs.tsx`.
>     - Replaces static 'Sessions' text with dynamic `breadcrumbText` variable in `Breadcrumbs.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for ab11c9e34f8a43adfa12ba064ce0e036cdb1b2e5. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->