### PR TITLE
Inherit

### DIFF
--- a/.claude/agents/codebase-analyzer.md
+++ b/.claude/agents/codebase-analyzer.md
@@ -2,6 +2,7 @@
 name: codebase-analyzer
 description: Analyzes codebase implementation details. Call the codebase-analyzer agent when you need to find detailed information about specific components. As always, the more detailed your request prompt, the better! :)
 tools: Read, Grep, Glob, LS
+model: inherit
 ---
 
 You are a specialist at understanding HOW code works. Your job is to analyze implementation details, trace data flow, and explain technical workings with precise file:line references.

--- a/.claude/agents/codebase-locator.md
+++ b/.claude/agents/codebase-locator.md
@@ -2,6 +2,7 @@
 name: codebase-locator
 description: Locates files, directories, and components relevant to a feature or task. Call `codebase-locator` with human language prompt describing what you're looking for. Basically a "Super Grep/Glob/LS tool" — Use it if you find yourself desiring to use one of these tools more than once.
 tools: Grep, Glob, LS
+model: inherit
 ---
 
 You are a specialist at finding WHERE code lives in a codebase. Your job is to locate relevant files and organize them by purpose, NOT to analyze their contents.

--- a/.claude/agents/codebase-pattern-finder.md
+++ b/.claude/agents/codebase-pattern-finder.md
@@ -2,6 +2,7 @@
 name: codebase-pattern-finder
 description: codebase-pattern-finder is a useful subagent_type for finding similar implementations, usage examples, or existing patterns that can be modeled after. It will give you concrete code examples based on what you're looking for! It's sorta like codebase-locator, but it will not only tell you the location of files, it will also give you code details!
 tools: Grep, Glob, Read, LS
+model: inherit
 ---
 
 You are a specialist at finding code patterns and examples in the codebase. Your job is to locate similar implementations that can serve as templates or inspiration for new work.

--- a/.claude/agents/thoughts-analyzer.md
+++ b/.claude/agents/thoughts-analyzer.md
@@ -2,6 +2,7 @@
 name: thoughts-analyzer
 description: The research equivalent of codebase-analyzer. Use this subagent_type when wanting to deep dive on a research topic. Not commonly needed otherwise.
 tools: Read, Grep, Glob, LS
+model: inherit
 ---
 
 You are a specialist at extracting HIGH-VALUE insights from thoughts documents. Your job is to deeply analyze documents and return only the most relevant, actionable information while filtering out noise.

--- a/.claude/agents/thoughts-locator.md
+++ b/.claude/agents/thoughts-locator.md
@@ -2,6 +2,7 @@
 name: thoughts-locator
 description: Discovers relevant documents in thoughts/ directory (We use this for all sorts of metadata storage!). This is really only relevant/needed when you're in a reseaching mood and need to figure out if we have random thoughts written down that are relevant to your current research task. Based on the name, I imagine you can guess this is the `thoughts` equivilent of `codebase-locator`
 tools: Grep, Glob, LS
+model: inherit
 ---
 
 You are a specialist at finding documents in the thoughts/ directory. Your job is to locate relevant thought documents and categorize them, NOT to analyze their contents in depth.

--- a/.claude/agents/web-search-researcher.md
+++ b/.claude/agents/web-search-researcher.md
@@ -3,6 +3,7 @@ name: web-search-researcher
 description: Do you find yourself desiring information that you don't quite feel well-trained (confident) on? Information that is modern and potentially only discoverable on the web? Use the web-search-researcher subagent_type today to find any and all answers to your questions! It will research deeply to figure out and attempt to answer your questions! If you aren't immediately satisfied you can get your money back! (Not really - but you can re-run web-search-researcher with an altered prompt in the event you're not satisfied the first time)
 tools: WebSearch, WebFetch, TodoWrite, Read, Grep, Glob, LS
 color: yellow
+model: inherit
 ---
 
 You are an expert web research specialist focused on finding accurate, relevant information from web sources. Your primary tools are WebSearch and WebFetch, which you use to discover and retrieve information based on user queries.

--- a/hld/Makefile
+++ b/hld/Makefile
@@ -27,7 +27,7 @@ test-quiet:
 # Base test-unit target overridden below
 
 # Run integration tests (requires build tag)
-test-integration: build
+test-integration:
 	@if [ -n "$$VERBOSE" ]; then \
 		CGO_LDFLAGS="-Wl,-w" go test -v -tags=integration -run Integration ./daemon/...; \
 	else \
@@ -35,7 +35,7 @@ test-integration: build
 	fi
 
 # Run integration tests with quiet output
-test-integration-quiet: build
+test-integration-quiet:
 	@. ../hack/run_silent.sh && run_silent_with_test_count "Integration tests passed" "CGO_LDFLAGS=\"-Wl,-w\" go test -json -tags=integration -run Integration ./daemon/..." "go"
 
 # Run integration tests with race detection
@@ -47,7 +47,7 @@ test-integration-race:
 	fi
 
 # Run integration tests with race detection and quiet output
-test-integration-race-quiet: build
+test-integration-race-quiet:
 	@. ../hack/run_silent.sh && run_silent_with_test_count "Integration tests with race detection passed" "CGO_LDFLAGS=\"-Wl,-w\" go test -json -race -tags=integration -run Integration ./daemon/..." "go"
 
 # Run unit tests with race detection


### PR DESCRIPTION
## What problem(s) was I solving?

Claude Code agents were not explicitly configured to inherit the model from the parent context, which could lead to inconsistent model usage. Additionally, the Makefile for hld had unnecessary build dependencies on integration test targets that slowed down test runs.

## What user-facing changes did I ship?

### Agent Model Configuration
- All Claude Code agents now explicitly inherit the model from their parent context
- This ensures consistent model usage across agent invocations
- Affects all 6 research agents: codebase-analyzer, codebase-locator, codebase-pattern-finder, thoughts-analyzer, thoughts-locator, web-search-researcher

### Test Performance
- Integration tests now run immediately without requiring a build step
- Faster feedback loop for developers running integration tests

## How I implemented it

### Agent Configuration Updates
Added `model: inherit` to the frontmatter of all agent markdown files:
- This allows agents to use the same model as the parent Claude instance
- Ensures consistency when using different model versions (e.g., opus, sonnet)
- Prevents potential confusion from agents using different models than expected

### Makefile Optimization
Removed `build` dependency from integration test targets in `hld/Makefile`:
- `test-integration` target no longer requires build
- `test-integration-quiet` target no longer requires build
- `test-integration-race-quiet` target no longer requires build
- Tests can now run directly without unnecessary compilation

## How to verify it

- [x] I have ensured `make check test` passes

### Manual Testing
1. Launch Claude Code with a specific model (e.g., opus)
2. Invoke any of the affected agents (codebase-analyzer, codebase-locator, etc.)
3. Verify that agents use the same model as the parent instance
4. Run `make test-integration` in hld/ and verify it runs without building first

## Description for the changelog

Added explicit model inheritance for all Claude Code agents and optimized integration test targets to run without unnecessary build steps.