### PR TITLE
Fix session rename input retaining previous session value

### DIFF
--- a/humanlayer-wui/src/components/Breadcrumbs.tsx
+++ b/humanlayer-wui/src/components/Breadcrumbs.tsx
@@ -82,7 +82,7 @@ export function Breadcrumbs() {
 
   // Watch for external triggers to start editing
   useEffect(() => {
-    if (isEditingTitle && session && !editValue) {
+    if (isEditingTitle && session) {
       setEditValue(session.title || session.summary || '')
     }
   }, [isEditingTitle, session])


### PR DESCRIPTION
## What problem(s) was I solving?

Fixed a bug where the session rename input field would retain the previously entered rename value from a different session instead of showing the current session's actual name when triggered with Shift-R. This created a confusing user experience where users would see the wrong default value and could accidentally rename sessions incorrectly.

Related issues:
- [ENG-2172](https://linear.app/humanlayer/issue/ENG-2172/session-rename-input-retains-previous-sessions-value-instead-of): Session rename input retains previous session's value instead of current session name

## What user-facing changes did I ship?

### Session Rename Behavior
- When pressing Shift-R on any session, the input field now always shows the current session's name
- No more stale values from previous rename operations appearing in different sessions
- Consistent behavior whether renaming via Shift-R keyboard shortcut or clicking the pencil icon

## How I implemented it

### Root Cause
The `useEffect` hook in `Breadcrumbs.tsx` that watches for external triggers (Shift-R from SessionDetail) had a condition `!editValue` that prevented re-populating the input if there was already a value from a previous rename operation.

### The Fix (`humanlayer-wui/src/components/Breadcrumbs.tsx`)
Removed the `!editValue` condition from the `useEffect` so it always populates with the current session's title when editing starts:

```tsx
// Before
useEffect(() => {
  if (isEditingTitle && session && !editValue) {
    setEditValue(session.title || session.summary || '')
  }
}, [isEditingTitle, session])

// After
useEffect(() => {
  if (isEditingTitle && session) {
    setEditValue(session.title || session.summary || '')
  }
}, [isEditingTitle, session])
```

This ensures the input always shows the correct session name regardless of any previous state.

## How to verify it

- [x] I have ensured `make -C humanlayer-wui check` passes
- [x] Build succeeds: `make -C humanlayer-wui build`

### Manual Testing
1. Open the WUI application
2. Navigate to Session A in the list
3. Click into Session A details
4. Press Shift-R to start renaming
5. Type "New Name A" but **don't save** (press Escape to cancel)
6. Navigate back to sessions list (use browser back)
7. Navigate to Session B details
8. Press Shift-R to start renaming
9. **Verify**: Input should show Session B's current name (not "New Name A")
10. Enter "New Name B" and press Enter to save
11. Navigate back to Session A
12. Press Shift-R and verify it shows Session A's current name

## Description for the changelog

Fixed session rename input incorrectly retaining previous session's value when using Shift-R shortcut to rename different sessions.