### PR TITLE
fix(wui): add defensive error handling for Tauri drag-drop unlisten race condition (ENG-2189) 

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseInput.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseInput.tsx
@@ -272,7 +272,13 @@ export const ResponseInput = forwardRef<{ focus: () => void; blur?: () => void }
         mounted = false
         isSettingUp = false
         if (unlisten) {
-          unlisten()
+          // Defensive try-catch for Tauri v2 race condition (ENG-2189)
+          // The unlisten function may fail if the listener wasn't fully registered
+          try {
+            unlisten()
+          } catch (error) {
+            console.warn('[ResponseInput] Error during drag-drop unlisten (non-critical):', error)
+          }
         }
       }
     }, [responseEditor])


### PR DESCRIPTION
## What problem(s) was I solving?

Fixed a race condition in Tauri's drag-drop event system that was causing TypeErrors in production when the ResponseInput component unmounts while event listeners are being cleaned up. This was creating noisy errors in Sentry that didn't affect functionality but were concerning for monitoring.

The error `TypeError: undefined is not an object (evaluating 'listeners[eventId].handlerId')` occurred when the Tauri internal event registry tried to unregister a listener that wasn't fully registered yet.

Related issue:
- [ENG-2189](https://linear.app/humanlayer/issue/ENG-2189/typeerror-undefined-is-not-an-object-evaluating): TypeError in Tauri event unlisten

## What user-facing changes did I ship?

No visible user-facing changes. This is an internal error handling improvement that:
- Suppresses non-critical errors in production (Sentry noise reduction)
- Maintains all existing drag-drop functionality
- Adds console warnings for debugging if the race condition occurs

## How I implemented it

Added a defensive try-catch block around the `unlisten()` call in ResponseInput's drag-drop event cleanup:
- Wrapped the unlisten call in try-catch at line 275-281
- Added explanatory comments about the Tauri v2 race condition
- Log warnings to console instead of throwing errors
- Marked the error as non-critical since it's just a cleanup failure

This is a known Tauri v2 issue that persists even in v2.7.0 which includes PR #13306 (the supposed fix). The error happens when:
1. Component starts unmounting
2. Async `onDragDropEvent` setup is still in progress
3. Cleanup tries to call `unlisten()` on a not-yet-registered listener
4. Tauri's internal `listeners[eventId]` is undefined

## How to verify it

- [ ] I have ensured `make check test` passes
  - Note: 4 Python SDK tests are failing but they're unrelated to this UI change (async approval tests)

### Manual Testing
1. Open CodeLayer and navigate to a session detail view
2. Try rapid navigation between sessions while dragging files
3. Check browser console - should see warning messages instead of errors if race condition occurs
4. Verify drag-drop still works correctly for adding file mentions
5. Monitor Sentry - the TypeError should no longer appear

## Description for the changelog

Fixed Tauri drag-drop event listener cleanup race condition that was causing non-critical TypeErrors in production