### PR TITLE
feat: add localStorage persistence for model selection preferences

### DIFF
--- a/humanlayer-wui/src/components/CommandInput.tsx
+++ b/humanlayer-wui/src/components/CommandInput.tsx
@@ -146,9 +146,21 @@ export default function CommandInput({
             <Select
               value={config.provider || 'anthropic'}
               onValueChange={value => {
+                const newProvider = value as 'anthropic' | 'openrouter' | 'baseten'
+
+                // Get the saved model for this provider
+                let savedModel: string | undefined
+                if (newProvider === 'anthropic') {
+                  savedModel = localStorage.getItem('humanlayer-model') || undefined
+                } else if (newProvider === 'openrouter') {
+                  savedModel = localStorage.getItem('humanlayer-openrouter-model') || undefined
+                } else if (newProvider === 'baseten') {
+                  savedModel = localStorage.getItem('humanlayer-baseten-model') || undefined
+                }
+
                 updateConfig({
-                  provider: value as 'anthropic' | 'openrouter' | 'baseten',
-                  model: undefined, // Clear model when provider changes
+                  provider: newProvider,
+                  model: savedModel,
                   // Keep the API key persistent across provider changes
                 })
               }}

--- a/humanlayer-wui/src/components/SettingsDialog.tsx
+++ b/humanlayer-wui/src/components/SettingsDialog.tsx
@@ -10,6 +10,7 @@ import { toast } from 'sonner'
 import { CheckCircle2, XCircle, RefreshCw, Pencil } from 'lucide-react'
 import { HotkeyScopeBoundary } from './HotkeyScopeBoundary'
 import { HOTKEY_SCOPES } from '@/hooks/hotkeys/scopes'
+import { clearSavedModelPreferences } from '@/hooks/useSessionLauncher'
 
 interface SettingsDialogProps {
   open: boolean
@@ -47,6 +48,12 @@ export function SettingsDialog({ open, onOpenChange, onConfigUpdate }: SettingsD
   const handleProvidersToggle = async (checked: boolean) => {
     try {
       setSaving(true)
+
+      // Clear saved model preferences when disabling advanced providers
+      if (!checked) {
+        clearSavedModelPreferences()
+      }
+
       await updateUserSettings({ advancedProviders: checked })
       logger.log('Advanced providers setting updated:', checked)
       toast.success(checked ? 'Advanced providers enabled' : 'Advanced providers disabled')


### PR DESCRIPTION
## What problem(s) was I solving?

Users launching sessions with non-Anthropic models (OpenRouter, Baseten) had to re-select their preferred provider and model every time they opened the session launcher. This created unnecessary friction in the workflow, especially for users who primarily work with specific non-default models.

Related issues:
- [ENG-2191](https://linear.app/humanlayer/issue/ENG-2191/remember-last-model-choice-in-localstorage): Remember last model choice in localStorage

## What user-facing changes did I ship?

### Session Launcher Persistence
- Provider and model selections are now saved to localStorage and persist across sessions
- Each provider (Anthropic, OpenRouter, Baseten) maintains its own saved model preference
- When switching providers, the last used model for that provider is automatically restored
- Working seamlessly with existing API key persistence for each provider

### Settings Integration
- When "Advanced Providers" setting is toggled off, all saved provider/model preferences are cleared
- This prevents confusion by ensuring users return to Anthropic defaults when disabling the feature
- Provides a clean slate when re-enabling advanced providers

### Provider-Specific Model Memory
- Anthropic models are saved separately from OpenRouter/Baseten custom model strings
- Switching between providers restores each provider's last used model
- Empty/default selections are properly handled

## How I implemented it

### localStorage Keys Structure
Added new localStorage keys with provider-specific model storage:
- `humanlayer-provider`: Stores the last selected provider
- `humanlayer-model`: Stores Anthropic model selection
- `humanlayer-openrouter-model`: Stores OpenRouter custom model string
- `humanlayer-baseten-model`: Stores Baseten custom model string

### Helper Functions (`useSessionLauncher.ts`)
- `getSavedProvider()`: Returns saved provider or defaults to 'anthropic'
- `getSavedModel(provider)`: Returns the saved model for the specific provider
- `clearSavedModelPreferences()`: Clears all saved preferences (exported for settings integration)

### Store Initialization Updates
Modified all initialization points to use saved preferences:
- Initial store creation
- `close()` method - restores saved state when closing launcher
- `createNewSession()` method - uses saved preferences for new sessions
- `reset()` method - maintains saved preferences through reset

### Persistence on Configuration Changes
Updated `setConfig()` method to:
- Save provider selection when changed
- Save model to the correct provider-specific key
- Remove model from localStorage when cleared
- Maintain existing API key and additional directories persistence

### Settings Dialog Integration
- Import and call `clearSavedModelPreferences()` when disabling advanced providers
- Ensures clean state transition when toggling the feature

### Provider Switching Logic (`CommandInput.tsx`)
- When provider dropdown changes, automatically load that provider's saved model
- Maintains separation between different provider's model preferences
- Preserves API keys when switching between providers

## How to verify it

- [x] I have ensured `make check test` passes (frontend checks all pass; unrelated Python test failures in core async tests)

### Manual Testing Steps
1. **Basic Persistence Test**
   - [ ] Open session launcher
   - [ ] Select OpenRouter provider and enter model "openai/gpt-4o-mini"
   - [ ] Launch a session
   - [ ] Close and reopen launcher
   - [ ] Verify OpenRouter and "openai/gpt-4o-mini" are pre-selected

2. **Provider Switching Test**
   - [ ] With OpenRouter selected, switch to Anthropic
   - [ ] Select "Opus" model
   - [ ] Close and reopen launcher
   - [ ] Verify Anthropic and Opus are selected
   - [ ] Switch to OpenRouter
   - [ ] Verify "openai/gpt-4o-mini" is restored from earlier

3. **Baseten Provider Test**
   - [ ] Select Baseten provider
   - [ ] Enter model "deepseek-ai/DeepSeek-V3.1"
   - [ ] Close and reopen launcher
   - [ ] Verify Baseten and model are preserved

4. **Settings Integration Test**
   - [ ] Set up non-Anthropic provider and model
   - [ ] Go to Settings → Toggle OFF "Advanced Providers"
   - [ ] Close and reopen launcher
   - [ ] Verify it defaults to Anthropic with no custom selections
   - [ ] Re-enable "Advanced Providers"
   - [ ] Verify no old selections are restored (clean state)

5. **API Key Persistence Test**
   - [ ] Enter API keys for OpenRouter and Baseten
   - [ ] Switch between providers
   - [ ] Verify each provider's API key remains saved

## Description for the changelog

Added localStorage persistence for model selection preferences in session launcher. Provider and model choices are now remembered across sessions, with each provider maintaining its own model preference. Preferences are automatically cleared when disabling advanced providers in settings.

---

<img width="1200" height="675" alt="image" src="https://github.com/user-attachments/assets/3e8c993f-d3b8-456c-b9f1-f7da4ddc6dc3" />
🤖 Generated with [Claude Code](https://claude.ai/code)