### PR TITLE
fix(telemetry-modal): set focus to Enable Reporting button by default (ENG-2194)

### DIFF
--- a/humanlayer-wui/src/components/OptInTelemetryModal.tsx
+++ b/humanlayer-wui/src/components/OptInTelemetryModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { useStore } from '@/AppStore'
 import {
   Dialog,
@@ -11,6 +11,9 @@ import {
 import { Button } from '@/components/ui/button'
 import { Shield, Eye, EyeOff } from 'lucide-react'
 import { toast } from 'sonner'
+import { useHotkeys } from 'react-hotkeys-hook'
+import { HotkeyScopeBoundary } from './HotkeyScopeBoundary'
+import { HOTKEY_SCOPES } from '@/hooks/hotkeys/scopes'
 
 interface OptInTelemetryModalProps {
   open: boolean
@@ -18,8 +21,27 @@ interface OptInTelemetryModalProps {
 }
 
 export function OptInTelemetryModal({ open, onOpenChange }: OptInTelemetryModalProps) {
+  const enableButtonRef = useRef<HTMLButtonElement>(null)
   const { updateUserSettings } = useStore()
   const [isUpdating, setIsUpdating] = useState(false)
+
+  // Handle Cmd+Enter to always enable reporting
+  useHotkeys(
+    'meta+enter, ctrl+enter',
+    e => {
+      e.preventDefault()
+      e.stopPropagation()
+      if (!isUpdating) {
+        handleOptIn(true)
+      }
+    },
+    {
+      enabled: open,
+      enableOnFormTags: true,
+      preventDefault: true,
+      scopes: [HOTKEY_SCOPES.TELEMETRY_MODAL],
+    },
+  )
 
   const handleOptIn = async (enable: boolean) => {
     setIsUpdating(true)
@@ -42,64 +64,86 @@ export function OptInTelemetryModal({ open, onOpenChange }: OptInTelemetryModalP
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
-        <DialogHeader>
-          <div className="flex items-center gap-3">
-            <Shield className="h-6 w-6 text-blue-600" />
-            <DialogTitle>Performance & Error Reporting Opt-In</DialogTitle>
-          </div>
-          <DialogDescription className="text-left">
-            Share anonymous performance data and error reports to help us improve your experience and
-            fix issues faster.
-          </DialogDescription>
-        </DialogHeader>
+    <HotkeyScopeBoundary
+      scope={HOTKEY_SCOPES.TELEMETRY_MODAL}
+      isActive={open}
+      rootScopeDisabled={true}
+      componentName="OptInTelemetryModal"
+    >
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent
+          className="max-w-lg"
+          onOpenAutoFocus={e => {
+            e.preventDefault()
+            enableButtonRef.current?.focus()
+          }}
+        >
+          <DialogHeader>
+            <div className="flex items-center gap-3">
+              <Shield className="h-6 w-6 text-blue-600" />
+              <DialogTitle>Performance & Error Reporting Opt-In</DialogTitle>
+            </div>
+            <DialogDescription className="text-left">
+              Share anonymous performance data and error reports to help us improve your experience and
+              fix issues faster.
+            </DialogDescription>
+          </DialogHeader>
 
-        <div className="space-y-4">
-          <div>
-            <h4 className="flex items-center gap-2 text-sm font-medium text-[var(--terminal-accent)] mb-2">
-              <Eye className="h-4 w-4" />
-              What we collect:
-            </h4>
-            <ul className="text-sm text-muted-foreground space-y-1 ml-6">
-              <li>• JavaScript errors and crash reports</li>
-              <li>• Performance metrics (load times, memory usage)</li>
-            </ul>
+          <div className="space-y-4">
+            <div>
+              <h4 className="flex items-center gap-2 text-sm font-medium text-[var(--terminal-accent)] mb-2">
+                <Eye className="h-4 w-4" />
+                What we collect:
+              </h4>
+              <ul className="text-sm text-muted-foreground space-y-1 ml-6">
+                <li>• JavaScript errors and crash reports</li>
+                <li>• Performance metrics (load times, memory usage)</li>
+              </ul>
+            </div>
+
+            <div>
+              <h4 className="flex items-center gap-2 text-sm font-medium text-destructive mb-2">
+                <EyeOff className="h-4 w-4" />
+                We NEVER collect:
+              </h4>
+              <ul className="text-sm text-muted-foreground space-y-1 ml-6">
+                <li>• Your prompts or conversations</li>
+                <li>• Code contents or file paths</li>
+                <li>• API keys or personal information</li>
+                <li>• Working directory names</li>
+              </ul>
+            </div>
           </div>
 
-          <div>
-            <h4 className="flex items-center gap-2 text-sm font-medium text-destructive mb-2">
-              <EyeOff className="h-4 w-4" />
-              We NEVER collect:
-            </h4>
-            <ul className="text-sm text-muted-foreground space-y-1 ml-6">
-              <li>• Your prompts or conversations</li>
-              <li>• Code contents or file paths</li>
-              <li>• API keys or personal information</li>
-              <li>• Working directory names</li>
-            </ul>
+          <DialogFooter className="gap-3 mt-4">
+            <Button variant="ghost" onClick={() => handleOptIn(false)} disabled={isUpdating}>
+              No Thanks
+            </Button>
+            <Button
+              ref={enableButtonRef}
+              variant="default"
+              onClick={() => handleOptIn(true)}
+              disabled={isUpdating}
+            >
+              {isUpdating ? (
+                'Saving...'
+              ) : (
+                <>
+                  Enable Reporting
+                  <kbd className="ml-2 px-1 py-0.5 text-xs bg-muted/50 rounded">
+                    {navigator.platform.toLowerCase().includes('mac') ? '⌘' : 'Ctrl'}+⏎
+                  </kbd>
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+          <div className="bg-muted/50 p-3 rounded-lg text-xs uppercase tracking-wider">
+            <p className="text-xs text-muted-foreground text-right">
+              You can change this preference anytime in Settings
+            </p>
           </div>
-        </div>
-
-        <DialogFooter className="gap-3 mt-4">
-          <Button tabIndex={2} variant="ghost" onClick={() => handleOptIn(false)} disabled={isUpdating}>
-            No Thanks
-          </Button>
-          <Button
-            tabIndex={1}
-            variant="default"
-            onClick={() => handleOptIn(true)}
-            disabled={isUpdating}
-          >
-            {isUpdating ? 'Saving...' : 'Enable Reporting'}
-          </Button>
-        </DialogFooter>
-        <div className="bg-muted/50 p-3 rounded-lg text-xs uppercase tracking-wider">
-          <p className="text-xs text-muted-foreground text-right">
-            You can change this preference anytime in Settings
-          </p>
-        </div>
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
+    </HotkeyScopeBoundary>
   )
 }

--- a/humanlayer-wui/src/hooks/hotkeys/scopes.ts
+++ b/humanlayer-wui/src/hooks/hotkeys/scopes.ts
@@ -17,6 +17,7 @@ export const HOTKEY_SCOPES = {
   TITLE_EDITING: 'sessions.details.titleEditing',
   ADDITIONAL_DIRECTORIES: 'additionalDirectories',
   SESSION_LAUNCHER: 'sessions.launcher',
+  TELEMETRY_MODAL: 'telemetry-modal',
 } as const
 
 export type HotkeyScope = (typeof HOTKEY_SCOPES)[keyof typeof HOTKEY_SCOPES]


### PR DESCRIPTION
## What problem(s) was I solving?

Fixed incorrect focus behavior in the telemetry opt-in popup where the "No Thanks" button was receiving initial focus instead of the "Enable Reporting" button. Also implemented keyboard navigation shortcuts to improve accessibility and user experience.

Related issues:
- [ENG-2194](https://linear.app/humanlayer/issue/ENG-2194/set-focus-for-enable-telemetry-popup-to-default-to-yes): Set focus for "enable telemetry" popup to default to yes

## What user-facing changes did I ship?

### Focus Management
- "Enable Reporting" button now receives focus by default when the modal opens
- Users can immediately press Enter to enable telemetry reporting

### Keyboard Shortcuts
- Added Cmd+Enter (Mac) / Ctrl+Enter (Windows/Linux) to always enable reporting regardless of current focus
- Visual keyboard hint displayed on the "Enable Reporting" button showing the shortcut
- Platform-specific keyboard hint (⌘ for Mac, Ctrl for others)

### Hotkey Scope Isolation
- Implemented proper hotkey scope boundary to prevent background shortcuts from triggering while modal is open
- Tab/Shift+Tab navigation properly cycles between buttons without escaping to background elements
- Follows established patterns from SessionLauncher for consistent modal behavior

## How I implemented it

### Focus Management (`OptInTelemetryModal.tsx`)
- Added `useRef` to track the "Enable Reporting" button reference
- Used `onOpenAutoFocus` prop on `DialogContent` to override Radix Dialog's default focus behavior
- Prevented default focus and explicitly set focus to the enable button

### Keyboard Shortcuts
- Integrated `useHotkeys` hook with meta+enter/ctrl+enter bindings
- Configured with `enableOnFormTags: true` to work in all contexts
- Added visual keyboard hint that adapts to platform (Mac vs Windows/Linux)

### Hotkey Scope Boundary
- Added `TELEMETRY_MODAL: 'telemetry-modal'` to hotkey scopes registry
- Wrapped dialog in `HotkeyScopeBoundary` with `rootScopeDisabled={true}`
- Ensures background hotkeys (like j/k for session navigation) don't interfere

### Code Changes
- Removed ineffective `tabIndex` attributes that were being overridden
- Removed unnecessary `useEffect` for focus management in favor of `onOpenAutoFocus`
- Follows established modal patterns for consistency across the application

## How to verify it

- [x] I have ensured `make check test` passes (WUI checks all pass; unrelated Python async test failures pre-exist)

### Manual Testing
1. Clear telemetry opt-in state:
   ```javascript
   localStorage.removeItem('telemetry-opt-in-seen')
   ```

2. Reload the application to trigger the modal

3. Verify focus behavior:
   - "Enable Reporting" button should have visible focus ring immediately
   - No focus jumping to "No Thanks" after modal opens

4. Test keyboard navigation:
   - Tab moves focus from "Enable Reporting" to "No Thanks"
   - Shift+Tab moves focus back to "Enable Reporting"
   - Focus doesn't escape to background elements

5. Test keyboard shortcuts:
   - Enter activates the currently focused button
   - Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux) always enables reporting
   - Escape closes the modal

6. Test hotkey isolation:
   - While modal is open, try pressing 'j' or 'k' keys
   - Verify they don't navigate sessions in the background
   - After closing modal, verify normal hotkeys work again

## Description for the changelog

Fixed telemetry opt-in modal to focus "Enable Reporting" button by default and added Cmd+Enter/Ctrl+Enter keyboard shortcut for quick approval. Implemented proper hotkey scope isolation to prevent background shortcuts from interfering with modal interaction.