### PR TITLE
[ENG-2168] Fix todo sidebar icon inconsistency for in-progress tasks

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/components/TodoWidget.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/TodoWidget.tsx
@@ -1,5 +1,5 @@
 import { ConversationEvent } from '@/lib/daemon/types'
-import { CheckCircle, CircleDashed, Hourglass } from 'lucide-react'
+import { CheckCircle, CircleDashed, Clock } from 'lucide-react'
 
 // TODO(2): Consider extracting priority and status constants to shared types
 // TODO(3): Add animations for status changes
@@ -11,7 +11,7 @@ export function TodoWidget({ event }: { event: ConversationEvent }) {
   const pendingCount = todos.filter((todo: any) => todo.status === 'pending').length
   const iconClasses = 'w-3 h-3 align-middle relative top-[1px]'
   const statusToIcon = {
-    in_progress: <Hourglass className={iconClasses + ' text-[var(--terminal-warning)]'} />,
+    in_progress: <Clock className={iconClasses + ' text-[var(--terminal-warning)]'} />,
     pending: <CircleDashed className={iconClasses + ' text-[var(--terminal-fg-dim)]'} />,
     completed: <CheckCircle className={iconClasses + ' text-[var(--terminal-success)]'} />,
   }


### PR DESCRIPTION
## Summary
- Changed TodoWidget to use Clock icon instead of Hourglass for in-progress tasks
- Now matches the icon used in TodoWriteToolCallContent event box

## Background
The TodoWrite tool was using different icons for in-progress tasks:
- Sidebar (TodoWidget): used Hourglass icon
- Event box (TodoWriteToolCallContent): used Clock icon

This change ensures consistency across the UI by using the Clock icon in both places.

## Test plan
- [x] Verified the Clock icon is now used in both locations
- [x] Ran `bun run check` in humanlayer-wui - all checks pass
- [x] Ran `bun test` in humanlayer-wui - all tests pass (202 tests)

Linear: [ENG-2168](https://linear.app/humanlayer/issue/ENG-2168/todowrite-tool-and-todo-sidebar-use-different-icons-for-pending-and-in)

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Changed `TodoWidget` to use `Clock` icon for in-progress tasks, ensuring consistency with `TodoWriteToolCallContent`.
> 
>   - **Behavior**:
>     - Changed `TodoWidget` to use `Clock` icon for `in-progress` tasks instead of `Hourglass`.
>     - Ensures consistency with `TodoWriteToolCallContent` event box.
>   - **Files**:
>     - Updated `TodoWidget.tsx` to import `Clock` from `lucide-react` and use it for `in-progress` tasks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for e7604e6a89afdb1067798a193be04f3758bdce7e. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->