### PR TITLE
[ENG-2198] Allow opt+y on a session to enable bypass permissions from the session list view

### DIFF
--- a/humanlayer-wui/src/AppStore.ts
+++ b/humanlayer-wui/src/AppStore.ts
@@ -457,7 +457,7 @@ export const useStore = create<StoreState>((set, get) => ({
   ) => {
     try {
       // Calculate timeout in milliseconds if expiration is set
-      const timeoutMs = expiresAt ? expiresAt.getTime() - Date.now() : undefined
+      const timeoutMs = expiresAt ? Math.max(0, expiresAt.getTime() - Date.now()) : undefined
 
       // Update all sessions in parallel
       const results = await Promise.allSettled(

--- a/humanlayer-wui/src/components/internal/SessionDetail/DangerouslySkipPermissionsDialog.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/DangerouslySkipPermissionsDialog.tsx
@@ -21,6 +21,7 @@ interface DangerouslySkipPermissionsDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   onConfirm: (timeoutMinutes: number | null) => void
+  sessionCount?: number // Add for multi-session support
 }
 
 // Inner component that uses the hotkey scope stealing
@@ -28,7 +29,8 @@ const DangerouslySkipPermissionsDialogContent: FC<{
   onOpenChange: (open: boolean) => void
   onConfirm: (timeoutMinutes: number | null) => void
   isOpen: boolean
-}> = ({ onOpenChange, onConfirm, isOpen }) => {
+  sessionCount?: number
+}> = ({ onOpenChange, onConfirm, isOpen, sessionCount }) => {
   const [timeoutMinutes, setTimeoutMinutes] = useState<number | ''>(15)
   const [useTimeout, setUseTimeout] = useState(true)
   const timeoutInputRef = useRef<HTMLInputElement>(null)
@@ -94,12 +96,15 @@ const DangerouslySkipPermissionsDialogContent: FC<{
         <DialogTitle className="flex items-center gap-2 text-[var(--terminal-error)] text-base font-bold">
           <AlertTriangle className="h-4 w-4" />
           Bypass Permissions
+          {sessionCount && sessionCount > 1 && ` for ${sessionCount} Sessions`}
         </DialogTitle>
         <DialogDescription asChild>
           <div className="space-y-2">
             <p>
               Bypassing permissions will <strong>automatically accept ALL tool calls</strong> without
-              your approval. This includes:
+              your approval
+              {sessionCount && sessionCount > 1 ? ` for all ${sessionCount} selected sessions` : ''}.
+              This includes:
             </p>
             <ul className="list-disc list-inside space-y-1">
               <li>File edits and writes</li>
@@ -170,7 +175,9 @@ const DangerouslySkipPermissionsDialogContent: FC<{
           disabled={useTimeout && (timeoutMinutes === '' || timeoutMinutes === 0)}
           className="border-[var(--terminal-error)] text-[var(--terminal-error)] hover:bg-[var(--terminal-error)] hover:text-background focus-visible:border-[var(--terminal-error)] focus-visible:ring-[var(--terminal-error)]/50 disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          Bypass Permissions
+          {sessionCount && sessionCount > 1
+            ? `Bypass Permissions for ${sessionCount} Sessions`
+            : 'Bypass Permissions'}
           {!useTimeout || (timeoutMinutes !== '' && timeoutMinutes !== 0) ? (
             <kbd className="ml-1 px-1 py-0.5 text-xs bg-muted/50 rounded">
               {navigator.platform.toLowerCase().includes('mac') ? '⌘' : 'Ctrl'}+⏎
@@ -186,6 +193,7 @@ export const DangerouslySkipPermissionsDialog: FC<DangerouslySkipPermissionsDial
   open,
   onOpenChange,
   onConfirm,
+  sessionCount,
 }) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -213,6 +221,7 @@ export const DangerouslySkipPermissionsDialog: FC<DangerouslySkipPermissionsDial
               onOpenChange={onOpenChange}
               onConfirm={onConfirm}
               isOpen={open}
+              sessionCount={sessionCount}
             />
           </HotkeyScopeBoundary>
         )}

--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -41,6 +41,7 @@ interface SessionTableProps {
       onClick: () => void
     }
   }
+  onBypassPermissions?: (sessionIds: string[]) => void
 }
 
 export default function SessionTable({
@@ -55,6 +56,7 @@ export default function SessionTable({
   matchedSessions,
   archived = false,
   emptyState,
+  onBypassPermissions,
 }: SessionTableProps) {
   const { isOpen: isSessionLauncherOpen } = useSessionLauncher()
   const tableRef = useRef<HTMLTableElement>(null)
@@ -400,6 +402,35 @@ export default function SessionTable({
       enableOnFormTags: false,
     },
     [focusedSession, startEdit, editingSessionId],
+  )
+
+  // Bypass permissions hotkey
+  const isInlineRenameOpen = editingSessionId !== null
+  useHotkeys(
+    'alt+y, option+y',
+    () => {
+      if (!focusedSession && selectedSessions.size === 0) {
+        return
+      }
+
+      // Get sessions to bypass
+      const sessionsToBypass =
+        selectedSessions.size > 0
+          ? Array.from(selectedSessions)
+          : focusedSession
+            ? [focusedSession.id]
+            : []
+
+      if (sessionsToBypass.length > 0) {
+        onBypassPermissions?.(sessionsToBypass)
+      }
+    },
+    {
+      scopes: [tableScope],
+      enabled: !isSessionLauncherOpen && !isInlineRenameOpen,
+      preventDefault: true,
+    },
+    [focusedSession, selectedSessions, onBypassPermissions, isInlineRenameOpen],
   )
 
   return (

--- a/humanlayer-wui/src/hooks/hotkeys/scopes.ts
+++ b/humanlayer-wui/src/hooks/hotkeys/scopes.ts
@@ -3,6 +3,7 @@ export const HOTKEY_SCOPES = {
   ROOT: '.',
   SESSIONS: 'sessions',
   SESSIONS_ARCHIVED: 'sessions.archived',
+  SESSIONS_BYPASS_PERMISSIONS_MODAL: 'sessions.bypassPermissionsModal',
   SESSION_DETAIL: 'sessions.details',
   SESSION_DETAIL_ARCHIVED: 'sessions.details.archived',
   SESSION_DETAIL_DRAFT: 'sessions.details.draft',


### PR DESCRIPTION
## What problem(s) was I solving?

Users needed the ability to enable bypass permissions mode from the session list view, not just from the session detail view. This was particularly important for bulk operations where users want to enable bypass permissions on multiple sessions simultaneously.

Related issues:
- [ENG-2198](https://linear.app/humanlayer/issue/ENG-2198/allow-opty-on-a-session-to-enable-bypass-permissions-from-the-session): Allow opt+y on a session to enable bypass permissions from the session list view

## What user-facing changes did I ship?

### Session List View - Bypass Permissions
- **opt+y hotkey** now triggers bypass permissions modal from the session list
- **Smart toggle behavior**:
  - If bypass is already enabled → disables silently (no modal/toast)
  - If bypass is disabled → shows modal to enable with timeout configuration
- **Multi-select support**:
  - Works with shift+j/k selection
  - Shows session count in modal title (e.g., "Bypass Permissions for 5 Sessions")
  - Applies configuration to all selected sessions simultaneously
- **Visual indicators** update immediately for all affected sessions (shield icon with pulse animation)

### Keyboard Shortcuts
- `opt+y` / `alt+y` - Toggle bypass permissions for focused/selected sessions
- Modal shortcuts remain consistent:
  - `Cmd+Enter` / `Ctrl+Enter` - Confirm
  - `Escape` - Cancel

## How I implemented it

### Hotkey Handler (`SessionTable.tsx`)
- Added `onBypassPermissions` prop to SessionTable component
- Registered opt+y/alt+y hotkey that:
  - Works with single focused session
  - Works with multiple selected sessions (shift+j/k)
  - Disabled during inline rename to prevent conflicts

### Intelligent Toggle Logic (`SessionTablePage.tsx`)
- Implemented `handleBypassPermissions` with smart behavior:
  - Single session + already bypassing → direct disable (silent)
  - Single session + not bypassing → show modal
  - Multiple sessions + all bypassing → direct disable all (silent)
  - Multiple sessions + mixed/none bypassing → show modal for enable/refresh
- Added `handleDirectDisable` for silent disabling without modal

### Modal Enhancement (`DangerouslySkipPermissionsDialog.tsx`)
- Added optional `sessionCount` prop for multi-session support
- Updated UI to show session count in title and button text
- Modal text adapts: "for all 5 selected sessions" when multiple

### Store Method (`AppStore.ts`)
- Added `bulkSetBypassPermissions` method:
  - Parallel API calls for performance
  - Handles timeout calculation
  - Updates local state for all sessions
  - Clears selection after successful operation
  - Updates active detail view if affected

### Hotkey Scope Management
- Created new scope: `SESSIONS_BYPASS_PERMISSIONS_MODAL`
- Ensures modal hotkeys are properly isolated from background

## How to verify it

- [x] I have ensured `make check test` passes

### Manual Testing

1. **Single Session Toggle**:
   - Focus a session with `j`/`k` navigation
   - Press `opt+y` → modal should appear
   - Configure timeout and confirm → shield icon appears
   - Press `opt+y` again → bypass disables silently (no modal)

2. **Multi-Session Operations**:
   - Select multiple sessions with `shift+j`/`shift+k`
   - Press `opt+y` → modal shows "for X Sessions"
   - Confirm → all selected sessions show shield icon
   - Select all bypassing sessions and press `opt+y` → all disable silently

3. **Edge Cases**:
   - Try during inline rename (shift+r) → hotkey should be disabled
   - Test with no selection → nothing should happen
   - Test mixed state (some bypassing, some not) → modal should appear

4. **Visual Verification**:
   - Shield icon with red pulse animation when bypass enabled
   - Session count displayed correctly in modal
   - Selection cleared after bulk operation

## Description for the changelog

Added opt+y hotkey to enable/disable bypass permissions from the session list view with support for bulk operations on multiple selected sessions. Includes intelligent toggle behavior that silently disables when already active and shows configuration modal when enabling.