### PR TITLE
[ENG-1970] Add arrow key navigation support to SessionTable

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -142,7 +142,7 @@ export default function SessionTable({
   }, [focusedSession])
 
   useHotkeys(
-    'j',
+    'j, ArrowDown',
     () => {
       handleFocusNextSession?.()
     },
@@ -154,7 +154,7 @@ export default function SessionTable({
   )
 
   useHotkeys(
-    'k',
+    'k, ArrowUp',
     () => {
       handleFocusPreviousSession?.()
     },
@@ -165,9 +165,9 @@ export default function SessionTable({
     [handleFocusPreviousSession],
   )
 
-  // Bulk selection with shift+j/k
+  // Bulk selection with shift+j/k and shift+arrow keys
   useHotkeys(
-    'shift+j',
+    'shift+j, shift+ArrowDown',
     () => {
       if (focusedSession && sessions.length > 0) {
         bulkSelect(focusedSession.id, 'desc')
@@ -182,7 +182,7 @@ export default function SessionTable({
   )
 
   useHotkeys(
-    'shift+k',
+    'shift+k, shift+ArrowUp',
     () => {
       if (focusedSession && sessions.length > 0) {
         bulkSelect(focusedSession.id, 'asc')


### PR DESCRIPTION
## What problem(s) was I solving?

The session list table (SessionTable component) currently only supports vim-style j/k navigation for moving between sessions. Users who are not familiar with vim keybindings or prefer standard arrow keys have to learn new navigation patterns, creating unnecessary friction in the user experience. This is inconsistent with other parts of the application where arrow keys are already supported (SessionDetail view via ENG-1711, ThemeSelector, etc.).

## What user-facing changes did I ship?

### Arrow Key Navigation for Session List
- **ArrowDown** key now moves to the next session (same behavior as j)
- **ArrowUp** key now moves to the previous session (same behavior as k)
- **Shift+ArrowDown** selects multiple sessions downward (same as shift+j)
- **Shift+ArrowUp** selects multiple sessions upward (same as shift+k)
- Both navigation methods (j/k and arrow keys) work simultaneously, allowing users to choose their preferred style
- Works in both normal and archived session views
- Respects existing hotkey scope system (SESSIONS/SESSIONS_ARCHIVED scopes)
- Arrow keys are properly disabled when the session launcher or other modals are open

## How I implemented it

Modified the keyboard event handlers in `SessionTable.tsx` to accept comma-separated key combinations:
- Updated the `useHotkeys` call for next session navigation to accept both 'j' and 'ArrowDown'
- Updated the `useHotkeys` call for previous session navigation to accept both 'k' and 'ArrowUp'
- Updated bulk selection handlers to also accept shift+arrow key combinations
- Updated the comment to reflect the new arrow key support

This minimal change leverages the existing navigation infrastructure and follows the established pattern used elsewhere in the codebase (e.g., SessionDetail, ThemeSelector). The implementation respects the existing hotkey scope management system that was refactored in PR #616 (ENG-2162).

## How to verify it

- [x] I have ensured `make check test` passes

### Manual Testing Steps:
1. Open the session list view
2. Press **ArrowDown** - verify focus moves to the first/next session
3. Press **ArrowUp** - verify focus moves to the previous session
4. Press **j** and **k** - verify vim bindings still work
5. Hold **Shift** and press **ArrowDown** - verify bulk selection downward
6. Hold **Shift** and press **ArrowUp** - verify bulk selection upward
7. Open command palette (Cmd+K) - verify arrow keys don't affect background list
8. Switch to archived view (Tab) - verify arrow keys work there too
9. Test rapid arrow key presses - verify smooth navigation

### Edge Cases Tested:
- Empty session list (no sessions)
- Single session in list
- Navigation with search filter applied
- Interleaving j/k with arrow keys

## Description for the changelog

Add arrow key navigation support to session list table - users can now use up/down arrow keys as alternatives to j/k vim bindings for navigating and selecting sessions