### PR TITLE
Fix ROOT scope hotkey activation on initial app load

### DIFF
--- a/humanlayer-wui/src/components/HotkeyScopeBoundary.tsx
+++ b/humanlayer-wui/src/components/HotkeyScopeBoundary.tsx
@@ -71,7 +71,7 @@ export function HotkeyScopeBoundary({
     enableScope(scope)
 
     // Step 3: Ensure root is enabled if not disabled
-    if (!rootScopeDisabled && !currentActive.includes(HOTKEY_SCOPES.ROOT)) {
+    if (!rootScopeDisabled) {
       enableScope(HOTKEY_SCOPES.ROOT)
     }
 


### PR DESCRIPTION
The 'C' hotkey (and other ROOT scope hotkeys) were not working on initial app load.

Fixes ENG-2210

Full PR description coming shortly...

🤖 Generated with [Claude Code](https://claude.com/claude-code)