### PR TITLE
dexter/eng 2218 improve welcome message on first use

### DIFF
--- a/humanlayer-wui/src/components/internal/ArchivedSessionsEmptyState.tsx
+++ b/humanlayer-wui/src/components/internal/ArchivedSessionsEmptyState.tsx
@@ -1,0 +1,24 @@
+import { Archive } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+interface ArchivedSessionsEmptyStateProps {
+  onNavigateBack: () => void
+}
+
+export function ArchivedSessionsEmptyState({ onNavigateBack }: ArchivedSessionsEmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
+      <Archive className="h-12 w-12 text-muted-foreground mb-4" />
+
+      <h3 className="text-lg font-semibold mb-2">No archived sessions</h3>
+
+      <p className="text-sm text-muted-foreground mb-4 max-w-md">
+        Sessions you archive will appear here. Press ESC or click below to go back.
+      </p>
+
+      <Button onClick={onNavigateBack} variant="ghost">
+        View all sessions
+      </Button>
+    </div>
+  )
+}

--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -3,7 +3,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '.
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useEffect, useRef, useState } from 'react'
-import { CircleOff, CheckSquare, Square, FileText, Pencil, ShieldOff } from 'lucide-react'
+import { CircleOff, CheckSquare, Square, Pencil, ShieldOff } from 'lucide-react'
 import { getStatusTextClass } from '@/utils/component-utils'
 import { formatTimestamp, formatAbsoluteTimestamp } from '@/utils/formatting'
 import { highlightMatches } from '@/lib/fuzzy-search'
@@ -11,8 +11,6 @@ import { cn } from '@/lib/utils'
 import { useStore } from '@/AppStore'
 import { useSessionLauncher } from '@/hooks/useSessionLauncher'
 import { toast } from 'sonner'
-import { EmptyState } from './EmptyState'
-import type { LucideIcon } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { daemonClient } from '@/lib/daemon/client'
@@ -21,6 +19,8 @@ import { logger } from '@/lib/logging'
 import { DiscardDraftDialog } from './SessionDetail/components/DiscardDraftDialog'
 import { HOTKEY_SCOPES } from '@/hooks/hotkeys/scopes'
 import { HotkeyScopeBoundary } from '../HotkeyScopeBoundary'
+import { SessionsEmptyState } from './SessionsEmptyState'
+import { ArchivedSessionsEmptyState } from './ArchivedSessionsEmptyState'
 
 interface SessionTableProps {
   sessions: Session[]
@@ -34,15 +34,7 @@ interface SessionTableProps {
   matchedSessions?: Map<string, any>
   isArchivedView?: boolean // Add this to indicate if showing archived sessions
   isDraftsView?: boolean // Add this to indicate if showing drafts view
-  emptyState?: {
-    icon?: LucideIcon
-    title: string
-    message?: string
-    action?: {
-      label: string
-      onClick: () => void
-    }
-  }
+  onNavigateToSessions?: () => void // For archived view navigation
   onBypassPermissions?: (sessionIds: string[]) => void
 }
 
@@ -58,7 +50,7 @@ export default function SessionTable({
   matchedSessions,
   isArchivedView = false,
   isDraftsView = false,
-  emptyState,
+  onNavigateToSessions,
   onBypassPermissions,
 }: SessionTableProps) {
   const isSessionLauncherOpen = useSessionLauncher(state => state.isOpen)
@@ -763,14 +755,10 @@ export default function SessionTable({
             </TableBody>
           </Table>
         </>
-      ) : emptyState ? (
-        <EmptyState {...emptyState} />
+      ) : isArchivedView ? (
+        <ArchivedSessionsEmptyState onNavigateBack={() => onNavigateToSessions?.()} />
       ) : (
-        <EmptyState
-          icon={FileText}
-          title="No sessions found"
-          message={searchText ? `No sessions matching "${searchText}"` : 'No sessions yet'}
-        />
+        <SessionsEmptyState />
       )}
 
       {/* Discard Drafts Confirmation Dialog */}

--- a/humanlayer-wui/src/components/internal/SessionsEmptyState.tsx
+++ b/humanlayer-wui/src/components/internal/SessionsEmptyState.tsx
@@ -1,0 +1,46 @@
+import { Button } from '@/components/ui/button'
+import { daemonClient } from '@/lib/daemon/client'
+import { getLastWorkingDir } from '@/hooks'
+
+export function SessionsEmptyState() {
+  const handleCreateSession = async () => {
+    try {
+      const response = await daemonClient.launchSession({
+        query: '',
+        working_dir: getLastWorkingDir() || '~/',
+        draft: true,
+      })
+      window.location.hash = `#/sessions/${response.sessionId}`
+    } catch (error) {
+      console.error('Failed to create draft session:', error)
+    }
+  }
+
+  return (
+    <div className="flex justify-center py-20 px-8">
+      <div className="flex flex-col items-start w-full max-w-xl">
+        <h1 className="text-2xl font-semibold mb-8">Welcome</h1>
+
+        <div className="text-sm text-muted-foreground mb-8 space-y-4">
+          <p>
+            CodeLayer is a tool for using AI Coding Agents to solve hard problems in complex codebases.
+          </p>
+
+          <p>
+            It uses your default claude code settings and api keys and supports any agents / slash
+            commands you have configured.
+          </p>
+
+          <p>Create a session to get started.</p>
+        </div>
+
+        <Button onClick={handleCreateSession} size="lg">
+          Create Session{' '}
+          <kbd className="ml-2 pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
+            C
+          </kbd>
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/humanlayer-wui/src/pages/SessionTablePage.tsx
+++ b/humanlayer-wui/src/pages/SessionTablePage.tsx
@@ -4,10 +4,8 @@ import { useStore } from '@/AppStore'
 import { ViewMode } from '@/lib/daemon/types'
 import SessionTable from '@/components/internal/SessionTable'
 import { useHotkeys } from 'react-hotkeys-hook'
-import { useKeyboardNavigationProtection, getLastWorkingDir } from '@/hooks'
-import { daemonClient } from '@/lib/daemon'
+import { useKeyboardNavigationProtection } from '@/hooks'
 import { useSessionLauncher } from '@/hooks/useSessionLauncher'
-import { Inbox, Archive } from 'lucide-react'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { HOTKEY_SCOPES } from '@/hooks/hotkeys/scopes'
 import { DangerouslySkipPermissionsDialog } from '@/components/internal/SessionDetail/DangerouslySkipPermissionsDialog'
@@ -367,41 +365,7 @@ export function SessionTablePage() {
           matchedSessions={undefined}
           isArchivedView={viewMode === ViewMode.Archived}
           isDraftsView={viewMode === ViewMode.Drafts}
-          emptyState={
-            viewMode === ViewMode.Archived
-              ? {
-                  icon: Archive,
-                  title: 'No archived sessions',
-                  message:
-                    'Sessions you archive will appear here. Press ESC or click below to go back.',
-                  action: {
-                    label: 'View all sessions',
-                    onClick: () => setViewMode(ViewMode.Normal),
-                  },
-                }
-              : {
-                  icon: Inbox,
-                  title: 'No sessions yet',
-                  message: 'Create a new session by pressing "c" or clicking below.',
-                  action: {
-                    label: 'Create new session',
-                    onClick: async () => {
-                      // Create draft session and navigate directly
-                      try {
-                        const response = await daemonClient.launchSession({
-                          query: '', // Empty initial query for draft
-                          working_dir: getLastWorkingDir() || '~/',
-                          draft: true, // Create as draft
-                        })
-                        // Navigate directly to SessionDetail
-                        window.location.hash = `#/sessions/${response.sessionId}`
-                      } catch (error) {
-                        console.error('Failed to create draft session:', error)
-                      }
-                    },
-                  },
-                }
-          }
+          onNavigateToSessions={() => setViewMode(ViewMode.Normal)}
           onBypassPermissions={handleBypassPermissions}
         />
       </div>


### PR DESCRIPTION
- **feat(hld): add draft session state foundation**
- **feat(wui): enable draft session creation via 'c' hotkey**
- **feat(wui): add draft mode support to SessionDetail**
- **feat(hld): implement draft session launch and delete endpoints**
- **feat(wui): complete Phase 4 - remove SessionLauncher modal and integrate draft sessions**
- **feat(wui): Phase 4a fixes for draft session experience**
- **feat(wui): Additional UI improvements for draft sessions and navigation**
- **refactor: consolidate session filtering API parameters**
- **feat(wui): improve draft session discard UX with confirmation dialogs**
- **feat(sessions): introduce 'discarded' status for draft sessions**
- **mid directory rework**
- **fix: Restore SessionLauncher modal and fix build errors**
- **mct sweep**
- **feat: Add g>d shortcut and improve tab count display**
- **feat: Add ability to update working directory for draft sessions**
- **feat: Add editor_state field to sessions table for draft persistence**
- **feat: Add persistent editor state storage for draft sessions**
- **fix: Add missing columns to SQL queries causing sessions to not load**
- **feat: Persist daemon URL in localStorage for browser environments**
- **fix: Prevent draft editor state from being overwritten on navigation**
- **feat: improve UI consistency and keyboard shortcuts**
- **fix: show warning when attempting to archive drafts in all scenarios**
- **fix: correct discard draft keyboard shortcut to meta+shift+period**
- **feat: consolidate draft discard dialogs and enhance draft workflow**
- **feat: add dedicated title input for draft sessions**
- **mct sweep**
- **fix: auto-inject permission_prompt_tool when launching sessions**
- **feat: improve keyboard shortcuts for draft sessions and model selection**
- **mct sweep**
- **fix: refresh session list after launching draft session**
- **feat: clear selection and focus on tab navigation in SessionTable**
- **feat: refactor SessionTable empty states with improved welcome message**
