### PR TITLE
comment out noisy autoscroll log

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/hooks/useAutoScroll.ts
+++ b/humanlayer-wui/src/components/internal/SessionDetail/hooks/useAutoScroll.ts
@@ -84,7 +84,7 @@ export function useAutoScroll(
     const setupScrollHandler = () => {
       const container = containerRef.current
       if (!container) {
-        console.log('[useAutoScroll] Container not ready, will retry in 100ms')
+        // console.log('[useAutoScroll] Container not ready, will retry in 100ms')
         const retryTimer = setTimeout(setupScrollHandler, 100)
         return () => clearTimeout(retryTimer)
       }


### PR DESCRIPTION
## What problem(s) was I solving?

The `useAutoScroll` hook was generating excessive console noise during session initialization. Specifically, the log message "Container not ready, will retry in 100ms" would spam the console repeatedly during the container setup retry loop, making it difficult to debug other issues and cluttering the development console.

Related to [ENG-2223](https://linear.app/humanlayer/issue/ENG-2223): Remove autoscroll log noise

## What user-facing changes did I ship?

None - this is a developer experience improvement only. Users won't see any functional changes.

## How I implemented it

Commented out a single console.log statement in the `setupScrollHandler` function within `humanlayer-wui/src/components/internal/SessionDetail/hooks/useAutoScroll.ts:87`.

The log was particularly noisy because it fires every 100ms in a retry loop until the container reference becomes available during component initialization. This could result in dozens of log messages per session load.

## How to verify it

- [x] I have ensured `make check test` passes

### Manual Testing
1. Open the WUI in development mode
2. Navigate to a session detail view
3. Check the browser console - you should no longer see repeated "Container not ready, will retry in 100ms" messages during page load
4. Verify auto-scroll functionality still works correctly (scroll behavior unchanged)

## Description for the changelog

Reduced console noise by removing excessive logging from auto-scroll initialization retry loop.
