### PR TITLE
Update last working directory on draft launch

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -36,6 +36,7 @@ import { useRecentPaths } from '@/hooks/useRecentPaths'
 import { logger } from '@/lib/logging'
 import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
+import { LAST_WORKING_DIR_KEY } from '@/hooks/useSessionLauncher'
 
 interface SessionDetailProps {
   session: Session
@@ -637,6 +638,9 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
       // Launch the draft session with the prompt
       // Note: working directory is already updated when selected in the fuzzy finder
       await daemonClient.launchDraftSession(session.id, prompt)
+
+      // store working directory in localStorage
+      localStorage.setItem(LAST_WORKING_DIR_KEY, selectedDirectory || '')
 
       // Clear the input after successful launch
       responseEditor?.commands.setContent('')

--- a/humanlayer-wui/src/hooks/useSessionLauncher.ts
+++ b/humanlayer-wui/src/hooks/useSessionLauncher.ts
@@ -49,7 +49,7 @@ const isViewingSessionDetail = (): boolean => {
   return /^#\/sessions\/[^/]+$/.test(hash)
 }
 
-const LAST_WORKING_DIR_KEY = 'humanlayer-last-working-dir'
+export const LAST_WORKING_DIR_KEY = 'humanlayer-last-working-dir'
 const SESSION_LAUNCHER_QUERY_KEY = 'session-launcher-query'
 const OPENROUTER_API_KEY = 'humanlayer-openrouter-api-key'
 const BASETEN_API_KEY = 'humanlayer-baseten-api-key'


### PR DESCRIPTION
Resolve issue where last working directory is not stored on draft launch.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Store the last working directory in localStorage on draft session launch using `LAST_WORKING_DIR_KEY`.
> 
>   - **Behavior**:
>     - On draft session launch, store the selected working directory in localStorage using `LAST_WORKING_DIR_KEY` in `SessionDetail.tsx`.
>   - **Exports**:
>     - Export `LAST_WORKING_DIR_KEY` from `useSessionLauncher.ts` for use in `SessionDetail.tsx`.
>   - **Misc**:
>     - Update `SessionDetail.tsx` to use `LAST_WORKING_DIR_KEY` for localStorage operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for a6cd07908aef324aef7bbe375200cfe570d6186b. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->