### PR TITLE
fix: add retry loop to prevent concurrent push failures in research workflow

### DIFF
--- a/.github/workflows/linear-research-tickets.yml
+++ b/.github/workflows/linear-research-tickets.yml
@@ -146,7 +146,27 @@ jobs:
       - name: Sync research to thoughts
         id: sync-research-document
         run: |
-          cd thoughts && git add -A && git commit -m "Sync thoughts from CI for ${{ matrix.ticket_id}}" && git pull --rebase && git push
+          cd thoughts
+
+          # Pull with rebase for cleaner history
+          git pull --rebase
+
+          # Stage and commit our changes
+          git add -A
+          git commit -m "Sync thoughts from CI for ${{ matrix.ticket_id}}"
+
+          # Retry push up to 5 times
+          for i in {1..5}; do
+            git push && break || {
+              if [ $i -eq 5 ]; then
+                echo "Failed to push after 5 attempts"
+                exit 1
+              fi
+              echo "Push failed, attempt $i/5. Pulling and retrying..."
+              git pull --rebase
+              sleep 2
+            }
+          done
 
       # if the task fails, update the status to "research needed"
       - name: In event of failure reset status


### PR DESCRIPTION
## What problem(s) was I solving?

Fixed race condition in the `linear-research-tickets.yml` GitHub Actions workflow causing concurrent matrix jobs to fail when pushing to the thoughts repository with error:
```
! [rejected]        main -> main (fetch first)
error: failed to push some refs to 'github.com:humanlayer/thoughts.git'
hint: Updates were rejected because the remote contains work that you do not have locally.
```

The workflow runs multiple jobs concurrently via matrix strategy (one per ticket). The original implementation did `git pull --rebase && git push` in sequence, but another job could push between the pull and push operations, causing the push to fail.

Related GitHub Actions run that exhibited the failure:
- https://github.com/humanlayer/humanlayer/actions/runs/18200118467/job/51817731667

## What user-facing changes did I ship?

None - this is an internal CI/CD infrastructure fix. The workflow will now handle concurrent ticket research jobs more reliably without push failures.

## How I implemented it

### Changed Git Operations Flow
**Before:**
```bash
cd thoughts && git add -A && git commit -m "..." && git pull --rebase && git push
```

**After:**
```bash
cd thoughts

# Pull with rebase for cleaner history
git pull --rebase

# Stage and commit our changes
git add -A
git commit -m "Sync thoughts from CI for ${{ matrix.ticket_id}}"

# Retry push up to 5 times
for i in {1..5}; do
  git push && break || {
    if [ $i -eq 5 ]; then
      echo "Failed to push after 5 attempts"
      exit 1
    fi
    echo "Push failed, attempt $i/5. Pulling and retrying..."
    git pull --rebase
    sleep 2
  }
done
```

### Key Changes
1. **Pull before commit** - Get latest changes from remote before creating local commit
2. **Retry loop** - Up to 5 attempts to push, with pull --rebase on failure
3. **Backoff delay** - 2-second sleep between retries to reduce thundering herd
4. **Rebase for clean history** - Avoids merge commits since files don't conflict (each ticket has unique file paths)

### Why This Works
Since each matrix job processes a different ticket ID and writes to `thoughts/shared/tickets/{ticket_id}.md` (unique paths), there are no actual file conflicts. The issue is purely a timing race condition where:
- Job A: pull → commit → push ✓
- Job B: pull → commit → push ✗ → pull (gets Job A's commit) → push ✓

The retry loop handles this gracefully.

## How to verify it

- [ ] Monitor future runs of the `linear-research-tickets.yml` workflow when multiple tickets are processed concurrently
- [ ] Verify that the "Sync research to thoughts" step completes successfully for all matrix jobs
- [ ] Check that no jobs fail with "Updates were rejected" errors

### Manual Testing
Can trigger the workflow manually with:
```bash
gh workflow run "Linear: Research Task" --repo humanlayer/humanlayer
```

Then monitor the workflow runs to ensure all matrix jobs complete successfully.

## Description for the changelog

Fixed race condition in linear-research-tickets workflow causing concurrent matrix jobs to fail when pushing to thoughts repository. Added retry loop with pull --rebase to handle concurrent pushes gracefully.
