### PR TITLE
feat: configure all Claude workflows to use opus model

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,7 +34,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          model: "claude-opus-4-20250514"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/linear-create-plan.yml
+++ b/.github/workflows/linear-create-plan.yml
@@ -129,7 +129,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: >
-          cd humanlayer && claude --dangerously-skip-permissions -p '/create_plan ${{ env.TICKET_FILE_PATH }} 
+          cd humanlayer && claude --dangerously-skip-permissions --model opus -p '/create_plan ${{ env.TICKET_FILE_PATH }} 
             Start by reading the ticket file and all of the comments in it. 
             Pay extra code attention to the comments - if you (LinearLayer/claude) are mentioned in a comment you should treat that comment as an instruction.
             Then, locate the research for the ticket in thoughts/shared/research.

--- a/.github/workflows/linear-implement-plan.yml
+++ b/.github/workflows/linear-implement-plan.yml
@@ -174,7 +174,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY}}
           GH_TOKEN: ${{ github.token }}
         run: >
-          cd humanlayer && claude --dangerously-skip-permissions -p '/implement_plan ${{ env.TICKET_FILE_PATH }}
+          cd humanlayer && claude --dangerously-skip-permissions --model opus -p '/implement_plan ${{ env.TICKET_FILE_PATH }}
             Start by reading the ticket file and all of the comments in it. 
             Pay extra code attention to the comments - if you (LinearLayer/claude are mentioned in a comment you should treat that comment as an instruction).
             Then, locate the research and the implementation plan for the ticket in thoughts/shared/research and thoughts/shared/plans.
@@ -195,7 +195,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ github.token }}
         run: >
-          cd humanlayer && claude --dangerously-skip-permissions -p "/ci_commit"
+          cd humanlayer && claude --dangerously-skip-permissions --model opus -p "/ci_commit"
 
       - name: Pull and merge before push (use claude to resolve any conflicts)
         id: pull-before-push
@@ -212,7 +212,7 @@ jobs:
             git pull origin $branch || {
               if git diff --name-only --diff-filter=U | grep -q .; then
                 echo "Merge conflicts detected, using Claude to resolve"
-                claude --dangerously-skip-permissions -p "There are merge conflicts in the current branch. Please resolve all merge conflicts by:
+                claude --dangerously-skip-permissions --model opus -p "There are merge conflicts in the current branch. Please resolve all merge conflicts by:
                 1. Reading the conflicted files
                 2. Understanding both changes
                 3. Resolving the conflicts appropriately
@@ -238,7 +238,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          cd humanlayer && claude --dangerously-skip-permissions -p '/ci_describe_pr 
+          cd humanlayer && claude --dangerously-skip-permissions --model opus -p '/ci_describe_pr 
 
           The changes for this PR have now been pushed to origin with the branch name "${{ steps.retrieve-branch-name.outputs.branch }}".
           Please create a PR for this issue.

--- a/.github/workflows/linear-research-tickets.yml
+++ b/.github/workflows/linear-research-tickets.yml
@@ -129,7 +129,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: >
-          cd humanlayer && claude --dangerously-skip-permissions -p '/research_codebase ${{ env.TICKET_FILE_PATH }} 
+          cd humanlayer && claude --dangerously-skip-permissions --model opus -p '/research_codebase ${{ env.TICKET_FILE_PATH }} 
             Start by reading the ticket and all of the comments.
             Pay extra code attention to the comments - if you (LinearLayer/claude) are mentioned in a comment you should treat that comment as an instruction.
             Also check /thoughts/shared/images/${{matrix.ticket_id}} for any relevant images and read any you find.


### PR DESCRIPTION
## Summary
Updated all GitHub workflow files to use Claude Opus 4 instead of the default Sonnet model for better performance and capabilities in automated workflows.

## Changes
- **claude-code-review.yml**: Uncommented opus model configuration
- **linear-create-plan.yml**: Added `--model opus` flag to Claude CLI invocation
- **linear-implement-plan.yml**: Added `--model opus` flag to all Claude CLI invocations (implement_plan, ci_commit, merge conflict resolution, ci_describe_pr)
- **linear-research-tickets.yml**: Added `--model opus` flag to Claude CLI invocation

## Test plan
- [ ] Verify workflows run successfully with opus model
- [ ] Monitor automated Linear ticket processing for improved results

🤖 Generated with [Claude Code](https://claude.com/claude-code)