### PR TITLE
fix(draft-mode): fix Cmd+Enter hotkey not working outside editor focus

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -907,7 +907,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
 
   // Cmd+Enter handler for launching draft sessions
   useHotkeys(
-    'cmd+enter, ctrl+enter',
+    'meta+enter, ctrl+enter',
     e => {
       e.preventDefault()
       e.stopPropagation()
@@ -936,7 +936,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
     {
       enabled: isDraft,
       preventDefault: true,
-      enableOnFormTags: true, // Important: allows hotkey to work in input fields
+      enableOnFormTags: ['INPUT', 'TEXTAREA', 'SELECT'], // Explicit array to ensure it works in form fields
       scopes: [HOTKEY_SCOPES.DRAFT_LAUNCHER],
     },
     [selectedDirectory, session.workingDir, responseEditor, handleLaunchDraft],
@@ -944,7 +944,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
 
   // Cmd+Shift+. handler for discarding draft sessions
   useHotkeys(
-    'cmd+shift+., ctrl+shift+.',
+    'meta+shift+., ctrl+shift+.',
     () => {
       setShowDiscardDialog(true)
     },

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -202,10 +202,16 @@ function OmniSpinner({ randomVerb, spinnerType }: { randomVerb: string; spinnerT
 function SessionDetail({ session, onClose }: SessionDetailProps) {
   // Note: enableScope/disableScope removed - now handled by HotkeyScopeBoundary
 
+  // Check if this is a draft session
+  const isDraft = session.status === SessionStatus.Draft
+
   // Determine the appropriate scope based on session state
-  const detailScope = session?.archived
-    ? HOTKEY_SCOPES.SESSION_DETAIL_ARCHIVED
-    : HOTKEY_SCOPES.SESSION_DETAIL
+  // Draft sessions get their own scope with different hotkey behaviors
+  const detailScope = isDraft
+    ? HOTKEY_SCOPES.DRAFT_LAUNCHER
+    : session?.archived
+      ? HOTKEY_SCOPES.SESSION_DETAIL_ARCHIVED
+      : HOTKEY_SCOPES.SESSION_DETAIL
 
   const [isWideView, setIsWideView] = useState(false)
   const [expandedToolResult, setExpandedToolResult] = useState<ConversationEvent | null>(null)
@@ -225,9 +231,6 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
   const [selectedDirectory, setSelectedDirectory] = useState<string>(() => {
     return session.workingDir || ''
   })
-
-  // Check if this is a draft session
-  const isDraft = session.status === SessionStatus.Draft
 
   // Get recent paths for draft directory selection
   const { paths: recentPaths } = useRecentPaths()
@@ -899,41 +902,124 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
     }
   }, [session.id, activeScopes, dangerousSkipPermissionsDialogOpen, updateSessionOptimistic])
 
-  // Add Option+A handler for auto-accept edits mode
+  // ===== DRAFT MODE HOTKEYS =====
+  // These only work when in draft mode (DRAFT_LAUNCHER scope)
+
+  // Cmd+Enter handler for launching draft sessions
+  useHotkeys(
+    'cmd+enter, ctrl+enter',
+    e => {
+      e.preventDefault()
+      e.stopPropagation()
+
+      // Check if editor has content
+      const prompt = responseEditor?.getText() || ''
+      if (!prompt.trim()) {
+        toast.error('Please enter a prompt', {
+          description: 'Cannot launch an empty session',
+        })
+        return
+      }
+
+      // Check if working directory is set
+      const workingDir = selectedDirectory || session.workingDir
+      if (!workingDir) {
+        toast.error('Please select a working directory', {
+          description: 'You must choose a directory before launching the session',
+        })
+        return
+      }
+
+      // Launch the draft
+      handleLaunchDraft()
+    },
+    {
+      enabled: isDraft,
+      preventDefault: true,
+      enableOnFormTags: true, // Important: allows hotkey to work in input fields
+      scopes: [HOTKEY_SCOPES.DRAFT_LAUNCHER],
+    },
+    [selectedDirectory, session.workingDir, responseEditor, handleLaunchDraft],
+  )
+
+  // Cmd+Shift+. handler for discarding draft sessions
+  useHotkeys(
+    'cmd+shift+., ctrl+shift+.',
+    () => {
+      setShowDiscardDialog(true)
+    },
+    {
+      enabled: isDraft,
+      preventDefault: true,
+      scopes: [HOTKEY_SCOPES.DRAFT_LAUNCHER],
+    },
+  )
+
+  // Option+A handler for auto-accept edits mode (draft version)
   useHotkeys(
     'alt+a, option+a',
-    handleToggleAutoAccept,
+    e => {
+      e.preventDefault()
+      handleToggleAutoAccept()
+    },
     {
+      enabled: isDraft,
       preventDefault: true,
-      scopes: [detailScope],
+      enableOnFormTags: ['INPUT', 'TEXTAREA', 'SELECT'], // Explicit to ensure it works in forms
+      scopes: [HOTKEY_SCOPES.DRAFT_LAUNCHER],
     },
     [handleToggleAutoAccept],
   )
 
-  // Add Option+Y handler for dangerously skip permissions mode
+  // Option+Y handler for dangerously skip permissions mode (draft version)
   useHotkeys(
     'alt+y, option+y',
-    handleToggleDangerouslySkipPermissions,
+    e => {
+      e.preventDefault()
+      handleToggleDangerouslySkipPermissions()
+    },
     {
+      enabled: isDraft,
       preventDefault: true,
-      scopes: [detailScope],
+      enableOnFormTags: ['INPUT', 'TEXTAREA', 'SELECT'], // Explicit to ensure it works in forms
+      scopes: [HOTKEY_SCOPES.DRAFT_LAUNCHER],
     },
     [handleToggleDangerouslySkipPermissions],
   )
 
-  // Add Cmd+Shift+. handler for discarding draft sessions
+  // ===== NON-DRAFT MODE HOTKEYS =====
+  // These only work when NOT in draft mode (SESSION_DETAIL scope)
+
+  // Option+A handler for auto-accept edits mode (non-draft version)
   useHotkeys(
-    'cmd+shift+., ctrl+shift+.',
-    () => {
-      if (isDraft) {
-        setShowDiscardDialog(true)
-      }
+    'alt+a, option+a',
+    e => {
+      e.preventDefault()
+      handleToggleAutoAccept()
     },
     {
+      enabled: !isDraft,
       preventDefault: true,
-      scopes: SessionDetailHotkeysScope,
+      enableOnFormTags: ['INPUT', 'TEXTAREA', 'SELECT'], // Explicit to ensure it works in forms
+      scopes: [HOTKEY_SCOPES.SESSION_DETAIL, HOTKEY_SCOPES.SESSION_DETAIL_ARCHIVED],
     },
-    [isDraft],
+    [handleToggleAutoAccept],
+  )
+
+  // Option+Y handler for dangerously skip permissions mode (non-draft version)
+  useHotkeys(
+    'alt+y, option+y',
+    e => {
+      e.preventDefault()
+      handleToggleDangerouslySkipPermissions()
+    },
+    {
+      enabled: !isDraft,
+      preventDefault: true,
+      enableOnFormTags: ['INPUT', 'TEXTAREA', 'SELECT'], // Explicit to ensure it works in forms
+      scopes: [HOTKEY_SCOPES.SESSION_DETAIL, HOTKEY_SCOPES.SESSION_DETAIL_ARCHIVED],
+    },
+    [handleToggleDangerouslySkipPermissions],
   )
 
   // Handle dialog confirmation
@@ -1320,7 +1406,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
   return (
     <HotkeyScopeBoundary
       scope={detailScope}
-      componentName={`SessionDetail-${session?.archived ? 'archived' : 'normal'}`}
+      componentName={`SessionDetail-${isDraft ? 'draft' : session?.archived ? 'archived' : 'normal'}`}
     >
       <section className="flex flex-col h-full gap-3">
         {/* Unified header with working directory */}

--- a/humanlayer-wui/src/hooks/hotkeys/scopes.ts
+++ b/humanlayer-wui/src/hooks/hotkeys/scopes.ts
@@ -7,6 +7,7 @@ export const HOTKEY_SCOPES = {
   SESSION_DETAIL: 'sessions.details',
   SESSION_DETAIL_ARCHIVED: 'sessions.details.archived',
   SESSION_DETAIL_DRAFT: 'sessions.details.draft',
+  DRAFT_LAUNCHER: 'sessions.details.draftLauncher',
   SESSION_DETAIL_FORK_IN_PROGRESS: 'sessions.details.forkInProgress',
   FORK_MODAL: 'sessions.details.forkModal',
   TOOL_RESULT_MODAL: 'sessions.details.toolResultModal',


### PR DESCRIPTION
## What problem(s) was I solving?

Fixed keyboard shortcuts not working correctly in draft mode for the CodeLayer UI. The main issue was that Cmd+Enter (for launching a session) only worked when the TipTap editor had focus, but should work from anywhere within the draft view.

Related issues:
- [ENG-2248](https://linear.app/humanlayer/issue/ENG-2248): Draft mode keyboard shortcut issues

## What user-facing changes did I ship?

### Fixed Keyboard Shortcuts
- **Cmd+Enter** now works from any focus state within the draft view (not just when the editor is focused)
- **Option+A** (toggle auto-accept) works without inserting unicode character 'å'
- **Option+Y** (toggle dangerous skip permissions) works without inserting unicode character '¥'
- **Cmd+Shift+.** (discard draft) continues to work correctly

### Scope Isolation
- Draft sessions now use a dedicated `DRAFT_LAUNCHER` scope to prevent hotkey conflicts with non-draft sessions
- Proper separation between draft and non-draft hotkey behaviors

## How I implemented it

### Root Cause
The react-hotkeys-hook library v4.0.0+ introduced a breaking change that deprecated `cmd` and `command` modifiers in favor of `meta`. The code was using `'cmd+enter'` which the library no longer recognized.

### Changes Made
1. **Updated hotkey patterns** (`SessionDetail.tsx`):
   - Changed `'cmd+enter'` to `'meta+enter'`
   - Changed `'cmd+shift+.'` to `'meta+shift+.'`

2. **Fixed unicode character insertion**:
   - Added explicit `e.preventDefault()` calls in Option+A and Option+Y handlers
   - Updated `enableOnFormTags` to use explicit array `['INPUT', 'TEXTAREA', 'SELECT']`

3. **Improved scope management**:
   - Added `DRAFT_LAUNCHER` scope definition
   - Draft sessions now use their own isolated scope
   - Separated draft and non-draft hotkey registrations with `enabled` flags

## How to verify it

- [x] I have ensured `make check test` passes

### Manual Testing
1. **Test Cmd+Enter from different focus states:**
   - Focus on the TipTap editor → Press Cmd+Enter → ✅ Session launches
   - Tab to Launch button → Press Cmd+Enter → ✅ Session launches
   - Click on directory input → Press Cmd+Enter → ✅ Session launches
   - Click on model selector → Press Cmd+Enter → ✅ Session launches
   - Click on empty space → Press Cmd+Enter → ✅ Session launches

2. **Test Option+A and Option+Y:**
   - Press Option+A → ✅ Toggles auto-accept without inserting 'å'
   - Press Option+Y → ✅ Toggles permissions without inserting '¥'

3. **Test edge cases:**
   - Empty editor → Shows "Please enter a prompt" error
   - No working directory → Shows "Please select a working directory" error
   - Non-draft mode → Hotkeys don't fire (proper scope isolation)

## Description for the changelog

Fixed draft mode keyboard shortcuts in CodeLayer UI - Cmd+Enter now works from any focus state, and Option+A/Y no longer insert unicode characters. Updated to react-hotkeys-hook v4 API.