### PR TITLE
Sundeep/eng 2200 add error boundaries to session details and session list

### DIFF
--- a/humanlayer-wui/src/components/internal/ConversationStream/ConversationEventRow.stories.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/ConversationEventRow.stories.tsx
@@ -1127,3 +1127,50 @@ export const MCPLinearListIssuesToolCall: Story = {
     },
   },
 }
+
+// Error Boundary Demo - shows error boundary with compact inline fallback UI
+export const ErrorBoundaryDemo: Story = {
+  args: {} as any,
+  render: () => {
+    // Create an event that throws when the component tries to access properties during render
+    const brokenEvent = new Proxy(
+      {
+        id: 1,
+        sessionId: 'test-session',
+        claudeSessionId: 'test-claude-session',
+        sequence: 1,
+        createdAt: new Date(),
+        isCompleted: false,
+      },
+      {
+        get(target, prop) {
+          // Throw error when component tries to access eventType during render
+          if (prop === 'eventType') {
+            throw new Error('Test error: ConversationEventRow rendering failed')
+          }
+          return (target as any)[prop]
+        },
+      },
+    ) as ConversationEvent
+
+    return (
+      <ConversationEventRow
+        event={brokenEvent}
+        shouldIgnoreMouseEvent={() => false}
+        setFocusedEventId={() => {}}
+        setFocusSource={() => {}}
+        isFocused={false}
+        isLast={true}
+        responseEditorIsFocused={false}
+      />
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates error boundary behavior by using a Proxy that throws when the component accesses properties during render. Shows the compact "response-editor" variant fallback UI with refresh functionality.',
+      },
+    },
+  },
+}

--- a/humanlayer-wui/src/components/internal/ConversationStream/ConversationEventRow.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/ConversationEventRow.tsx
@@ -20,6 +20,7 @@ import {
   FileText,
   List,
   Brain,
+  AlertCircle,
 } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { formatAbsoluteTimestamp, formatTimestamp } from '@/utils/formatting'
@@ -703,11 +704,35 @@ function ConversationEventRowInner({
   )
 }
 
+// Custom error fallback component for ConversationEventRow
+function ConversationEventRowErrorFallback({
+  error,
+  resetError,
+}: {
+  error: Error
+  resetError: () => void
+}) {
+  return (
+    <div className="flex flex-col space-y-2 p-3 text-sm text-muted-foreground">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-2">
+          <AlertCircle className="w-4 h-4" />
+          <span>Error rendering event</span>
+        </div>
+        <Button onClick={resetError} variant="outline" size="sm" className="h-6 text-xs">
+          Reload Session
+        </Button>
+      </div>
+      <div className="text-xs text-destructive">{error.message}</div>
+    </div>
+  )
+}
+
 // Export wrapped version with error boundary
 export function ConversationEventRow(props: ConversationEventRowProps) {
   return (
     <SentryErrorBoundary
-      variant="response-editor"
+      fallback={ConversationEventRowErrorFallback}
       componentName="ConversationEventRow"
       handleRefresh={() => {
         // Extract session ID from URL and reload

--- a/humanlayer-wui/src/components/internal/ConversationStream/ConversationEventRow.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/ConversationEventRow.tsx
@@ -5,6 +5,7 @@ import type {
   ConversationEventRoleEnum,
 } from '@humanlayer/hld-sdk'
 import { ConversationEventType, ConversationRole } from '@/lib/daemon'
+import { SentryErrorBoundary } from '@/components/ErrorBoundary'
 import {
   Bot,
   User,
@@ -343,7 +344,7 @@ export interface ConversationEventRowProps extends React.HTMLAttributes<HTMLDivE
   onCancelDeny?: () => void
 }
 
-export function ConversationEventRow({
+function ConversationEventRowInner({
   event,
   toolResult,
   ref,
@@ -699,5 +700,27 @@ export function ConversationEventRow({
         messageContent
       )}
     </ConversationEventRowShell>
+  )
+}
+
+// Export wrapped version with error boundary
+export function ConversationEventRow(props: ConversationEventRowProps) {
+  return (
+    <SentryErrorBoundary
+      variant="response-editor"
+      componentName="ConversationEventRow"
+      handleRefresh={() => {
+        // Extract session ID from URL and reload
+        const sessionId = window.location.hash.match(/sessions\/([^/?]+)/)?.[1]
+        if (sessionId) {
+          window.location.href = `/#/sessions/${sessionId}`
+        } else {
+          window.location.href = '/#/'
+        }
+      }}
+      refreshButtonText="Reload Session"
+    >
+      <ConversationEventRowInner {...props} />
+    </SentryErrorBoundary>
   )
 }

--- a/humanlayer-wui/src/components/internal/ConversationStream/TaskGroupEventRow.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/TaskGroupEventRow.tsx
@@ -6,6 +6,7 @@ import { StatusBadge } from './EventContent/StatusBadge'
 import { ConversationEvent, ConversationEventType } from '@/lib/daemon/types'
 import { formatTimestamp, formatAbsoluteTimestamp } from '@/utils/formatting'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { SentryErrorBoundary } from '@/components/ErrorBoundary'
 
 interface TaskGroupEventRowProps extends Omit<ConversationEventRowProps, 'event'> {
   group: TaskEventGroup
@@ -15,7 +16,7 @@ interface TaskGroupEventRowProps extends Omit<ConversationEventRowProps, 'event'
   focusedEventId?: number | null
 }
 
-export function TaskGroupEventRow({
+function TaskGroupEventRowInner({
   group,
   isExpanded,
   onToggle,
@@ -162,5 +163,26 @@ export function TaskGroupEventRow({
         </div>
       )}
     </div>
+  )
+}
+
+// Export wrapped version with error boundary
+export function TaskGroupEventRow(props: TaskGroupEventRowProps) {
+  return (
+    <SentryErrorBoundary
+      variant="response-editor"
+      componentName="TaskGroupEventRow"
+      handleRefresh={() => {
+        const sessionId = window.location.hash.match(/sessions\/([^/?]+)/)?.[1]
+        if (sessionId) {
+          window.location.href = `/#/sessions/${sessionId}`
+        } else {
+          window.location.href = '/#/'
+        }
+      }}
+      refreshButtonText="Reload Session"
+    >
+      <TaskGroupEventRowInner {...props} />
+    </SentryErrorBoundary>
   )
 }

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.stories.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import SessionDetail from './SessionDetail'
+import { Session, SessionStatus } from '@/lib/daemon/types'
+import { MemoryRouter } from 'react-router'
+
+const meta = {
+  title: 'Internal/SessionDetail',
+  component: SessionDetail,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <MemoryRouter>
+        <div className="h-screen w-full">
+          <Story />
+        </div>
+      </MemoryRouter>
+    ),
+  ],
+} satisfies Meta<typeof SessionDetail>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// Helper to create valid session
+const createValidSession = (id: string, overrides?: Partial<Session>): Session => ({
+  id,
+  runId: `run-${id}`,
+  status: SessionStatus.Running,
+  query: 'Implement user authentication feature',
+  createdAt: new Date('2025-10-03T10:00:00Z'),
+  lastActivityAt: new Date('2025-10-03T10:15:00Z'),
+  workingDir: '/Users/test/project',
+  summary: 'Working on user authentication',
+  model: 'claude-sonnet-4',
+  archived: false,
+  ...overrides,
+})
+
+// Basic working story
+export const Default: Story = {
+  args: {
+    session: createValidSession('session-1'),
+    onClose: () => console.log('Close clicked'),
+  },
+}
+
+// Completed session
+export const Completed: Story = {
+  args: {
+    session: createValidSession('session-2', {
+      status: SessionStatus.Completed,
+      query: 'Fix bug in payment processing',
+      summary: 'Fixed payment processing bug',
+    }),
+    onClose: () => console.log('Close clicked'),
+  },
+}
+
+// Draft session
+export const Draft: Story = {
+  args: {
+    session: createValidSession('session-3', {
+      status: SessionStatus.Draft,
+      query: 'Add dark mode support',
+      summary: 'Draft: Dark mode implementation',
+    }),
+    onClose: () => console.log('Close clicked'),
+  },
+}
+
+// Error boundary story - demonstrates error handling
+export const ErrorBoundaryDemo: Story = {
+  args: {} as any,
+  render: () => {
+    // Create a session that throws when the component tries to access properties during render
+    const brokenSession = new Proxy(
+      {
+        id: 'broken-session',
+        runId: 'broken-run',
+        createdAt: new Date(),
+        lastActivityAt: new Date(),
+        workingDir: '/test/path',
+      },
+      {
+        get(target, prop) {
+          // Throw error when component tries to access query during render
+          if (prop === 'query') {
+            throw new Error('Test error: SessionDetail rendering failed')
+          }
+          return (target as any)[prop]
+        },
+      },
+    ) as Session
+
+    return <SessionDetail session={brokenSession} onClose={() => {}} />
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates error boundary behavior by using a Proxy that throws when the component accesses properties during render. Shows the centered "session-detail" variant fallback UI with "Something went wrong" message and "Reload Session" button.',
+      },
+    },
+  },
+}

--- a/humanlayer-wui/src/components/internal/SessionTable.stories.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import SessionTable from './SessionTable'
+import { Session, SessionStatus } from '@/lib/daemon/types'
+
+const meta = {
+  title: 'Internal/SessionTable',
+  component: SessionTable,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <div className="p-4 h-screen">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof SessionTable>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// Helper to create valid sessions
+const createValidSession = (id: string, overrides?: Partial<Session>): Session => ({
+  id,
+  runId: `run-${id}`,
+  status: SessionStatus.Running,
+  query: 'Test query',
+  createdAt: new Date(),
+  lastActivityAt: new Date(),
+  workingDir: '/Users/test/project',
+  summary: `Test session ${id}`,
+  model: 'claude-sonnet-4',
+  archived: false,
+  ...overrides,
+})
+
+// Basic working story
+export const Default: Story = {
+  args: {
+    sessions: [
+      createValidSession('1'),
+      createValidSession('2', { status: SessionStatus.Completed }),
+      createValidSession('3', { status: SessionStatus.Draft }),
+    ],
+    focusedSession: null,
+  },
+}
+
+// Error boundary story - demonstrates error handling
+export const ErrorBoundaryDemo: Story = {
+  args: {} as any,
+  render: () => {
+    // Create a session that throws when the component tries to access properties during render
+    const brokenSession = new Proxy(
+      {
+        id: 'broken-session',
+        runId: 'broken-run',
+        createdAt: new Date(),
+        lastActivityAt: new Date(),
+      },
+      {
+        get(target, prop) {
+          // Throw error when component tries to access status during render
+          if (prop === 'status') {
+            throw new Error('Test error: Session table rendering failed')
+          }
+          return (target as any)[prop]
+        },
+      },
+    ) as Session
+
+    return <SessionTable sessions={[brokenSession]} focusedSession={null} />
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates error boundary behavior by using a Proxy that throws when the component accesses properties during render. Shows the centered "session-detail" variant error UI with "Something went wrong" message and "Reload Sessions" button.',
+      },
+    },
+  },
+}

--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -4,6 +4,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useEffect, useRef, useState } from 'react'
 import { CircleOff, CheckSquare, Square, Pencil, ShieldOff } from 'lucide-react'
+import { SentryErrorBoundary } from '@/components/ErrorBoundary'
 import { getStatusTextClass } from '@/utils/component-utils'
 import { formatTimestamp, formatAbsoluteTimestamp } from '@/utils/formatting'
 import { highlightMatches } from '@/lib/fuzzy-search'
@@ -38,7 +39,7 @@ interface SessionTableProps {
   onBypassPermissions?: (sessionIds: string[]) => void
 }
 
-export default function SessionTable({
+function SessionTableInner({
   sessions,
   handleFocusSession,
   handleBlurSession,
@@ -772,5 +773,21 @@ export default function SessionTable({
         }}
       />
     </HotkeyScopeBoundary>
+  )
+}
+
+// Export wrapped version with error boundary
+export default function SessionTable(props: SessionTableProps) {
+  return (
+    <SentryErrorBoundary
+      variant="session-detail"
+      componentName="SessionTable"
+      handleRefresh={() => {
+        window.location.href = '/#/'
+      }}
+      refreshButtonText="Reload Sessions"
+    >
+      <SessionTableInner {...props} />
+    </SentryErrorBoundary>
   )
 }


### PR DESCRIPTION
## What problem(s) was I solving?

Component rendering errors in the WUI were causing the entire UI to crash, forcing users to reload the application. Without granular error boundaries, a single broken event or session could make the entire interface unusable.

Related issues:
- [ENG-2200](https://linear.app/humanlayer/issue/ENG-2200/add-error-boundaries-to-session-details-and-session-list): Add error boundaries to session details and session list

## What user-facing changes did I ship?

### Error Isolation
- Individual event boxes now fail gracefully without crashing the conversation view
- Task group headers have isolated error handling
- Session table errors no longer break the entire sessions list
- Each component displays context-appropriate error messages with recovery options

### Error UI Variants
- **ConversationEventRow**: Shows "Error rendering event" with error message and "Reload Session" button
- **TaskGroupEventRow**: Shows compact "Editor unavailable" message inline with the event stream
- **SessionTable**: Shows centered "Something went wrong" message with "Reload Sessions" button

### Error Reporting
- All errors are automatically reported to Sentry with component context
- Error reports include component name and variant type for better debugging
- No user data (props/state) is sent to Sentry, only error stacks

## How I implemented it

### Error Boundary Wrapper Pattern
Applied the inner/wrapper pattern to isolate error boundaries:
- Created `*Inner` component with original implementation
- Exported wrapped version with `SentryErrorBoundary`
- Allows error boundary logic to be separate from component logic

### Components Wrapped
1. **ConversationEventRow** (`humanlayer-wui/src/components/internal/ConversationStream/ConversationEventRow.tsx:706-750`)
   - Custom error fallback showing "Error rendering event"
   - Extracts session ID from URL to enable reload
   - Uses `response-editor` variant for inline error display

2. **TaskGroupEventRow** (`humanlayer-wui/src/components/internal/ConversationStream/TaskGroupEventRow.tsx:168-187`)
   - Uses `response-editor` variant for compact inline errors
   - Same session reload logic as ConversationEventRow

3. **SessionTable** (`humanlayer-wui/src/components/internal/SessionTable.tsx:778-793`)
   - Uses `session-detail` variant for centered error display
   - Reloads to home page on error recovery

### Error Boundary Variants
The `SentryErrorBoundary` component (`humanlayer-wui/src/components/ErrorBoundary.tsx`) supports multiple variants:
- `response-editor`: Compact inline error for event stream components
- `session-detail`: Centered error display for table/list views
- Custom fallback components can be provided for specific error messages

### Storybook Demos
Added ErrorBoundaryDemo stories to demonstrate error handling:
- `ConversationEventRow.stories.tsx`: Proxy-based error trigger showing custom fallback
- `SessionTable.stories.tsx`: Demonstrates session-detail variant
- `SessionDetail.stories.tsx`: Shows error handling for session detail view

All stories use the Proxy pattern to trigger errors during component render, simulating real-world failure scenarios.

## How to verify it

- [x] I have ensured `make check test` passes

### Manual Testing
1. **Test ConversationEventRow error boundary:**
   - Open Storybook: `cd humanlayer-wui && bun run storybook`
   - Navigate to Internal/ConversationStream/ConversationEventRow
   - View "Error Boundary Demo" story
   - Verify shows "Error rendering event" message
   - Verify "Reload Session" button is displayed
   - Check browser console for Sentry error reporting

2. **Test TaskGroupEventRow error boundary:**
   - Same Storybook instance
   - Navigate to task group stories (if available)
   - Verify compact inline error display

3. **Test SessionTable error boundary:**
   - Navigate to Internal/SessionTable
   - View "Error Boundary Demo" story
   - Verify centered "Something went wrong" message
   - Verify "Reload Sessions" button is displayed

4. **Test in running application:**
   - Start WUI in development mode
   - Introduce a deliberate error in one of the wrapped components
   - Verify error boundary catches it and displays appropriate fallback
   - Verify clicking refresh button reloads correctly
   - Check `~/.humanlayer/logs/wui-{branch}/codelayer.log` for error logging

## Description for the changelog

Add granular error boundaries to WUI session views preventing component failures from breaking the entire UI. Individual events, task groups, and session table now have isolated error handling with context-appropriate fallback UI and Sentry reporting.
