### PR TITLE
Resolve missing summary on newly launched draft

### DIFF
--- a/hld/session/draft_summary_test.go
+++ b/hld/session/draft_summary_test.go
@@ -1,0 +1,77 @@
+package session
+
+import (
+	"context"
+	"testing"
+
+	"github.com/humanlayer/humanlayer/hld/bus"
+	"github.com/humanlayer/humanlayer/hld/store"
+)
+
+func TestLaunchDraftSession_SummaryShouldBeUpdated(t *testing.T) {
+	ctx := context.Background()
+
+	// Create test components
+	eventBus := bus.NewEventBus()
+	sqliteStore, err := store.NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+	defer func() { _ = sqliteStore.Close() }()
+
+	manager, err := NewManager(eventBus, sqliteStore, "")
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+
+	// Create a draft session with an initial query
+	initialQuery := "This is the initial draft query that will be replaced when we launch"
+	initialSummary := CalculateSummary(initialQuery)
+
+	draftSession := &store.Session{
+		ID:      "draft-summary-test",
+		RunID:   "run-draft-summary-test",
+		Status:  store.SessionStatusDraft,
+		Query:   initialQuery,
+		Summary: initialSummary,
+		Model:   "claude-3-5-sonnet-20241022",
+	}
+
+	if err := sqliteStore.CreateSession(ctx, draftSession); err != nil {
+		t.Fatalf("Failed to create draft session: %v", err)
+	}
+
+	// Verify initial summary
+	session, err := sqliteStore.GetSession(ctx, draftSession.ID)
+	if err != nil {
+		t.Fatalf("Failed to get session: %v", err)
+	}
+	if session.Summary != initialSummary {
+		t.Errorf("expected initial summary %q, got %q", initialSummary, session.Summary)
+	}
+
+	// Launch the draft with a completely different prompt
+	newPrompt := "Write a Python script to parse JSON files"
+	expectedNewSummary := CalculateSummary(newPrompt)
+
+	// LaunchDraftSession will fail because Claude binary doesn't exist in test env,
+	// but the database update happens before that, so we can still verify the behavior
+	_ = manager.LaunchDraftSession(ctx, draftSession.ID, newPrompt)
+
+	// Verify the query was updated
+	session, err = sqliteStore.GetSession(ctx, draftSession.ID)
+	if err != nil {
+		t.Fatalf("Failed to get session after launch: %v", err)
+	}
+
+	if session.Query != newPrompt {
+		t.Errorf("expected query to be updated to %q, got %q", newPrompt, session.Query)
+	}
+
+	// Verify the summary was updated to match the new query
+	// This test will FAIL until we fix the implementation
+	if session.Summary != expectedNewSummary {
+		t.Errorf("expected summary to be updated to %q, got %q (old summary was %q)",
+			expectedNewSummary, session.Summary, initialSummary)
+	}
+}

--- a/hld/session/manager.go
+++ b/hld/session/manager.go
@@ -2023,12 +2023,14 @@ func (m *Manager) LaunchDraftSession(ctx context.Context, sessionID string, prom
 
 	// Update the query with the actual prompt and clear editor state
 	queryUpdate := prompt
+	summaryUpdate := CalculateSummary(prompt)
 	statusStarting := string(StatusStarting)
 	now := time.Now()
 	emptyString := "" // Use empty string to clear editor state
 	update := store.SessionUpdate{
 		Status:         &statusStarting,
 		Query:          &queryUpdate,
+		Summary:        &summaryUpdate,
 		LastActivityAt: &now,
 		EditorState:    &emptyString, // Clear editor state when launching
 	}


### PR DESCRIPTION
## What problem(s) was I solving?

When launching a draft session with a new prompt, the session's summary field was not being updated to match the new query. This caused confusion in the session table where the displayed summary would reflect the original draft text instead of the actual prompt the user launched the session with.

Related issues:
- [ENG-2249](https://linear.app/humanlayer/issue/ENG-2249/title-in-session-table-should-be-changed-back-to-summary-and): Title in session table should be changed back to summary

## What user-facing changes did I ship?

- Session summaries in the session table now correctly update when a draft is launched with a new prompt
- Users will see accurate summaries that match their launched prompts instead of stale draft text
- This improves session navigation and identification in the UI

## How I implemented it

### Summary Update in LaunchDraftSession
Modified `hld/session/manager.go:2023`:
- Calculate new summary from the launch prompt using `CalculateSummary(prompt)`
- Include `Summary` field in the `SessionUpdate` struct alongside the existing query update
- This ensures both query and summary are synchronized when launching a draft

### Test Coverage
Added comprehensive test in `hld/session/draft_summary_test.go`:
- Creates a draft session with initial query and summary
- Launches the draft with a completely different prompt
- Verifies both query and summary are updated to reflect the new prompt
- Tests the fix for the bug this PR resolves

## How to verify it

- [x] I have ensured `make check test` passes

### Manual Testing
1. Create a draft session with an initial query
2. Launch the draft with a different prompt
3. Verify the session summary in the session table reflects the launch prompt, not the original draft text
4. Confirm the automated test `TestLaunchDraftSession_SummaryShouldBeUpdated` passes

## Description for the changelog

Fixed draft session summaries not updating when launched with new prompts. Session summaries now correctly reflect the actual launch prompt instead of showing stale draft text.
