### PR TITLE
Update sub-agents to use sonnet model

### DIFF
--- a/.claude/agents/codebase-analyzer.md
+++ b/.claude/agents/codebase-analyzer.md
@@ -2,7 +2,7 @@
 name: codebase-analyzer
 description: Analyzes codebase implementation details. Call the codebase-analyzer agent when you need to find detailed information about specific components. As always, the more detailed your request prompt, the better! :)
 tools: Read, Grep, Glob, LS
-model: inherit
+model: sonnet
 ---
 
 You are a specialist at understanding HOW code works. Your job is to analyze implementation details, trace data flow, and explain technical workings with precise file:line references.

--- a/.claude/agents/codebase-locator.md
+++ b/.claude/agents/codebase-locator.md
@@ -2,7 +2,7 @@
 name: codebase-locator
 description: Locates files, directories, and components relevant to a feature or task. Call `codebase-locator` with human language prompt describing what you're looking for. Basically a "Super Grep/Glob/LS tool" — Use it if you find yourself desiring to use one of these tools more than once.
 tools: Grep, Glob, LS
-model: inherit
+model: sonnet
 ---
 
 You are a specialist at finding WHERE code lives in a codebase. Your job is to locate relevant files and organize them by purpose, NOT to analyze their contents.

--- a/.claude/agents/codebase-pattern-finder.md
+++ b/.claude/agents/codebase-pattern-finder.md
@@ -2,7 +2,7 @@
 name: codebase-pattern-finder
 description: codebase-pattern-finder is a useful subagent_type for finding similar implementations, usage examples, or existing patterns that can be modeled after. It will give you concrete code examples based on what you're looking for! It's sorta like codebase-locator, but it will not only tell you the location of files, it will also give you code details!
 tools: Grep, Glob, Read, LS
-model: inherit
+model: sonnet
 ---
 
 You are a specialist at finding code patterns and examples in the codebase. Your job is to locate similar implementations that can serve as templates or inspiration for new work.

--- a/.claude/agents/thoughts-analyzer.md
+++ b/.claude/agents/thoughts-analyzer.md
@@ -2,7 +2,7 @@
 name: thoughts-analyzer
 description: The research equivalent of codebase-analyzer. Use this subagent_type when wanting to deep dive on a research topic. Not commonly needed otherwise.
 tools: Read, Grep, Glob, LS
-model: inherit
+model: sonnet
 ---
 
 You are a specialist at extracting HIGH-VALUE insights from thoughts documents. Your job is to deeply analyze documents and return only the most relevant, actionable information while filtering out noise.

--- a/.claude/agents/thoughts-locator.md
+++ b/.claude/agents/thoughts-locator.md
@@ -2,7 +2,7 @@
 name: thoughts-locator
 description: Discovers relevant documents in thoughts/ directory (We use this for all sorts of metadata storage!). This is really only relevant/needed when you're in a reseaching mood and need to figure out if we have random thoughts written down that are relevant to your current research task. Based on the name, I imagine you can guess this is the `thoughts` equivilent of `codebase-locator`
 tools: Grep, Glob, LS
-model: inherit
+model: sonnet
 ---
 
 You are a specialist at finding documents in the thoughts/ directory. Your job is to locate relevant thought documents and categorize them, NOT to analyze their contents in depth.

--- a/.claude/agents/web-search-researcher.md
+++ b/.claude/agents/web-search-researcher.md
@@ -3,7 +3,7 @@ name: web-search-researcher
 description: Do you find yourself desiring information that you don't quite feel well-trained (confident) on? Information that is modern and potentially only discoverable on the web? Use the web-search-researcher subagent_type today to find any and all answers to your questions! It will research deeply to figure out and attempt to answer your questions! If you aren't immediately satisfied you can get your money back! (Not really - but you can re-run web-search-researcher with an altered prompt in the event you're not satisfied the first time)
 tools: WebSearch, WebFetch, TodoWrite, Read, Grep, Glob, LS
 color: yellow
-model: inherit
+model: sonnet
 ---
 
 You are an expert web research specialist focused on finding accurate, relevant information from web sources. Your primary tools are WebSearch and WebFetch, which you use to discover and retrieve information based on user queries.


### PR DESCRIPTION
## What problem(s) was I solving?

Sub-agents were using `model: inherit` which caused them to inherit the model from the parent session. This meant that when running with Opus, all sub-agents would also use Opus, which is unnecessary and expensive for simple search/grep/read operations.

By switching to `model: sonnet`, sub-agents will automatically use the latest sonnet version regardless of what model the parent session is using, providing a good balance of performance and cost.

## What user-facing changes did I ship?

No direct user-facing changes. This is an internal configuration change that affects cost and performance:

- Sub-agents will now use Sonnet instead of inheriting the parent model
- When a user runs a session with Opus, sub-agents will use Sonnet instead of Opus
- The `sonnet` alias automatically resolves to the latest sonnet version

## How I implemented it

Updated the `model` field in all 6 sub-agent configuration files (`.claude/agents/*.md`):
- Changed from `model: inherit` to `model: sonnet`

Affected agents:
- `codebase-analyzer.md`
- `codebase-locator.md`
- `codebase-pattern-finder.md`
- `thoughts-analyzer.md`
- `thoughts-locator.md`
- `web-search-researcher.md`

## How to verify it

- [x] I have ensured `make check test` passes ✅ All checks and tests passed

### Manual Testing
1. Launch a session with Opus model
2. Trigger a sub-agent (e.g., use codebase-locator)
3. Verify the sub-agent uses Sonnet instead of Opus (check logs/API calls)

## Description for the changelog

Updated sub-agent model configuration from 'inherit' to 'sonnet' for cost optimization - sub-agents now use Sonnet regardless of parent session model.
