### PR TITLE
Fix: Prevent flag injection when query starts with dash (ENG-2092)

### DIFF
--- a/claudecode-go/client.go
+++ b/claudecode-go/client.go
@@ -183,11 +183,6 @@ func tryLoginShell() string {
 func (c *Client) buildArgs(config SessionConfig) ([]string, error) {
 	args := []string{}
 
-	// Always use print mode for SDK
-	if config.Query != "" {
-		args = append(args, "--print", config.Query)
-	}
-
 	// Session management
 	if config.SessionID != "" {
 		args = append(args, "--resume", config.SessionID)
@@ -301,6 +296,15 @@ func (c *Client) buildArgs(config SessionConfig) ([]string, error) {
 	// Verbose
 	if config.Verbose {
 		args = append(args, "--verbose")
+	}
+
+	// Always use print mode for SDK - MUST be the last flag before --
+	// The -- separator tells the CLI parser to stop interpreting flags
+	// Correct order: <all flags> --print -- <query>
+	if config.Query != "" {
+		args = append(args, "--print")
+		args = append(args, "--")
+		args = append(args, config.Query)
 	}
 
 	return args, nil

--- a/claudecode-go/client_internal_test.go
+++ b/claudecode-go/client_internal_test.go
@@ -1,0 +1,199 @@
+package claudecode
+
+import (
+	"testing"
+)
+
+// TestBuildArgsWithDashPrefixedQuery tests that queries starting with dashes are handled correctly
+// This test file uses package claudecode (not claudecode_test) to access private methods
+func TestBuildArgsWithDashPrefixedQuery(t *testing.T) {
+	client := NewClientWithPath("/usr/bin/claude")
+
+	testCases := []struct {
+		name        string
+		query       string
+		description string
+	}{
+		{
+			name:        "query starting with single dash",
+			query:       "-one thing",
+			description: "Single dash at start should be treated as query text, not flag",
+		},
+		{
+			name:        "query starting with double dash",
+			query:       "--help",
+			description: "Double dash at start should be treated as query text, not help flag",
+		},
+		{
+			name:        "query with dash in middle",
+			query:       "do this - and that",
+			description: "Dash in middle should work correctly",
+		},
+		{
+			name:        "query with only dash",
+			query:       "-",
+			description: "Single dash character should be treated as query text",
+		},
+		{
+			name:        "query that looks like a flag",
+			query:       "--model opus",
+			description: "Query resembling a flag should be treated as text",
+		},
+		{
+			name:        "normal query without dashes",
+			query:       "normal query",
+			description: "Normal queries should continue to work",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := SessionConfig{
+				Query: tc.query,
+			}
+
+			// Call the private buildArgs method directly (accessible in same package)
+			args, err := client.buildArgs(config)
+			if err != nil {
+				t.Fatalf("buildArgs failed: %v", err)
+			}
+
+			// Verify structure: args should end with --print -- <query>
+			if len(args) < 3 {
+				t.Fatalf("%s: expected at least 3 args [--print -- query], got %d: %v",
+					tc.description, len(args), args)
+			}
+
+			// Check last three elements: must be --print, --, query (in that order)
+			lastThree := args[len(args)-3:]
+			if lastThree[0] != "--print" {
+				t.Errorf("%s: expected --print as third-to-last arg, got %q", tc.description, lastThree[0])
+			}
+			if lastThree[1] != "--" {
+				t.Errorf("%s: expected -- as second-to-last arg, got %q", tc.description, lastThree[1])
+			}
+			if lastThree[2] != tc.query {
+				t.Errorf("%s: expected query %q as last arg, got %q", tc.description, tc.query, lastThree[2])
+			}
+		})
+	}
+}
+
+// TestBuildArgsWithComplexConfigs tests buildArgs with various configuration options
+// to ensure the -- separator doesn't interfere with other arguments
+func TestBuildArgsWithComplexConfigs(t *testing.T) {
+	client := NewClientWithPath("/usr/bin/claude")
+
+	testCases := []struct {
+		name     string
+		config   SessionConfig
+		contains []string
+	}{
+		{
+			name: "dash query with model",
+			config: SessionConfig{
+				Query: "-help me",
+				Model: ModelSonnet,
+			},
+			contains: []string{"--print", "--", "-help me", "--model", "sonnet"},
+		},
+		{
+			name: "dash query with session",
+			config: SessionConfig{
+				Query:     "--test",
+				SessionID: "test-session",
+			},
+			contains: []string{"--print", "--", "--test", "--resume", "test-session"},
+		},
+		{
+			name: "dash query with output format",
+			config: SessionConfig{
+				Query:        "-query",
+				OutputFormat: OutputJSON,
+			},
+			contains: []string{"--print", "--", "-query", "--output-format", "json"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			args, err := client.buildArgs(tc.config)
+			if err != nil {
+				t.Fatalf("buildArgs failed: %v", err)
+			}
+
+			// Verify all expected strings are present
+			argsStr := ""
+			for _, arg := range args {
+				argsStr += arg + " "
+			}
+
+			for _, expected := range tc.contains {
+				found := false
+				for _, arg := range args {
+					if arg == expected {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected arg %q not found in args: %v", expected, args)
+				}
+			}
+
+			// Verify correct ordering: <flags> --print -- <query>
+			printIdx := -1
+			separatorIdx := -1
+			queryIdx := -1
+
+			for i, arg := range args {
+				if arg == "--print" {
+					printIdx = i
+				}
+				if arg == "--" {
+					separatorIdx = i
+				}
+				if arg == tc.config.Query {
+					queryIdx = i
+				}
+			}
+
+			if printIdx == -1 {
+				t.Error("--print flag not found")
+			}
+			if separatorIdx == -1 {
+				t.Error("-- separator not found")
+			}
+			if queryIdx == -1 {
+				t.Errorf("query %q not found", tc.config.Query)
+			}
+
+			// Verify --print is the last flag before --
+			if separatorIdx != printIdx+1 {
+				t.Errorf("-- separator should immediately follow --print, got positions: --print=%d, --=%d",
+					printIdx, separatorIdx)
+			}
+			// Verify query immediately follows --
+			if queryIdx != separatorIdx+1 {
+				t.Errorf("query should immediately follow --, got positions: --=%d, query=%d",
+					separatorIdx, queryIdx)
+			}
+			// Verify query is the last argument
+			if queryIdx != len(args)-1 {
+				t.Errorf("query should be the last argument, got position %d of %d total args",
+					queryIdx, len(args))
+			}
+			// Verify other flags come before --print
+			for i := 0; i < printIdx; i++ {
+				if args[i] == "--" {
+					t.Errorf("-- separator found at position %d, should only appear at position %d (before query)",
+						i, separatorIdx)
+				}
+				if args[i] == tc.config.Query {
+					t.Errorf("query found at position %d, should only appear at position %d (after all flags)",
+						i, queryIdx)
+				}
+			}
+		})
+	}
+}

--- a/humanlayer-wui/src/App.css
+++ b/humanlayer-wui/src/App.css
@@ -908,6 +908,27 @@
     animation: pulse-once 0.6s ease-in-out;
   }
 
+  /* Deny button pulse animation - pulses between filled and unfilled states */
+  @keyframes pulse-deny {
+    0%,
+    100% {
+      background-color: hsl(var(--destructive));
+      color: hsl(var(--destructive-foreground));
+      border-color: transparent;
+    }
+    50% {
+      background-color: transparent;
+      color: hsl(var(--destructive));
+      border-color: hsl(var(--destructive));
+    }
+  }
+
+  .animate-pulse-deny {
+    animation: pulse-deny 2s ease-in-out infinite;
+    border-width: 1px;
+    border-style: solid;
+  }
+
   /* Gradient utilities for conic and radial gradients */
   .bg-gradient-conic {
     background: conic-gradient(var(--tw-gradient-stops));

--- a/humanlayer-wui/src/App.css
+++ b/humanlayer-wui/src/App.css
@@ -893,6 +893,21 @@
     animation: glitch 5s linear infinite;
   }
 
+  /* Single pulse animation for approval confirmation */
+  @keyframes pulse-once {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.5;
+    }
+  }
+
+  .animate-pulse-once {
+    animation: pulse-once 0.6s ease-in-out;
+  }
+
   /* Gradient utilities for conic and radial gradients */
   .bg-gradient-conic {
     background: conic-gradient(var(--tw-gradient-stops));

--- a/humanlayer-wui/src/components/internal/ConversationStream/ConversationEventRow.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/ConversationEventRow.tsx
@@ -340,6 +340,7 @@ export interface ConversationEventRowProps extends React.HTMLAttributes<HTMLDivE
   onApprove?: (approvalId: string) => void
   onDeny?: (approvalId: string, reason: string) => void
   approvingApprovalId?: string | null
+  confirmingApprovalId?: string | null
   denyingApprovalId?: string | null
   setDenyingApprovalId?: (approvalId: string | null) => void
   onCancelDeny?: () => void
@@ -362,6 +363,7 @@ function ConversationEventRowInner({
   onApprove,
   onDeny,
   approvingApprovalId,
+  confirmingApprovalId,
   denyingApprovalId,
   setDenyingApprovalId,
   onCancelDeny,
@@ -691,6 +693,7 @@ function ConversationEventRowInner({
           onApprove={() => onApprove(event.approvalId!)}
           onDeny={(reason: string) => onDeny(event.approvalId!, reason)}
           isApproving={approvingApprovalId === event.approvalId}
+          confirmingApprovalId={confirmingApprovalId}
           isDenying={denyingApprovalId === event.approvalId}
           onStartDeny={() => setDenyingApprovalId?.(event.approvalId!)}
           onCancelDeny={onCancelDeny}

--- a/humanlayer-wui/src/components/internal/ConversationStream/ConversationStream.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/ConversationStream.tsx
@@ -21,6 +21,7 @@ export function ConversationStream({
   onApprove,
   onDeny,
   approvingApprovalId,
+  confirmingApprovalId,
   denyingApprovalId,
   setDenyingApprovalId,
   onCancelDeny,
@@ -247,6 +248,7 @@ export function ConversationStream({
             onApprove={onApprove}
             onDeny={onDeny}
             approvingApprovalId={approvingApprovalId}
+            confirmingApprovalId={confirmingApprovalId}
             denyingApprovalId={denyingApprovalId}
             setDenyingApprovalId={setDenyingApprovalId}
             onCancelDeny={onCancelDeny}

--- a/humanlayer-wui/src/components/internal/ConversationStream/EventContent/ApprovalWrapper.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/EventContent/ApprovalWrapper.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Button } from '@/components/ui/button'
 import { ConversationEvent } from '@/lib/daemon/types'
 import { DenyButtons } from '../../SessionDetail/components/DenyButtons'
+import { cn } from '@/lib/utils'
 
 interface ApprovalWrapperProps {
   children: React.ReactNode
@@ -43,7 +44,10 @@ export function ApprovalWrapper({
           {!isDenying ? (
             <>
               <Button
-                className="cursor-pointer"
+                className={cn(
+                  'cursor-pointer',
+                  confirmingApprovalId === event.approvalId && 'animate-pulse-once',
+                )}
                 size="sm"
                 variant={isApproving ? 'outline' : 'default'}
                 onClick={e => {

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -1491,6 +1491,7 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
                     approvals.handleDeny(approvalId, reason, session.id)
                   }
                   approvingApprovalId={approvals.approvingApprovalId}
+                  confirmingApprovalId={approvals.confirmingApprovalId}
                   denyingApprovalId={approvals.denyingApprovalId ?? undefined}
                   setDenyingApprovalId={approvals.setDenyingApprovalId}
                   onCancelDeny={approvals.handleCancelDeny}

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/DenyButtons.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/DenyButtons.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 
 export function DenyButtons({
   isDenying,
@@ -23,7 +24,10 @@ export function DenyButtons({
       className="inline-flex gap-2"
     >
       <Button
-        className={isDisabled ? 'cursor-not-allowed' : 'cursor-pointer'}
+        className={cn(
+          isDisabled ? 'cursor-not-allowed' : 'cursor-pointer',
+          isDenying && 'animate-pulse-deny',
+        )}
         type="button"
         size="sm"
         variant="destructive"


### PR DESCRIPTION
## What problem(s) was I solving?

### Primary Fix: Claude CLI Flag Injection (ENG-2092)
Fixed a critical bug where Claude CLI sessions would fail when user queries started with a dash (`-`) character. The CLI's argument parser was misinterpreting these queries as command-line flags, causing "unknown option" errors that crashed Claude sessions.

Example error from production:
```
claude process failed: claude error: error: unknown option '-one thing, but we'll just include some notes in the report...'
```

Related issues:
- [ENG-2092](https://linear.app/humanlayer/issue/ENG-2092/claude-launched-with-unsafe-stringing-if-prompt-starts-with-it-treated): claude launched with unsafe stringing, if prompt starts with `-` it treated like a flag

### Secondary: UI/UX Improvements
- Added visual feedback for approval confirmation (single pulse animation)
- Added pulse animation for deny button during denial mode to improve discoverability

## What user-facing changes did I ship?

### Claude CLI Flag Injection Fix
- **Before**: Queries starting with `-` or `--` would cause Claude sessions to crash with "unknown option" errors
- **After**: All queries work correctly, regardless of whether they start with dashes or look like flags
- Examples that now work:
  - `-one thing - just do one thing`
  - `--help` (processes as text instead of showing help)
  - `--model opus` (processes as query instead of trying to set model)

### UI Improvements
- Approve button shows a brief pulse animation when clicked to confirm the action was registered
- Deny button pulses continuously during denial mode to draw attention and guide users to enter a reason

## How I implemented it

### Claude CLI Fix (`claudecode-go/client.go`)
The core issue was argument ordering. The `--print` flag and query were being added at the beginning of the argument list, before other flags like `--model`, `--resume`, etc.

**Solution**: Use the POSIX standard `--` separator to tell the CLI parser to stop interpreting flags:
1. Moved query argument construction to the END of `buildArgs()` function
2. Added `--` separator between `--print` and the query value
3. Ensured command structure: `claude <all-flags> --print -- <query>`

**Why this works**: The `--` separator is a universal CLI convention that signals "everything after this point is data, not flags." This is supported by all major argument parsing libraries.

### Test Coverage (`claudecode-go/client_internal_test.go`)
Added comprehensive test suite with 2 test functions covering:
- Basic dash-prefixed query handling (6 test cases)
- Complex configurations with multiple flags (3 test cases)
- Verification of correct argument ordering
- Edge cases: single dash, double dash, dash in middle, flag-like queries

Tests use internal package access to test the private `buildArgs()` method directly, ensuring correctness before command execution.

### UI Animations (`humanlayer-wui/`)
- Added `animate-pulse-once` CSS animation for single-use confirmation feedback (600ms)
- Added `animate-pulse-deny` CSS animation that transitions between filled/unfilled button states (2s infinite)
- Applied animations conditionally based on component state

## How to verify it

- [x] I have ensured `make check test` passes (all 50 Go tests, 341 daemon tests, UI tests pass)

### Manual Testing for Claude CLI Fix

1. Test dash-prefixed queries via CodeLayer UI:
   ```
   Send message: "-one thing - just do one thing"
   Expected: Claude processes the query successfully without errors
   ```

2. Test via command line:
   ```bash
   # Should work with various flags
   claude --model sonnet --print -- "-help me"
   claude --output-format json --print -- "--test"

   # Verify old syntax fails (without --)
   claude --print "-one thing"  # Should fail with "unknown option"
   ```

3. Verify backwards compatibility:
   - Normal queries without dashes continue to work
   - All existing flags (`--model`, `--resume`, `--output-format`, etc.) work correctly
   - Query is always processed last, after all flags

### Manual Testing for UI Changes

1. Test approve button pulse:
   - Trigger an approval request in CodeLayer
   - Click "Approve" button
   - Verify brief pulse animation plays once

2. Test deny button pulse:
   - Trigger an approval request
   - Press 'd' or click "Deny" button
   - Verify deny button pulses continuously while waiting for reason input
   - Enter reason and submit
   - Verify pulsing stops

## Description for the changelog

Fixed critical bug (ENG-2092) where Claude CLI sessions would crash when user queries started with dash characters. Added POSIX `--` separator to properly handle queries like "-one thing" or "--help" as text instead of flags. Includes comprehensive test coverage and UI improvements for approval/denial feedback.
