### PR TITLE
Fix: Prevent flag injection when query starts with dash (ENG-2092)

### DIFF
--- a/claudecode-go/client.go
+++ b/claudecode-go/client.go
@@ -183,11 +183,6 @@ func tryLoginShell() string {
 func (c *Client) buildArgs(config SessionConfig) ([]string, error) {
 	args := []string{}
 
-	// Always use print mode for SDK
-	if config.Query != "" {
-		args = append(args, "--print", config.Query)
-	}
-
 	// Session management
 	if config.SessionID != "" {
 		args = append(args, "--resume", config.SessionID)
@@ -301,6 +296,15 @@ func (c *Client) buildArgs(config SessionConfig) ([]string, error) {
 	// Verbose
 	if config.Verbose {
 		args = append(args, "--verbose")
+	}
+
+	// Always use print mode for SDK - MUST be the last flag before --
+	// The -- separator tells the CLI parser to stop interpreting flags
+	// Correct order: <all flags> --print -- <query>
+	if config.Query != "" {
+		args = append(args, "--print")
+		args = append(args, "--")
+		args = append(args, config.Query)
 	}
 
 	return args, nil

--- a/claudecode-go/client_internal_test.go
+++ b/claudecode-go/client_internal_test.go
@@ -1,0 +1,199 @@
+package claudecode
+
+import (
+	"testing"
+)
+
+// TestBuildArgsWithDashPrefixedQuery tests that queries starting with dashes are handled correctly
+// This test file uses package claudecode (not claudecode_test) to access private methods
+func TestBuildArgsWithDashPrefixedQuery(t *testing.T) {
+	client := NewClientWithPath("/usr/bin/claude")
+
+	testCases := []struct {
+		name        string
+		query       string
+		description string
+	}{
+		{
+			name:        "query starting with single dash",
+			query:       "-one thing",
+			description: "Single dash at start should be treated as query text, not flag",
+		},
+		{
+			name:        "query starting with double dash",
+			query:       "--help",
+			description: "Double dash at start should be treated as query text, not help flag",
+		},
+		{
+			name:        "query with dash in middle",
+			query:       "do this - and that",
+			description: "Dash in middle should work correctly",
+		},
+		{
+			name:        "query with only dash",
+			query:       "-",
+			description: "Single dash character should be treated as query text",
+		},
+		{
+			name:        "query that looks like a flag",
+			query:       "--model opus",
+			description: "Query resembling a flag should be treated as text",
+		},
+		{
+			name:        "normal query without dashes",
+			query:       "normal query",
+			description: "Normal queries should continue to work",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := SessionConfig{
+				Query: tc.query,
+			}
+
+			// Call the private buildArgs method directly (accessible in same package)
+			args, err := client.buildArgs(config)
+			if err != nil {
+				t.Fatalf("buildArgs failed: %v", err)
+			}
+
+			// Verify structure: args should end with --print -- <query>
+			if len(args) < 3 {
+				t.Fatalf("%s: expected at least 3 args [--print -- query], got %d: %v",
+					tc.description, len(args), args)
+			}
+
+			// Check last three elements: must be --print, --, query (in that order)
+			lastThree := args[len(args)-3:]
+			if lastThree[0] != "--print" {
+				t.Errorf("%s: expected --print as third-to-last arg, got %q", tc.description, lastThree[0])
+			}
+			if lastThree[1] != "--" {
+				t.Errorf("%s: expected -- as second-to-last arg, got %q", tc.description, lastThree[1])
+			}
+			if lastThree[2] != tc.query {
+				t.Errorf("%s: expected query %q as last arg, got %q", tc.description, tc.query, lastThree[2])
+			}
+		})
+	}
+}
+
+// TestBuildArgsWithComplexConfigs tests buildArgs with various configuration options
+// to ensure the -- separator doesn't interfere with other arguments
+func TestBuildArgsWithComplexConfigs(t *testing.T) {
+	client := NewClientWithPath("/usr/bin/claude")
+
+	testCases := []struct {
+		name     string
+		config   SessionConfig
+		contains []string
+	}{
+		{
+			name: "dash query with model",
+			config: SessionConfig{
+				Query: "-help me",
+				Model: ModelSonnet,
+			},
+			contains: []string{"--print", "--", "-help me", "--model", "sonnet"},
+		},
+		{
+			name: "dash query with session",
+			config: SessionConfig{
+				Query:     "--test",
+				SessionID: "test-session",
+			},
+			contains: []string{"--print", "--", "--test", "--resume", "test-session"},
+		},
+		{
+			name: "dash query with output format",
+			config: SessionConfig{
+				Query:        "-query",
+				OutputFormat: OutputJSON,
+			},
+			contains: []string{"--print", "--", "-query", "--output-format", "json"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			args, err := client.buildArgs(tc.config)
+			if err != nil {
+				t.Fatalf("buildArgs failed: %v", err)
+			}
+
+			// Verify all expected strings are present
+			argsStr := ""
+			for _, arg := range args {
+				argsStr += arg + " "
+			}
+
+			for _, expected := range tc.contains {
+				found := false
+				for _, arg := range args {
+					if arg == expected {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected arg %q not found in args: %v", expected, args)
+				}
+			}
+
+			// Verify correct ordering: <flags> --print -- <query>
+			printIdx := -1
+			separatorIdx := -1
+			queryIdx := -1
+
+			for i, arg := range args {
+				if arg == "--print" {
+					printIdx = i
+				}
+				if arg == "--" {
+					separatorIdx = i
+				}
+				if arg == tc.config.Query {
+					queryIdx = i
+				}
+			}
+
+			if printIdx == -1 {
+				t.Error("--print flag not found")
+			}
+			if separatorIdx == -1 {
+				t.Error("-- separator not found")
+			}
+			if queryIdx == -1 {
+				t.Errorf("query %q not found", tc.config.Query)
+			}
+
+			// Verify --print is the last flag before --
+			if separatorIdx != printIdx+1 {
+				t.Errorf("-- separator should immediately follow --print, got positions: --print=%d, --=%d",
+					printIdx, separatorIdx)
+			}
+			// Verify query immediately follows --
+			if queryIdx != separatorIdx+1 {
+				t.Errorf("query should immediately follow --, got positions: --=%d, query=%d",
+					separatorIdx, queryIdx)
+			}
+			// Verify query is the last argument
+			if queryIdx != len(args)-1 {
+				t.Errorf("query should be the last argument, got position %d of %d total args",
+					queryIdx, len(args))
+			}
+			// Verify other flags come before --print
+			for i := 0; i < printIdx; i++ {
+				if args[i] == "--" {
+					t.Errorf("-- separator found at position %d, should only appear at position %d (before query)",
+						i, separatorIdx)
+				}
+				if args[i] == tc.config.Query {
+					t.Errorf("query found at position %d, should only appear at position %d (after all flags)",
+						i, queryIdx)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What problem(s) was I solving?

Fixed a critical bug where Claude CLI sessions would fail when user queries started with a dash (`-`) character. The CLI's argument parser was misinterpreting these queries as command-line flags, causing "unknown option" errors that crashed Claude sessions.

Example error from production:
```
claude process failed: claude error: error: unknown option '-one thing, but we'll just include some notes in the report...'
```

Related issues:
- [ENG-2092](https://linear.app/humanlayer/issue/ENG-2092/claude-launched-with-unsafe-stringing-if-prompt-starts-with-it-treated): claude launched with unsafe stringing, if prompt starts with `-` it treated like a flag

## What user-facing changes did I ship?

### Claude CLI Flag Injection Fix
- **Before**: Queries starting with `-` or `--` would cause Claude sessions to crash with "unknown option" errors
- **After**: All queries work correctly, regardless of whether they start with dashes or look like flags
- Examples that now work:
  - `-one thing - just do one thing`
  - `--help` (processes as text instead of showing help)
  - `--model opus` (processes as query instead of trying to set model)

## How I implemented it

### Claude CLI Fix (`claudecode-go/client.go`)
The core issue was argument ordering. The `--print` flag and query were being added at the beginning of the argument list, before other flags like `--model`, `--resume`, etc.

**Solution**: Use the POSIX standard `--` separator to tell the CLI parser to stop interpreting flags:
1. Moved query argument construction to the END of `buildArgs()` function
2. Added `--` separator between `--print` and the query value
3. Ensured command structure: `claude <all-flags> --print -- <query>`

**Why this works**: The `--` separator is a universal CLI convention that signals "everything after this point is data, not flags." This is supported by all major argument parsing libraries.

### Test Coverage (`claudecode-go/client_internal_test.go`)
Added comprehensive test suite with 2 test functions covering:
- Basic dash-prefixed query handling (6 test cases)
- Complex configurations with multiple flags (3 test cases)
- Verification of correct argument ordering
- Edge cases: single dash, double dash, dash in middle, flag-like queries

Tests use internal package access to test the private `buildArgs()` method directly, ensuring correctness before command execution.

## How to verify it

- [x] I have ensured `make check test` passes (all 50 Go tests, 341 daemon tests, UI tests pass)

### Manual Testing

1. Test dash-prefixed queries via CodeLayer UI:
   ```
   Send message: "-one thing - just do one thing"
   Expected: Claude processes the query successfully without errors
   ```

2. Test via command line:
   ```bash
   # Should work with various flags
   claude --model sonnet --print -- "-help me"
   claude --output-format json --print -- "--test"

   # Verify old syntax fails (without --)
   claude --print "-one thing"  # Should fail with "unknown option"
   ```

3. Verify backwards compatibility:
   - Normal queries without dashes continue to work
   - All existing flags (`--model`, `--resume`, `--output-format`, etc.) work correctly
   - Query is always processed last, after all flags

## Description for the changelog

Fixed critical bug (ENG-2092) where Claude CLI sessions would crash when user queries started with dash characters. Added POSIX `--` separator to properly handle queries like "-one thing" or "--help" as text instead of flags. Includes comprehensive test coverage.
