### PR TITLE
Add manual verification pause points between implementation phases

### DIFF
--- a/.claude/commands/create_plan.md
+++ b/.claude/commands/create_plan.md
@@ -232,6 +232,8 @@ After structure approval:
 - [ ] Edge case handling verified manually
 - [ ] No regressions in related features
 
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation from the human that the manual testing was successful before proceeding to the next phase.
+
 ---
 
 ## Phase 2: [Descriptive Name]

--- a/.claude/commands/create_plan_generic.md
+++ b/.claude/commands/create_plan_generic.md
@@ -231,6 +231,8 @@ After structure approval:
 - [ ] Edge case handling verified manually
 - [ ] No regressions in related features
 
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation from the human that the manual testing was successful before proceeding to the next phase.
+
 ---
 
 ## Phase 2: [Descriptive Name]

--- a/.claude/commands/create_plan_nt.md
+++ b/.claude/commands/create_plan_nt.md
@@ -227,6 +227,8 @@ After structure approval:
 - [ ] Edge case handling verified manually
 - [ ] No regressions in related features
 
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation from the human that the manual testing was successful before proceeding to the next phase.
+
 ---
 
 ## Phase 2: [Descriptive Name]

--- a/.claude/commands/implement_plan.md
+++ b/.claude/commands/implement_plan.md
@@ -56,7 +56,7 @@ After implementing a phase:
   Let me know when manual testing is complete so I can proceed to Phase [N+1].
   ```
 
-If you are explicitly asked to do multiple specific phases without stopping. Then you can skip this until you complete the last phase mentioned by the user. Otherwise assume you are just doing one phase.
+If instructed to execute multiple phases consecutively, skip the pause until the last phase. Otherwise, assume you are just doing one phase.
 
 do not check off items in the manual testing steps until confirmed by the user.
 

--- a/.claude/commands/implement_plan.md
+++ b/.claude/commands/implement_plan.md
@@ -43,8 +43,23 @@ After implementing a phase:
 - Fix any issues before proceeding
 - Update your progress in both the plan and your todos
 - Check off completed items in the plan file itself using Edit
+- **Pause for human verification**: After completing all automated verification for a phase, pause and inform the human that the phase is ready for manual testing. Use this format:
+  ```
+  Phase [N] Complete - Ready for Manual Verification
 
-Don't let verification interrupt your flow - batch it at natural stopping points.
+  Automated verification passed:
+  - [List automated checks that passed]
+
+  Please perform the manual verification steps listed in the plan:
+  - [List manual verification items from the plan]
+
+  Let me know when manual testing is complete so I can proceed to Phase [N+1].
+  ```
+
+If you are explicitly asked to do multiple specific phases without stopping. Then you can skip this until you complete the last phase mentioned by the user. Otherwise assume you are just doing one phase.
+
+do not check off items in the manual testing steps until confirmed by the user.
+
 
 ## If You Get Stuck
 


### PR DESCRIPTION
## What problem(s) was I solving?

Claude Code agents implementing multi-phase plans were not pausing between phases to allow humans to perform manual verification testing. This could lead to agents proceeding to subsequent phases before humans confirmed that manual tests passed, potentially building on top of unverified work.

## What user-facing changes did I ship?

### For agents implementing plans:
- Agents now pause after completing automated verification for each phase
- Clear messaging when a phase is ready for manual testing
- Explicit list of manual verification steps that need human testing
- Agents wait for human confirmation before proceeding to next phase

### For plan templates:
- All generated implementation plans now include explicit pause instructions
- Clear separation between automated and manual verification steps
- Implementation notes remind agents to pause for human confirmation

## How I implemented it

### Updated `implement_plan.md` command:
- Added structured pause format after automated verification completes
- Agents now display:
  - Phase completion status
  - List of passed automated checks
  - Manual verification items from the plan
  - Clear request for human to confirm before proceeding
- Added logic to skip pauses when explicitly asked to do multiple phases
- Clarified that manual test checkboxes should not be checked off until user confirms

### Updated plan creation templates:
- Modified `create_plan.md`, `create_plan_generic.md`, and `create_plan_nt.md`
- Added "Implementation Note" to phase templates
- Note explicitly states to pause for manual confirmation after automated tests pass
- Ensures all future plans include these pause points

## How to verify it

- [ ] I have ensured `make check test` passes (Note: Pre-existing TypeScript errors in WUI unrelated to these changes)

### Manual Testing:
1. Create a new implementation plan using any of the updated templates
   - Verify the plan includes the "Implementation Note" about pausing

2. Have an agent implement a plan with multiple phases:
   - Verify agent pauses after completing Phase 1's automated tests
   - Confirm agent displays clear message about manual verification needed
   - Check that agent waits for human confirmation before proceeding

3. Test the skip logic:
   - Explicitly ask agent to implement multiple specific phases
   - Verify agent completes all requested phases before pausing

## Description for the changelog

Enhanced Claude Code's implementation workflow to pause between phases for manual verification, ensuring human confirmation of manual tests before proceeding to subsequent implementation phases.