### PR TITLE
Fix auto-accept tooltip to show correct hotkey ⌥A

### DIFF
--- a/humanlayer-wui/src/components/HotkeyPanel.tsx
+++ b/humanlayer-wui/src/components/HotkeyPanel.tsx
@@ -67,7 +67,7 @@ const hotkeyData = [
   { category: 'Session Detail', key: 'Ctrl+X', description: 'Interrupt session' },
   { category: 'Session Detail', key: 'P', description: 'Go to parent session' },
   { category: 'Session Detail', key: '⌘+Y', description: 'Toggle fork view' },
-  { category: 'Session Detail', key: 'Option+A', description: 'Toggle auto-accept edits' },
+  { category: 'Session Detail', key: '⌥+A', description: 'Toggle auto-accept edits' },
   { category: 'Session Detail', key: 'Enter', description: 'Focus response input' },
   { category: 'Session Detail', key: '⌘+Enter', description: 'Submit response' },
   { category: 'Session Detail', key: '⌥+Y', description: 'Toggle bypass permissions' },

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ActionButtons.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ActionButtons.tsx
@@ -86,7 +86,7 @@ export const ActionButtons: FC<ActionButtonsProps> = ({
         <TooltipContent>
           <p className="flex items-center gap-1">
             {bypassEnabled ? 'Disable' : 'Enable'} bypass permissions{' '}
-            <KeyboardShortcut keyString="⌥Y" />
+            <KeyboardShortcut keyString="⌥+Y" />
           </p>
         </TooltipContent>
       </Tooltip>
@@ -114,8 +114,7 @@ export const ActionButtons: FC<ActionButtonsProps> = ({
         </TooltipTrigger>
         <TooltipContent>
           <p className="flex items-center gap-1">
-            {autoAcceptEnabled ? 'Disable' : 'Enable'} auto-accept{' '}
-            <KeyboardShortcut keyString="⇧+TAB" />
+            {autoAcceptEnabled ? 'Disable' : 'Enable'} auto-accept <KeyboardShortcut keyString="⌥+A" />
           </p>
         </TooltipContent>
       </Tooltip>


### PR DESCRIPTION
## What problem(s) was I solving?

The tooltip for the "auto-accept edits" button in the session details screen was displaying the wrong keyboard shortcut. It showed `⇧+TAB` (Shift+Tab) instead of the correct hotkey `⌥A` (Option+A).

This was confusing for users who wanted to quickly toggle auto-accept mode using the keyboard, as the displayed hint didn't match the actual keyboard shortcut.

## What user-facing changes did I ship?

- Updated the auto-accept button tooltip to correctly display `⌥A` instead of `⇧+TAB`
- The tooltip now matches the pattern used by other option-key shortcuts in the UI (like `⌥Y` for bypass permissions)
- Users will now see the correct keyboard hint when hovering over the auto-accept button

## How I implemented it

Changed the `KeyboardShortcut` component's `keyString` prop from `"⇧+TAB"` to `"⌥A"` in the ActionButtons component's auto-accept tooltip section (line 118 of ActionButtons.tsx).

This aligns with the existing pattern used for the bypass permissions button, which correctly shows `⌥Y` and follows the unicode symbol convention used throughout the app.

## How to verify it

- [x] I have ensured `make check test` passes

### Manual Testing

1. Launch the WUI application
2. Navigate to any session detail view
3. Hover over the auto-accept button (the "⏵⏵" button in the action buttons row)
4. Verify the tooltip displays "Enable/Disable auto-accept ⌥A" with the option symbol
5. Press Option+A to verify the hotkey still works as expected

## Description for the changelog

Fix: Auto-accept button tooltip now correctly displays ⌥A keyboard shortcut instead of ⇧+TAB

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes tooltip in `ActionButtons.tsx` to display correct hotkey `⌥A` for auto-accept edits and updates `HotkeyPanel.tsx` accordingly.
> 
>   - **Behavior**:
>     - Fixes tooltip for "auto-accept edits" button in `ActionButtons.tsx` to display `⌥A` instead of `⇧+TAB`.
>     - Updates `HotkeyPanel.tsx` to use `⌥+A` for "Toggle auto-accept edits".
>   - **Components**:
>     - Changes `KeyboardShortcut` component's `keyString` prop in `ActionButtons.tsx` to reflect the correct hotkey.
>     - Ensures consistency with other option-key shortcuts like `⌥Y` for bypass permissions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 35e023da8776b1f1ddcf8da37b3cb33e64db30ff. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->