### PR TITLE
(ENG-2289) Replace cmd+shift+. with 'e' for draft deletion

### DIFF
--- a/hld/api/handlers/approvals.go
+++ b/hld/api/handlers/approvals.go
@@ -6,12 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"github.com/humanlayer/humanlayer/hld/api"
 	"github.com/humanlayer/humanlayer/hld/api/mapper"
 	"github.com/humanlayer/humanlayer/hld/approval"
 	"github.com/humanlayer/humanlayer/hld/session"
 	"github.com/humanlayer/humanlayer/hld/store"
+	"log/slog"
 )
 
 type ApprovalHandlers struct {

--- a/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/SessionDetail.tsx
@@ -942,19 +942,6 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
     [selectedDirectory, session.workingDir, responseEditor, handleLaunchDraft],
   )
 
-  // Cmd+Shift+. handler for discarding draft sessions
-  useHotkeys(
-    'meta+shift+., ctrl+shift+.',
-    () => {
-      setShowDiscardDialog(true)
-    },
-    {
-      enabled: isDraft,
-      preventDefault: true,
-      scopes: [HOTKEY_SCOPES.DRAFT_LAUNCHER],
-    },
-  )
-
   // Option+A handler for auto-accept edits mode (draft version)
   useHotkeys(
     'alt+a, option+a',
@@ -1056,24 +1043,6 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
     },
   )
 
-  // Add hotkey to discard draft ('cmd+shift+.' key, which is 'mod+shift+>')
-  useHotkeys(
-    'meta+shift+period',
-    async () => {
-      console.log('[SessionDetail] discard draft hotkey "cmd+shift+>" fired')
-
-      // Only works for draft sessions
-      if (isDraft) {
-        handleDiscardDraft()
-      }
-    },
-    {
-      enableOnFormTags: true,
-      preventDefault: true,
-      scopes: [detailScope],
-    },
-  )
-
   // Add hotkey to archive session ('e' key)
   useHotkeys(
     'e',
@@ -1086,9 +1055,9 @@ function SessionDetail({ session, onClose }: SessionDetailProps) {
         return
       }
 
-      // Don't archive drafts with 'e' key
+      // Handle drafts - discard instead of archive
       if (isDraft) {
-        toast.warning('Drafts cannot be archived with "e" key. Use Cmd+Shift+. to discard drafts.')
+        handleDiscardDraft()
         return
       }
 


### PR DESCRIPTION
## Summary

- Removed the `cmd+shift+.` hotkey for discarding drafts
- Updated the `e` hotkey to discard drafts instead of showing a warning
- Improved handling of mixed selection (drafts + sessions)

## Problem

Users found the `cmd+shift+.` hotkey awkward and inconsistent with session archival behavior. The `e` key would show a warning when pressed on drafts instead of taking action.

## Solution

Made `e` behave consistently across both sessions and drafts:
- For sessions: archives/unarchives
- For drafts: discards (opens confirmation dialog)
- For mixed selection: shows appropriate warning

## Test Plan

- [x] Run `make check test` - all tests pass
- [ ] Manual testing: press `e` on a draft in the draft list view to verify it opens the discard dialog
- [ ] Manual testing: press `e` on a session to verify it archives
- [ ] Manual testing: select both drafts and sessions, press `e` to verify warning appears

Resolves ENG-2289
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaced `cmd+shift+.` with `e` for discarding drafts and updated `e` to handle both archiving sessions and discarding drafts.
> 
>   - **Behavior**:
>     - Removed `cmd+shift+.` hotkey for discarding drafts.
>     - Updated `e` hotkey to discard drafts (opens confirmation dialog) and archive/unarchive sessions.
>     - Handles mixed selection of drafts and sessions by showing a warning.
>   - **Files**:
>     - `SessionDetail.tsx`: Removed `cmd+shift+.` hotkey, updated `e` hotkey to discard drafts.
>     - `SessionTable.tsx`: Removed `cmd+shift+.` hotkey, updated `e` hotkey to handle both archiving and discarding drafts.
>   - **Misc**:
>     - Adjusted logging and error handling for new hotkey behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 9f0bbcd1bcfe5ba267825f3bce6f49406c74a3e9. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->