### PR TITLE
fix: Replace Enter unicode character with 'ENTER' text in keyboard shortcuts

### DIFF
--- a/humanlayer-wui/src/components/CommandInput.tsx
+++ b/humanlayer-wui/src/components/CommandInput.tsx
@@ -306,7 +306,9 @@ export default function CommandInput({
             ) : (
               <>
                 Launch Session
-                <kbd className="ml-2 px-1 py-0.5 text-xs bg-muted/50 rounded">{getPlatformKey()}+⏎</kbd>
+                <kbd className="ml-2 px-1 py-0.5 text-xs bg-muted/50 rounded">
+                  {getPlatformKey()}+ENTER
+                </kbd>
               </>
             )}
           </Button>

--- a/humanlayer-wui/src/components/OptInTelemetryModal.tsx
+++ b/humanlayer-wui/src/components/OptInTelemetryModal.tsx
@@ -131,7 +131,7 @@ export function OptInTelemetryModal({ open, onOpenChange }: OptInTelemetryModalP
                 <>
                   Enable Reporting
                   <kbd className="ml-2 px-1 py-0.5 text-xs bg-muted/50 rounded">
-                    {navigator.platform.toLowerCase().includes('mac') ? '⌘' : 'Ctrl'}+⏎
+                    {navigator.platform.toLowerCase().includes('mac') ? '⌘' : 'Ctrl'}+ENTER
                   </kbd>
                 </>
               )}

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/DenyButtons.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/DenyButtons.tsx
@@ -12,7 +12,7 @@ export function DenyButtons({
   isDisabled?: boolean
 }) {
   const isMac = navigator.platform.includes('Mac')
-  const sendKey = isMac ? '⌘+⏎' : 'Ctrl+⏎'
+  const sendKey = isMac ? '⌘+ENTER' : 'Ctrl+ENTER'
 
   return (
     <div

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ForkViewModal.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ForkViewModal.tsx
@@ -453,7 +453,7 @@ function ForkViewModalContent({
           >
             Fork Session
             <kbd className="ml-1 px-1 py-0.5 text-xs bg-muted/50 rounded">
-              {navigator.platform.toLowerCase().includes('mac') ? '⌘' : 'Ctrl'}+⏎
+              {navigator.platform.toLowerCase().includes('mac') ? '⌘' : 'Ctrl'}+ENTER
             </kbd>
           </Button>
         </DialogFooter>
@@ -463,7 +463,7 @@ function ForkViewModalContent({
             <span>↑↓/j/k Navigate</span>
             <span>1-9 Jump</span>
             <span>Tab Focus</span>
-            <span>⌘⏎ Fork</span>
+            <span>⌘+ENTER Fork</span>
             <span>Esc Cancel</span>
           </div>
         </div>


### PR DESCRIPTION
## What problem(s) was I solving?

The CodeLayer UI was inconsistently displaying keyboard shortcuts for the Enter key. The first-time modal (OptInTelemetryModal) and other UI components were using the Unicode character ⏎ (U+23CE) to represent the Enter key, while the standard practice across the codebase is to spell out "ENTER" as text. This created visual inconsistency and potential confusion for users.

Additionally, the keyboard shortcut format was inconsistent, sometimes showing `⌘ ENTER` (with a space) instead of `⌘+ENTER` (with a plus sign), which is the standard notation for key combinations.

## What user-facing changes did I ship?

- **Standardized keyboard shortcut display**: All Enter key references now use "ENTER" text instead of the ⏎ Unicode character
- **Consistent formatting**: All keyboard combinations now use the `+` symbol (e.g., `⌘+ENTER` instead of `⌘ ENTER`)
- **Affected UI components**:
  - OptInTelemetryModal: First-time setup modal's "Enable Reporting" button
  - CommandInput: "Launch Session" button
  - DenyButtons: Session denial confirmation tooltips
  - ForkViewModal: "Fork Session" button and keyboard hint text

## How I implemented it

1. **Identified all occurrences**: Used grep to find all instances of the Enter Unicode character (⏎ or \u23CE) across the codebase
2. **Replaced Unicode with text**: Changed all `⏎` characters to "ENTER" text
3. **Fixed formatting**: Updated keyboard shortcut format from space-separated to plus-separated (e.g., `⌘ ENTER` → `⌘+ENTER`)
4. **Verified completeness**: Confirmed no remaining Unicode Enter characters exist in the UI components

Changes were made in 4 files:
- `humanlayer-wui/src/components/OptInTelemetryModal.tsx`
- `humanlayer-wui/src/components/CommandInput.tsx`
- `humanlayer-wui/src/components/internal/SessionDetail/components/DenyButtons.tsx`
- `humanlayer-wui/src/components/internal/SessionDetail/components/ForkViewModal.tsx`

## How to verify it

### Manual Testing

- [ ] Open CodeLayer for the first time (or clear settings to trigger OptInTelemetryModal) - verify the "Enable Reporting" button shows `⌘+ENTER` or `Ctrl+ENTER`
- [ ] Open the Command Input component - verify the "Launch Session" button shows correct keyboard hint
- [ ] Open a session and try to deny it - verify the deny buttons show correct keyboard hints
- [ ] Open the Fork View Modal - verify both the button and the keyboard hints at the bottom show `⌘+ENTER`

### Automated Testing
- [x] Run `make check test` to ensure no TypeScript errors or test failures

## Description for the changelog

fix: Standardize keyboard shortcut display to use "ENTER" text instead of Unicode character across all UI components