### PR TITLE
[ENG-2273] Fix Model Selector modal keyboard navigation and hotkey scope

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ModelSelector.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ModelSelector.tsx
@@ -16,7 +16,7 @@ import { HOTKEY_SCOPES } from '@/hooks/hotkeys/scopes'
 import { useFocusTrap } from '@/hooks/useFocusTrap'
 import { daemonClient } from '@/lib/daemon'
 import { ConfigStatus, Session } from '@/lib/daemon/types'
-import { AlertCircle, CheckCircle, Eye, EyeOff, Pencil } from 'lucide-react'
+import { AlertCircle, CheckCircle, Eye, EyeOff, GitBranch, Pencil } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { toast } from 'sonner'
@@ -517,7 +517,6 @@ export function ModelSelector({
   const isOpen = open ?? internalOpen
   const setIsOpen = onOpenChange ?? setInternalOpen
 
-
   return (
     <HotkeyScopeBoundary
       scope={HOTKEY_SCOPES.SELECT_MODEL_MODAL}
@@ -528,14 +527,14 @@ export function ModelSelector({
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
         {/* Only show trigger if not controlled externally */}
         {!open && !onOpenChange && (
-          <DialogTrigger asChild >
+          <DialogTrigger asChild>
             <Button
               variant="ghost"
               size="sm"
               className={`h-8 w-8 p-0 ${className}`}
               title="Model Configuration"
             >
-              
+              <GitBranch className="h-4 w-4" />
             </Button>
           </DialogTrigger>
         )}

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/StatusBar.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/StatusBar.tsx
@@ -94,12 +94,11 @@ export function StatusBar({
                   : 'cursor-not-allowed hover:bg-transparent'
               } ${isReadyForInputOrDraft ? '' : getStatusTextClass(session.status)}`}
               onClick={() => isReadyForInputOrDraft && setIsModelSelectorOpen(true)}
-              onKeyDown={(e) => {
-                if (isReadyForInput && e.key === 'Enter') {
+              onKeyDown={e => {
+                if (isReadyForInputOrDraft && e.key === 'Enter') {
                   e.preventDefault()
                   setIsModelSelectorOpen(true)
                 }
-                isReadyForInputOrDraft && e.key === 'Enter' && setIsModelSelectorOpen(true)
               }}
             >
               {modelText}


### PR DESCRIPTION
## What problem(s) was I solving?

**Problem 1: CMD+ENTER launches draft instead of applying model preferences**

When the Model Selector modal was open on the draft launcher view, pressing CMD+ENTER would incorrectly launch the draft instead of applying the model/provider/API key changes. This happened because the modal lacked proper hotkey scope isolation, allowing the parent scope's (DRAFT_LAUNCHER) CMD+ENTER hotkey to "leak through" and trigger.

**Problem 2: No keyboard hint on Apply button**

The Apply button in the Model Selector modal did not display the standard `⌘+ENTER` (or `Ctrl+ENTER`) keyboard hint that users see on other modal action buttons throughout the application, making the keyboard shortcut less discoverable.

**Problem 3: Enter key doesn't open modal from status bar**

When users tabbed to focus the model selector button in the status bar and pressed Enter, the modal did not open. Only Space would work, creating an inconsistent keyboard navigation experience.

## What user-facing changes did I ship?

1. **CMD+ENTER now applies model preferences in the modal** - When the Model Selector modal is open, pressing CMD+ENTER (or Ctrl+ENTER on Windows/Linux) now correctly applies the model/provider/API key changes instead of launching the draft

2. **Keyboard hint always visible on Apply button** - The Apply button now displays `⌘+ENTER` (Mac) or `Ctrl+ENTER` (Windows/Linux) whenever the button is not in the "Applying..." state, even when disabled, to help users learn the keyboard shortcut

3. **Enter key opens modal from status bar** - Users can now press Enter when the model selector button in the status bar is focused to open the modal, matching standard button keyboard behavior

4. **Focus trapped within modal** - Tab navigation is now properly trapped within the modal, preventing focus from escaping to background elements

## How I implemented it

### 1. Added HotkeyScopeBoundary wrapper (ModelSelector.tsx:518-527)
Wrapped the Dialog component with `HotkeyScopeBoundary` using the `SELECT_MODEL_MODAL` scope with `rootScopeDisabled={true}`. This prevents hotkeys from parent scopes (like DRAFT_LAUNCHER) from firing while the modal is open.

### 2. Registered CMD+ENTER hotkey (ModelSelector.tsx:264-284)
Added `useHotkeys` hook to register `mod+enter` (CMD on Mac, Ctrl on Windows/Linux) with:
- `scopes: [HOTKEY_SCOPES.SELECT_MODEL_MODAL]` - only active when modal is open
- `enableOnFormTags: true` - allows hotkey to work when form elements (Select, Input, Button) are focused
- Conditional logic to only apply when button would be enabled (has changes, not updating, valid provider/model configuration)

### 3. Added keyboard hint to Apply button (ModelSelector.tsx:496-500)
Added a `<kbd>` element that displays the platform-appropriate modifier key (⌘ or Ctrl) + ENTER. The hint is always visible except during the "Applying..." state, matching the pattern used in other modals.

### 4. Implemented focus trap (ModelSelector.tsx:87-90, 287)
Added `useFocusTrap` hook with `allowTabNavigation: false` to trap Tab key navigation within the modal, wrapping the modal content with the focus trap ref.

### 5. Added Enter key handler to status bar button (StatusBar.tsx:97-102)
Added `onKeyDown` handler to the model selector button in the status bar that opens the modal when Enter is pressed (in addition to the existing Space key behavior from the Button component).

## How to verify it

### Automated Testing
- [x] Type checking passes: `make -C humanlayer-wui check`
- [x] Linting passes: `make -C humanlayer-wui check`
- [x] Build succeeds: `make -C humanlayer-wui build`

### Manual Testing

#### Test 1: CMD+ENTER applies preferences (not launch draft)
1. Create or open a draft session
2. Click the model selector button (GitBranch icon in status bar)
3. Change the model selection (e.g., from "System Default" to "Sonnet")
4. Press CMD+ENTER (or Ctrl+ENTER)
5. ✅ Verify: Modal closes, toast shows "Model updated", draft does NOT launch

#### Test 2: Keyboard hint visibility
1. Open the model selector modal
2. ✅ Verify: Apply button shows `⌘+ENTER` (Mac) or `Ctrl+ENTER` (Windows/Linux)
3. Make no changes (button is disabled)
4. ✅ Verify: Keyboard hint still visible even though button is disabled

#### Test 3: Enter key opens modal from status bar
1. Use Tab to navigate to the model selector button in the status bar
2. Press Enter
3. ✅ Verify: Modal opens
4. Close modal (Escape)
5. Tab back to button, press Space
6. ✅ Verify: Modal also opens (existing behavior preserved)

#### Test 4: Focus trap
1. Open the model selector modal
2. Press Tab repeatedly
3. ✅ Verify: Focus cycles through modal elements only, never escapes to background
4. Press Shift+Tab repeatedly
5. ✅ Verify: Focus cycles backward through modal elements

#### Test 5: Works in both draft and session detail views
1. Test in draft launcher view
2. ✅ Verify: All above behaviors work
3. Navigate to a completed session (session detail view)
4. ✅ Verify: All above behaviors work

## Description for the changelog

Fixed Model Selector modal keyboard navigation: CMD+ENTER now applies model preferences instead of launching drafts, keyboard hint is always visible, Enter key opens modal from status bar, and focus is properly trapped within the modal.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Model Selector modal keyboard navigation by applying CMD+ENTER for preferences, showing keyboard hints, trapping focus, and enabling Enter key to open modal from status bar.
> 
>   - **Behavior**:
>     - CMD+ENTER now applies model preferences in the `ModelSelector` modal instead of launching drafts.
>     - Enter key opens the `ModelSelector` modal from the status bar.
>     - Keyboard hint for CMD+ENTER is always visible on the Apply button.
>     - Focus is trapped within the `ModelSelector` modal.
>   - **Implementation**:
>     - Added `HotkeyScopeBoundary` in `ModelSelector.tsx` to isolate hotkey scope.
>     - Registered CMD+ENTER hotkey using `useHotkeys` in `ModelSelector.tsx`.
>     - Added keyboard hint to Apply button in `ModelSelector.tsx`.
>     - Implemented focus trap using `useFocusTrap` in `ModelSelector.tsx`.
>     - Added Enter key handler to status bar button in `StatusBar.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 5e59aa3ee0124fc13c6b65329456fe92434a80a9. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->