### PR TITLE
[ENG-2305] Replace JavaScript resize detection with Tailwind responsive utilities

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ActiveSession.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ActiveSession.tsx
@@ -238,7 +238,6 @@ export function ActiveSession({ session, onClose }: ActiveSessionProps) {
     responseEditor?.commands.setContent('')
   }, [responseEditor])
 
-
   // Reset scroll flag when session changes
   useEffect(() => {
     if (session.id) {


### PR DESCRIPTION
## What problem(s) was I solving?

The SessionDetail component (specifically ActiveSession) was using JavaScript-based resize detection to switch between responsive layouts. This approach had several drawbacks:

- **Performance overhead**: Window resize listeners fire continuously during resize operations, causing unnecessary React re-renders
- **SSR incompatibility**: The `isWideView` state initializes to `false` and then updates on mount, potentially causing hydration mismatches
- **Code complexity**: ~15 lines of JavaScript code managing state and event listeners for something CSS can handle natively
- **Delayed responsiveness**: JavaScript-based detection has a slight lag compared to native CSS media queries

## What user-facing changes did I ship?

No visible user-facing changes. The responsive behavior remains identical:
- TodoWidget sidebar appears at exactly 1024px width (same as before)
- Layout switches between single column (mobile) and two column (desktop) at the same breakpoint
- 80/20 width split maintained using Tailwind's fractional width utilities (lg:w-1/5 = 20%)

## How I implemented it

The refactoring involved three main phases:

### 1. Core Refactoring
- Removed the `isWideView` state variable and its associated useState hook
- Removed the resize event listener and its useEffect cleanup logic
- Replaced JavaScript-based conditional classes with Tailwind responsive utilities:
  - Layout container: Changed from `${isWideView ? 'flex-row' : 'flex-col'}` to `flex-col lg:flex-row`
  - TodoWidget: Changed from `{isWideView && ...}` conditional rendering to CSS visibility using `hidden lg:flex lg:w-1/5`

### 2. Documentation
- Added a "Responsive Design Patterns" section to `humanlayer-wui/CLAUDE.md`
- Documented Tailwind breakpoint usage across the codebase
- Provided implementation examples for future developers

### 3. Code Quality
- Ran Prettier formatting to ensure consistent code style
- All existing tests continue to pass without modification

## How to verify it

### Automated Verification
- [x] `make check test` - All checks and tests pass

### Manual Testing

To verify the responsive behavior works correctly:

1. Open any session with TodoWrite events in the SessionDetail view
2. Resize your browser window around the 1024px breakpoint
3. Verify:
   - TodoWidget appears at exactly 1024px width
   - TodoWidget disappears below 1024px width
   - Layout switches smoothly from horizontal to vertical
   - No visual jumps or flickers during resize
   - No console errors or React warnings

## Description for the changelog

refactor: Replace JavaScript resize detection with Tailwind responsive utilities in SessionDetail

Eliminated state-based responsive layout in ActiveSession component in favor of pure CSS media queries using Tailwind's lg: breakpoint (1024px). This removes resize event listeners, reduces React re-renders, and improves SSR compatibility while maintaining identical responsive behavior.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `ActiveSession` to use Tailwind CSS for responsive design, removing JavaScript resize detection.
> 
>   - **Behavior**:
>     - Removed `isWideView` state and associated `useState` hook in `ActiveSession`.
>     - Removed resize event listener and `useEffect` cleanup logic in `ActiveSession`.
>     - Replaced JavaScript-based conditional classes with Tailwind utilities in `ActiveSession`.
>   - **Documentation**:
>     - Added "Responsive Design Patterns" section to `CLAUDE.md`.
>     - Documented Tailwind breakpoint usage and provided examples.
>   - **Code Quality**:
>     - Ran Prettier for consistent code style.
>     - All tests pass without modification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 0dc5bb8b5eb29598face5e58a8b63cfc4adc6fe1. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->