### PR TITLE
[ENG-2312] Fix interrupt button functionality on session details page

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ActiveSession.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ActiveSession.tsx
@@ -202,7 +202,7 @@ export function ActiveSession({ session, onClose }: ActiveSessionProps) {
   }, [])
 
   // Use session actions hook
-  const actions = useSessionActions({
+  const { isResponding, handleContinueSession, interruptSession } = useSessionActions({
     session,
     onClose,
     pendingForkMessage: forkPreviewData?.message || null,
@@ -887,8 +887,9 @@ export function ActiveSession({ session, onClose }: ActiveSessionProps) {
         <ActiveSessionInput
           session={session}
           parentSessionData={parentSessionData || parentSession || undefined}
-          isResponding={actions.isResponding}
-          handleContinueSession={actions.handleContinueSession}
+          isResponding={isResponding}
+          handleContinueSession={handleContinueSession}
+          interruptSession={interruptSession}
           isForkMode={!!forkPreviewData}
           forkTokenCount={forkPreviewData?.tokenCount}
           forkTurnNumber={

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ActiveSessionInput.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ActiveSessionInput.tsx
@@ -25,6 +25,7 @@ interface ActiveSessionInputProps {
   parentSessionData?: Partial<Session>
   isResponding: boolean
   handleContinueSession: () => void
+  interruptSession: (sessionId: string) => void
   isForkMode?: boolean
   forkTokenCount?: number | null
   forkTurnNumber?: number
@@ -60,6 +61,7 @@ export const ActiveSessionInput = forwardRef<
       parentSessionData,
       isResponding,
       handleContinueSession,
+      interruptSession,
       isForkMode,
       forkTokenCount,
       forkTurnNumber,
@@ -173,7 +175,20 @@ export const ActiveSessionInput = forwardRef<
         session.status === SessionStatus.Running || session.status === SessionStatus.Starting
       const hasText = !isResponseEditorEmpty
 
-      // Early return if no text in editor
+      // Handle interrupt-only case (no text in editor)
+      if (!hasText && isRunning) {
+        if (!debouncedCanInterrupt) {
+          toast.warning('Session cannot be interrupted yet', {
+            description: 'Waiting for Claude to initialize the session. Please try again in a moment.',
+          })
+          return
+        }
+        // Interrupt the session
+        interruptSession(session.id)
+        return
+      }
+
+      // Early return if no text in editor and not running
       if (!hasText) {
         return
       }

--- a/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionActions.ts
+++ b/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionActions.ts
@@ -221,7 +221,9 @@ export function useSessionActions({
     },
     {
       scopes: [scope],
-      enableOnFormTags: true,
+      enableOnFormTags: ['INPUT', 'TEXTAREA', 'SELECT'],
+      enableOnContentEditable: true,
+      preventDefault: true,
     },
   )
 


### PR DESCRIPTION
## What problem(s) was I solving?

Fixed the non-functional "Interrupt" button on the session details page (ENG-2312). The button was displaying "Interrupt" when a session was running with no text in the editor, but clicking it did nothing. Additionally, the Ctrl+X keyboard shortcut worked correctly but didn't function when the TipTap editor was focused, which was inconsistent with other keyboard shortcuts in the application.

## What user-facing changes did I ship?

- **Interrupt button now works**: Users can now click the "Interrupt" button to interrupt a running session when there's no text in the editor
- **Improved keyboard shortcut**: The Ctrl+X shortcut now works consistently whether the TipTap editor is focused or not, matching the behavior of other shortcuts (Alt+A, Alt+Y, Cmd+Y)
- **Consistent validation**: Both the button and keyboard shortcut show the same warning toast when the session cannot be interrupted yet (when claudeSessionId is not ready)

## How I implemented it

The issue was caused by the `handleSubmit` function in `ActiveSessionInput` returning early when the editor was empty, preventing the interrupt logic from being reached. The `interruptSession` function existed and was being called by the Ctrl+X hotkey, but wasn't available to the input component.

The fix involved:
1. **Passing the interruptSession function**: Destructured `interruptSession` from `useSessionActions` in `ActiveSession.tsx` and passed it as a prop to `ActiveSessionInput`
2. **Updated component interface**: Added `interruptSession` to the `ActiveSessionInputProps` interface
3. **Fixed handleSubmit logic**: Modified `handleSubmit` to detect interrupt-only scenarios (running session + empty editor) and call `interruptSession` instead of returning early
4. **Enhanced hotkey configuration**: Added `enableOnContentEditable: true` and `preventDefault: true` to the Ctrl+X hotkey configuration to make it work when TipTap is focused

## How to verify it

### Manual Testing

- [x] TypeScript compilation passes (`make -C humanlayer-wui check`)
- [x] Linting passes (`make -C humanlayer-wui lint`)
- [x] Unit tests pass (`make -C humanlayer-wui test`)
- [x] Build completes successfully (`make -C humanlayer-wui build`)
- [ ] Start a new Claude session and wait for it to enter "running" state
- [ ] With empty editor, verify button shows "Interrupt" text
- [ ] Click the "Interrupt" button and verify session is interrupted
- [ ] Start another session, focus the TipTap editor
- [ ] Press Ctrl+X and verify session is interrupted
- [ ] Start a session, type some text, verify "Interrupt & Send" still works
- [ ] Start a session and immediately try to interrupt before claudeSessionId is set
- [ ] Verify warning toast appears for both button and hotkey when session cannot be interrupted yet

## Description for the changelog

Fix interrupt button functionality on session details page - button now properly interrupts running sessions and Ctrl+X works when editor is focused