### PR TITLE
Keep Write tool diffs always expanded in conversation stream

### DIFF
--- a/humanlayer-wui/src/components/internal/ConversationStream/EventContent/WriteToolCallContent.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/EventContent/WriteToolCallContent.tsx
@@ -1,7 +1,7 @@
 import { ToolHeader } from './ToolHeader'
 import { StatusBadge } from './StatusBadge'
 import { DiffViewer } from './DiffViewer/DiffViewer'
-import { formatToolResultPreview, detectToolError, getApprovalStatusColor } from './utils/formatters'
+import { getApprovalStatusColor } from './utils/formatters'
 import { ToolCallContentProps } from './types'
 
 export interface WriteToolInput {
@@ -17,9 +17,6 @@ interface WriteToolCallContentPropsWithSnapshot extends ToolCallContentProps<Wri
 export function WriteToolCallContent({
   toolInput,
   approvalStatus,
-  isCompleted,
-  toolResultContent,
-  isFocused,
   fileSnapshot,
   isGroupItem,
 }: WriteToolCallContentPropsWithSnapshot) {
@@ -28,9 +25,6 @@ export function WriteToolCallContent({
     isGroupItem && !approvalStatusColor ? 'text-[var(--terminal-accent)]' : approvalStatusColor
 
   const isNewFile = !fileSnapshot || fileSnapshot.trim() === ''
-  const hasError = toolResultContent ? detectToolError('Write', toolResultContent) : false
-  const preview = toolResultContent ? formatToolResultPreview(toolResultContent) : null
-  const showDiff = approvalStatus === 'pending' || approvalStatus === undefined
 
   return (
     <div className="space-y-2">
@@ -42,30 +36,14 @@ export function WriteToolCallContent({
         status={<StatusBadge status={approvalStatus} />}
       />
 
-      {showDiff && (
-        <div className="mt-2">
-          <DiffViewer
-            oldContent={fileSnapshot || ''}
-            newContent={toolInput.content || ''}
-            mode="unified"
-            showFullFile={false}
-          />
-        </div>
-      )}
-
-      {!showDiff && isCompleted && (
-        <div className="mt-1 text-sm text-muted-foreground font-mono flex items-start gap-1">
-          <span className="text-muted-foreground/50">⎿</span>
-          <span className={hasError ? 'text-destructive' : ''}>
-            {hasError ? preview || 'Error writing file' : isNewFile ? 'File created' : 'File written'}
-            {isFocused && !hasError && (
-              <span className="text-xs text-muted-foreground/50 ml-2">
-                <kbd className="px-1 py-0.5 text-xs bg-muted/50 rounded">i</kbd> expand
-              </span>
-            )}
-          </span>
-        </div>
-      )}
+      <div className="mt-2">
+        <DiffViewer
+          oldContent={fileSnapshot || ''}
+          newContent={toolInput.content || ''}
+          mode="unified"
+          showFullFile={false}
+        />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## What problem(s) was I solving?

Write tool calls in the Claude Code conversation stream would collapse their diff view immediately after approval, hiding the file changes from view. This was problematic because:

1. Users lost visibility of what files were being created or modified once they approved the change
2. The behavior was inconsistent with Edit tools, which remain expanded throughout their lifecycle
3. With "dangerously bypass permissions" enabled, Write tool diffs would instantly collapse, making it impossible to review what was written

This issue was tracked as [ENG-2275](https://linear.app/humanlayer/issue/ENG-2275/feature-write-tool-calls-should-stay-expanded-in-the-stream).

## What user-facing changes did I ship?

- **Write tool calls now always show their diff view** - The file changes remain visible regardless of approval status (pending, approved, or denied) and completion state
- **Removed the collapsed state entirely** - The single-line "File created" or "File written" message no longer appears; the diff is always visible
- **Consistent behavior with Edit tools** - All file modification tools now maintain their expanded state throughout execution

## How I implemented it

The fix was a targeted change to the `WriteToolCallContent` component:

1. **Removed conditional display logic**: Changed `showDiff` from being conditional on `approvalStatus` to always being `true`
2. **Deleted collapsed message UI**: Removed the entire block that rendered the collapsed state message
3. **Cleaned up unused code**:
   - Removed unused imports (`formatToolResultPreview`, `detectToolError`)
   - Removed unused variables (`hasError`, `preview`, `showDiff`)
   - Removed unused component parameters (`isCompleted`, `toolResultContent`, `isFocused`)
4. **Simplified JSX**: Since the diff is always shown, removed the conditional wrapper around the `DiffViewer`

The implementation ensures the diff viewer is unconditionally rendered, providing permanent visibility of file changes.

## How to verify it

### Automated Testing
- [x] Type checking passes: `make -C humanlayer-wui check`
- [x] Linting passes: `make -C humanlayer-wui lint`
- [x] Unit tests pass: `make -C humanlayer-wui test`
- [x] Build succeeds: `make -C humanlayer-wui build`

### Manual Testing

1. Create a Claude Code session and have it write a file
2. Verify the diff remains visible when:
   - [ ] Tool call is pending approval
   - [ ] After approving the tool call
   - [ ] After denying the tool call
   - [ ] During tool execution
   - [ ] After successful completion
3. Enable "dangerously bypass permissions" mode
   - [ ] Verify Write tool diffs stay expanded (don't instantly collapse)
4. Test keyboard navigation:
   - [ ] Press 'i' on a Write tool call to expand into modal view
5. Test with large files:
   - [ ] Create a Write tool call with >1000 lines
   - [ ] Verify performance remains acceptable

## Description for the changelog

Keep Write tool diffs always expanded in conversation stream - file changes now remain visible throughout the entire tool lifecycle instead of collapsing after approval