### PR TITLE
fix: max thinking tokens

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,5 +6,8 @@
       "Bash(bash hack/spec_metadata.sh)"
     ]
   },
-  "enableAllProjectMcpServers": false
+  "enableAllProjectMcpServers": false,
+  "env": {
+    "MAX_THINKING_TOKENS": "32000"
+  }
 }


### PR DESCRIPTION
set MAX_THINKING_TOKENS to `32000` in `.claude/settings.json` so we don't need to use `ultrathink` all the time

due to a change in claude / claude code where the model seems less willing to think spontaneously without ultrathink
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `MAX_THINKING_TOKENS` to `32000` in `.claude/settings.json` to reduce reliance on `ultrathink`.
> 
>   - **Configuration**:
>     - Set `MAX_THINKING_TOKENS` to `32000` in `.claude/settings.json` to reduce reliance on `ultrathink`.
>   - **Context**:
>     - Addresses a change in Claude's behavior where the model is less willing to think spontaneously without `ultrathink`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for ad41c7d54dc278a525a143251af4cac53a672c70. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->