### PR TITLE
Fix draft table to show user message preview when title is blank

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -6,7 +6,12 @@ import { useEffect, useRef, useState } from 'react'
 import { CircleOff, CheckSquare, Square, Pencil, ShieldOff } from 'lucide-react'
 import { SentryErrorBoundary } from '@/components/ErrorBoundary'
 import { getStatusTextClass } from '@/utils/component-utils'
-import { formatTimestamp, formatAbsoluteTimestamp } from '@/utils/formatting'
+import {
+  formatTimestamp,
+  formatAbsoluteTimestamp,
+  truncate,
+  extractTextFromEditorState,
+} from '@/utils/formatting'
 import { highlightMatches } from '@/lib/fuzzy-search'
 import { cn } from '@/lib/utils'
 import { useStore } from '@/AppStore'
@@ -682,7 +687,13 @@ function SessionTableInner({
                     ) : (
                       <div className="flex items-center gap-2 group">
                         <span>
-                          {renderHighlightedText(session.title || session.summary || '', session.id)}
+                          {renderHighlightedText(
+                            session.title ||
+                              session.summary ||
+                              (session.query ? truncate(session.query, 80) : '') ||
+                              truncate(extractTextFromEditorState(session.editorState), 80),
+                            session.id,
+                          )}
                         </span>
                         <Button
                           size="sm"

--- a/humanlayer-wui/src/utils/formatting.ts
+++ b/humanlayer-wui/src/utils/formatting.ts
@@ -160,3 +160,48 @@ export function getSessionNotificationText(
   const text = session.title || session.summary || session.query
   return text.trim().slice(0, maxLength)
 }
+
+/**
+ * Extract plaintext from TipTap editor state JSON
+ * @param editorState - JSON string containing TipTap editor state
+ * @returns Extracted plaintext content
+ */
+export function extractTextFromEditorState(editorState: string | undefined): string {
+  if (!editorState) return ''
+
+  try {
+    const parsed = JSON.parse(editorState)
+    return extractTextFromNode(parsed)
+  } catch {
+    // If parsing fails, return empty string
+    return ''
+  }
+}
+
+/**
+ * Recursively extract text from a TipTap node
+ * @param node - TipTap node object
+ * @returns Extracted text content
+ */
+function extractTextFromNode(node: any): string {
+  if (!node) return ''
+
+  // Handle text nodes
+  if (node.type === 'text') {
+    return node.text || ''
+  }
+
+  // Handle mention nodes (file references)
+  if (node.type === 'mention') {
+    // Use the label if available, otherwise use the id (file path)
+    return node.attrs?.label || node.attrs?.id || ''
+  }
+
+  // Handle nodes with content (doc, paragraph, etc.)
+  if (node.content && Array.isArray(node.content)) {
+    return node.content.map(extractTextFromNode).join('')
+  }
+
+  // Default: return empty string for unknown node types
+  return ''
+}


### PR DESCRIPTION
## What problem(s) was I solving?

Fixed [ENG-2293](https://linear.app/humanlayer/issue/ENG-2293/bug-draft-table-doesnt-show-user-message-preview-when-title-is-blank) - Draft sessions in the table view showed empty cells when no title was set, making it impossible for users to identify their drafts.

The root cause was that draft sessions store prompt text in the `editorState` field as TipTap JSON (rich editor format) rather than in the `query` field. The `query` field only gets populated when a draft is launched, meaning unlaunch drafts always had an empty `query` field and would display as blank in the table.

## What user-facing changes did I ship?

- **Before**: Draft sessions without titles showed as empty rows in the drafts table, providing no way to identify them
- **After**: Draft sessions now display a truncated preview (80 chars) of the prompt text, making them easily identifiable

The drafts table now shows content with this priority:
1. User-set title (if available)
2. AI-generated summary (if available)
3. Query text from launched sessions (if available)
4. **NEW**: Extracted text from editor state for unlaunched drafts
5. Empty string as final fallback

## How I implemented it

### Added text extraction utility (`humanlayer-wui/src/utils/formatting.ts`)
- Created `extractTextFromEditorState()` function that parses TipTap JSON and extracts plaintext
- Handles text nodes, mention nodes (file references), and nested content structures
- Returns empty string gracefully if parsing fails

### Updated SessionTable display logic (`humanlayer-wui/src/components/internal/SessionTable.tsx`)
- Added `extractTextFromEditorState` to the import list
- Extended the fallback chain for title display to include extracted editor state text
- Applied 80-character truncation to prevent table overflow

The implementation follows existing patterns in the codebase (similar to `getSessionNotificationText`) and requires no backend changes since the `editorState` field is already returned by the ListSessions API.

## How to verify it

### Automated Testing
- [x] Type checking passes: `make -C humanlayer-wui check`
- [x] Linting passes: `make -C humanlayer-wui lint`
- [x] Unit tests pass: `make -C humanlayer-wui test`

### Manual Testing

1. **Test draft with prompt but no title:**
   - Create a new draft session
   - Enter some prompt text (e.g., "Help me refactor this authentication code")
   - Do NOT set a custom title
   - Navigate back to the drafts list
   - ✅ Verify the prompt text appears truncated in the Title column

2. **Test existing behavior is preserved:**
   - Create a draft with a custom title set
   - ✅ Verify the custom title still takes precedence
   - Launch a draft to generate a summary
   - ✅ Verify summary shows when no title is set

3. **Test truncation:**
   - Create a draft with a very long prompt (200+ characters)
   - ✅ Verify it shows truncated with "..." at 80 characters
   - ✅ Verify the table layout isn't broken

## Description for the changelog

Fixed draft sessions showing as blank in the drafts table when no title was set. The table now displays a preview of the draft's prompt text, making it easy to identify drafts at a glance.