### PR TITLE
fix: add renderText to slash-command mention to prevent double slashes

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ActiveSessionInput.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ActiveSessionInput.tsx
@@ -162,18 +162,6 @@ export const ActiveSessionInput = forwardRef<
       async (value: Content) => {
         const valueStr = JSON.stringify(value)
 
-        // Debug logging for slash commands
-        const textContent = responseEditor?.getText() ?? ''
-        if (textContent.includes('/')) {
-          logger.log('[SLASH_DEBUG] ActiveSessionInput - handleChange with slash:', {
-            textContent,
-            jsonContent: value,
-            valueToStore: valueStr,
-            sessionId: session.id,
-            timestamp: Date.now(),
-          })
-        }
-
         // Save to localStorage for active sessions
         localStorage.setItem(`${ResponseInputLocalStorageKey}.${session.id}`, valueStr)
       },
@@ -182,22 +170,6 @@ export const ActiveSessionInput = forwardRef<
 
     const handleSubmit = () => {
       logger.log('ActiveSessionInput.handleSubmit()')
-
-      // Debug log the content being sent
-      const editorContent = responseEditor?.getText() ?? ''
-      const editorJSON = responseEditor?.getJSON()
-
-      logger.log('[SLASH_DEBUG] ActiveSessionInput - Submitting with content:', {
-        textContent: editorContent,
-        jsonContent: editorJSON,
-        containsSlash: editorContent.includes('/'),
-        doubleSlash: editorContent.includes('//'),
-        sessionId: session.id,
-        sessionStatus: session.status,
-        isDenying,
-        isForkMode,
-        timestamp: Date.now(),
-      })
 
       // Check if this is an interruption attempt without claudeSessionId
       const isRunning =

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/DraftLauncherInput.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/DraftLauncherInput.tsx
@@ -90,17 +90,6 @@ export const DraftLauncherInput = forwardRef<
 
         const textContent = responseEditor?.getText() ?? ''
 
-        // Debug logging for slash commands
-        if (textContent.includes('/')) {
-          logger.log('[SLASH_DEBUG] DraftLauncherInput - handleChange with slash:', {
-            textContent,
-            jsonContent: value,
-            editorStateToSave: valueStr,
-            sessionId: session.id,
-            timestamp: Date.now(),
-          })
-        }
-
         // Only notify parent if there's actual text content (not just empty editor structure)
         if (onContentChange && textContent.trim().length > 0) {
           onContentChange()
@@ -129,19 +118,6 @@ export const DraftLauncherInput = forwardRef<
       if (isResponseEditorEmpty) {
         return
       }
-
-      // Debug log the final content being sent
-      const editorContent = responseEditor?.getText() ?? ''
-      const editorJSON = responseEditor?.getJSON()
-
-      logger.log('[SLASH_DEBUG] DraftLauncherInput - Submitting draft with content:', {
-        textContent: editorContent,
-        jsonContent: editorJSON,
-        containsSlash: editorContent.includes('/'),
-        doubleSlash: editorContent.includes('//'),
-        sessionId: session.id,
-        timestamp: Date.now(),
-      })
 
       // Launch the draft with current settings
       onLaunchDraft({

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/SlashCommandList.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/SlashCommandList.tsx
@@ -86,14 +86,6 @@ export const SlashCommandList = forwardRef<SlashCommandListRef, SlashCommandList
     // Keyboard navigation
     const onKeyDown = useCallback(
       ({ event }: { event: KeyboardEvent }) => {
-        logger.log('[SLASH_DEBUG] SlashCommandList - onKeyDown:', {
-          key: event.key,
-          selectedIndex,
-          commands: commands.map(c => c.name),
-          currentlySelected: commands[selectedIndex]?.name,
-          timestamp: Date.now(),
-        })
-
         if (event.key === 'ArrowUp') {
           event.preventDefault()
           mouseEnabledRef.current = false
@@ -123,12 +115,6 @@ export const SlashCommandList = forwardRef<SlashCommandListRef, SlashCommandList
           event.preventDefault()
           if (commands.length > 0) {
             const selected = commands[selectedIndex]
-            logger.log('[SLASH_DEBUG] SlashCommandList - Enter pressed, selecting command:', {
-              selectedCommand: selected.name,
-              selectedIndex,
-              commandToSend: { id: selected.name, label: selected.name },
-              timestamp: Date.now(),
-            })
             // Pass the full command with slash - Tiptap will replace the trigger /
             command({ id: selected.name, label: selected.name })
           }
@@ -136,13 +122,11 @@ export const SlashCommandList = forwardRef<SlashCommandListRef, SlashCommandList
         }
 
         if (event.key === ' ') {
-          logger.log('[SLASH_DEBUG] SlashCommandList - Space pressed, closing dropdown')
           // Space closes dropdown, leaves raw text
           return false
         }
 
         if (event.key === 'Escape') {
-          logger.log('[SLASH_DEBUG] SlashCommandList - Escape pressed, closing dropdown')
           return false
         }
 
@@ -206,11 +190,6 @@ export const SlashCommandList = forwardRef<SlashCommandListRef, SlashCommandList
                 mouseEnabledRef.current = true
               }}
               onClick={() => {
-                logger.log('[SLASH_DEBUG] SlashCommandList - Button clicked, selecting command:', {
-                  selectedCommand: cmd.name,
-                  commandToSend: { id: cmd.name, label: cmd.name },
-                  timestamp: Date.now(),
-                })
                 // Pass the full command with slash - Tiptap will replace the trigger /
                 command({ id: cmd.name, label: cmd.name })
               }}


### PR DESCRIPTION
The slash command autocomplete was inserting double slashes (e.g. //research_codebase) because TipTap's getText() method didn't know how to serialize the mention node properly. Added a renderText function that returns the label as-is since it already contains the slash.

Also added debug logging with [SLASH_DEBUG] prefix to track the slash command flow through selection, insertion, and serialization for verification.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes double slashes in slash commands by adding `renderText` in `ResponseEditor.tsx` and adds debug logging for slash command flow.
> 
>   - **Behavior**:
>     - Adds `renderText` function to `slash-command` in `ResponseEditor.tsx` to prevent double slashes by returning the label as-is.
>     - Adds debug logging with `[SLASH_DEBUG]` prefix to track slash command flow.
>   - **Misc**:
>     - Updates `handleChange` dependencies in `ActiveSessionInput.tsx` to include `responseEditor`.
>     - Minor import reordering in `ResponseEditor.tsx` and `SlashCommandList.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 8b164c2607b1a55ee4a15add99c4ff1c39676d1f. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->