### PR TITLE
feat: implement tagged stable build system with auto-versioning

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -73,7 +73,8 @@ jobs:
 
               if (inputVersion) {
                 // Manual dispatch with explicit version
-                buildVersion = inputVersion;
+                // Strip leading 'v' if present for normalization
+                buildVersion = inputVersion.replace(/^v/, '');
               } else {
                 // Manual dispatch without version - auto-increment patch
                 // Fetch tags from GitHub API

--- a/humanlayer-wui/src-tauri/src/daemon.rs
+++ b/humanlayer-wui/src-tauri/src/daemon.rs
@@ -40,6 +40,8 @@ impl DaemonManager {
         is_dev: bool,
         branch_override: Option<String>,
     ) -> Result<DaemonInfo, String> {
+        // Check if this is a nightly build based on app identifier
+        let is_nightly = app_handle.config().identifier.contains("nightly");
         // Check if already running
         {
             let process = self.process.lock().unwrap();
@@ -131,6 +133,9 @@ impl DaemonManager {
                 }
             }
             dev_db
+        } else if is_nightly {
+            // Nightly build uses daemon-nightly.db
+            humanlayer_dir.join("daemon-nightly.db")
         } else {
             humanlayer_dir.join("daemon.db")
         };
@@ -141,6 +146,9 @@ impl DaemonManager {
             PathBuf::from(sock_path)
         } else if is_dev {
             humanlayer_dir.join(format!("daemon-{branch_id}.sock"))
+        } else if is_nightly {
+            // Nightly build uses daemon-nightly.sock
+            humanlayer_dir.join("daemon-nightly.sock")
         } else {
             humanlayer_dir.join("daemon.sock")
         };


### PR DESCRIPTION
## Summary

Implements ENG-2271: Tagged stable build system that creates official releases triggered by git tags or manual workflow dispatch. This complements the existing nightly build system with stable, versioned releases using semantic versioning.

## Changes

### Tag Push Trigger & Version Detection
- Added git tag trigger for semantic versions (`v[0-9]+.[0-9]+.[0-9]+`)
- Implemented auto-increment patch version for manual dispatch without explicit version
- Added version validation (rejects pre-release tags like `v0.2.0-beta`)
- Auto-creates and pushes tags when using auto-increment

### Build Process for Stable Builds
- Explicit LDFLAGS injection for both stable and nightly builds
  - **Stable**: `daemon.db`, `daemon.sock`, port 7777, `humanlayer` command
  - **Nightly**: `daemon-nightly.db`, `daemon-nightly.sock`, port 7778, `humanlayer-nightly` command
- Icon swapping only for nightly builds
- DMG naming: `CodeLayer-darwin-arm64.dmg` (stable) vs versioned (nightly)
- Tauri config selection based on build type

### GitHub Release Creation
- Correct tag naming: `v{version}` for stable, version string for nightly
- `make_latest: true` only for stable releases
- `prerelease: true` only for nightly builds
- Dynamic release body adapts between Nightly/Stable labels

### Homebrew Cask Automation
- Auto-updates `codelayer.rb` for stable releases
- Auto-updates `codelayer-nightly.rb` for nightly builds
- Correct SHA256 calculation and URL generation
- Atomic commits to homebrew-humanlayer repo

### Bug Fix
- Fixed version normalization to strip leading 'v' from manual input (prevents `vv0.12.0` in URLs)

## Testing

Successfully tested on branch with workflow run:
- Run ID: 18549587025
- Auto-incremented version to 0.11.3
- Created tag `v0.11.3`
- Built stable release with correct LDFLAGS
- Updated homebrew cask correctly
- Marked as latest release (not pre-release)

## Isolation Configuration

| Component | Stable | Nightly |
|-----------|--------|---------|
| **Database** | `daemon.db` | `daemon-nightly.db` |
| **Socket** | `daemon.sock` | `daemon-nightly.sock` |
| **Port** | `7777` | `7778` |
| **CLI Command** | `humanlayer` | `humanlayer-nightly` |

Both versions can run simultaneously without conflicts.

## Related Documentation

- Implementation plan: `thoughts/shared/plans/2025-01-04-ENG-2271-tagged-stable-build.md`
- Socket isolation plan: `thoughts/shared/plans/2025-01-05-ENG-2271-daemon-socket-isolation.md`
- Research: `thoughts/shared/research/2025-10-04-ENG-2271-macos-nightly-build-system.md`