### PR TITLE
Add codelayer binary aliases to workflow cask generation

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -397,6 +397,7 @@ jobs:
             app "CodeLayer.app"
 
             binary "#{appdir}/CodeLayer.app/Contents/Resources/bin/humanlayer"
+            binary "#{appdir}/CodeLayer.app/Contents/Resources/bin/humanlayer", target: "codelayer"
             binary "#{appdir}/CodeLayer.app/Contents/Resources/bin/hld"
 
             zap trash: [
@@ -433,6 +434,7 @@ jobs:
             app "CodeLayer-Nightly.app"
 
             binary "#{appdir}/CodeLayer-Nightly.app/Contents/Resources/bin/humanlayer", target: "humanlayer-nightly"
+            binary "#{appdir}/CodeLayer-Nightly.app/Contents/Resources/bin/humanlayer", target: "codelayer-nightly"
             binary "#{appdir}/CodeLayer-Nightly.app/Contents/Resources/bin/hld", target: "hld-nightly"
 
             zap trash: [


### PR DESCRIPTION
Update the GitHub workflow to include codelayer and codelayer-nightly binary symlinks when generating Homebrew cask files. This ensures the aliases are included in automated releases.

- Stable: Added 'codelayer' symlink alongside 'humanlayer'
- Nightly: Added 'codelayer-nightly' symlink alongside 'humanlayer-nightly'

Part of ENG-2327

## What problem(s) was I solving?

## What user-facing changes did I ship?

## How I implemented it

## How to verify it

- [ ] I have ensured `make check test` passes

## Description for the changelog

## A picture of a cute animal (not mandatory but encouraged)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `codelayer` and `codelayer-nightly` binary symlinks to GitHub workflow for Homebrew cask generation.
> 
>   - **GitHub Workflow**:
>     - Update `release-macos.yml` to include `codelayer` symlink for stable builds and `codelayer-nightly` symlink for nightly builds.
>     - Stable: Add `binary "#{appdir}/CodeLayer.app/Contents/Resources/bin/humanlayer", target: "codelayer"`.
>     - Nightly: Add `binary "#{appdir}/CodeLayer-Nightly.app/Contents/Resources/bin/humanlayer", target: "codelayer-nightly"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for edafab550f930b5a798b7b20fd6688c95650007e. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->