### PR TITLE
feat(linear): Update ResearchBot to output terse comments only

### DIFF
--- a/.github/workflows/linear-research-tickets.yml
+++ b/.github/workflows/linear-research-tickets.yml
@@ -129,7 +129,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: >
-          cd humanlayer && claude --dangerously-skip-permissions --model opus -p '/research_codebase ${{ env.TICKET_FILE_PATH }} 
+          cd humanlayer && claude --dangerously-skip-permissions --model opus -p '/research_codebase ${{ env.TICKET_FILE_PATH }}
             Start by reading the ticket and all of the comments.
             Pay extra code attention to the comments - if you (LinearLayer/claude) are mentioned in a comment you should treat that comment as an instruction.
             Also check /thoughts/shared/images/${{matrix.ticket_id}} for any relevant images and read any you find.
@@ -138,9 +138,17 @@ jobs:
             **DO NOT ASK THE USER FOR DIRECTIONS OR CLARIFICATION. Simply proceed to the research based on the information you have been provided with, and then write your research document. **
 
             If there is already a research document for this ticket and there are comments on the ticket, use the comments as instructions for updating the research document.
-            When referencing the research document that you created in thoughts/ to the user once you finish, always provide GitHub markdown-style links:
-            - thoughts/shared/research/... → [LINK TITLE HERE](https://github.com/humanlayer/thoughts/blob/main/repos/humanlayer/shared/research/...)
-              
+
+            CRITICAL: After completing all your research and writing the document, your FINAL output must be EXACTLY in this format (nothing else):
+
+            research completed - [thoughts/shared/YYYY-MM-DD-ENG-XXXX-description.md](https://github.com/humanlayer/thoughts/blob/main/repos/humanlayer/shared/research/YYYY-MM-DD-ENG-XXXX-description.md)
+
+            ### open questions
+            1. [First open question from your research document]
+            2. [Second open question from your research document]
+            3. [Continue for all open questions, or write "None at this time" if there are no open questions]
+
+            Output ONLY this message as your final response, nothing else. Do not include any other text, explanations, or conversation before or after this format.
             ' 2>&1 | tee CLAUDE_ANSWER.md
 
       - name: Sync research to thoughts


### PR DESCRIPTION
## What problem(s) was I solving?

ResearchBot (LinearLayer/Claude) was posting extremely verbose comments to Linear tickets containing the entire Claude conversation history, including tool calls, thinking processes, and implementation details. This made Linear comments difficult to read and cluttered the ticket history with unnecessary information.

**Issue:** [ENG-2240](https://linear.app/humanlayer/issue/ENG-2240) - Update ResearchBot comments to be terse with doc link and open questions

## What user-facing changes did I ship?

**For Linear ticket viewers:**
- ResearchBot comments are now concise and readable, containing only:
  - "research completed" message with a clickable link to the research document
  - A list of open questions from the research
- No more verbose conversation logs, tool outputs, or implementation chatter in Linear comments

**Example new format:**
```
research completed - [thoughts/shared/2025-10-21-ENG-XXXX-description.md](https://github.com/humanlayer/thoughts/blob/main/repos/humanlayer/shared/research/2025-10-21-ENG-XXXX-description.md)

### open questions
1. Should we add retry logic for API failures?
2. How should we handle legacy data format?
3. None at this time [if no questions]
```

## How I implemented it

**Single, Simple Change - Prompt Modification:**

Updated the Claude prompt in `.github/workflows/linear-research-tickets.yml` to explicitly instruct Claude to output ONLY the terse format as its final response.

**Key changes:**
1. Removed the old instruction about formatting GitHub links inline
2. Added a `CRITICAL:` section that specifies the exact output format required
3. Emphasized "Output ONLY this message as your final response, nothing else"

**What I did NOT do** (per the implementation plan):
- No parsing or extraction logic
- No markers or separators
- No modifications to the Linear CLI
- No changes to `/research_codebase` command
- Just a clean prompt change

The workflow still captures output with `tee CLAUDE_ANSWER.md` and posts it via `linear add-comment`, but now Claude's output is exactly what we want posted.

## How to verify it

### Automated Verification:
- [x] YAML syntax is valid (verified with `yq`)
- [x] Workflow file syntax is correct

### Manual Testing:

**To test this change:**
1. Create or use a Linear ticket with status "research needed" assigned to "LinearLayer (Claude)"
2. Trigger the workflow manually: `gh workflow run "Linear: Research Task" --repo humanlayer/humanlayer`
3. Wait for the workflow to complete
4. Check the Linear comment - it should contain ONLY:
   - Research completion message with document link
   - Open questions section
   - No verbose conversation history, tool outputs, or extra explanations
5. Click the research document link to verify it navigates correctly

**Note:** This change only affects NEW research runs. Existing comments with old format will remain unchanged.

## Description for the changelog

**ResearchBot now posts concise Linear comments** - Updated the automated research workflow to post terse comments containing only the research document link and open questions, eliminating verbose conversation logs from Linear ticket comments.

---

## Additional Changes in This PR

This PR also includes work related to directory validation and creation for the WUI (CodeLayer) and HLD daemon:

- Added directory validation and creation endpoints to HLD API
- Added directory validation to WUI launch flow with creation dialog
- Deferred directory validation for draft sessions to launch time
- Various cleanup and regeneration of API types

These changes improve the user experience when launching Claude Code sessions with directories that don't exist yet.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updated ResearchBot to post concise comments in Linear tickets by modifying the Claude prompt in the GitHub workflow.
> 
>   - **Behavior**:
>     - ResearchBot comments in Linear are now concise, containing only a research completion message with a document link and open questions.
>     - Removed verbose conversation logs and tool outputs from comments.
>   - **Workflow Changes**:
>     - Updated `.github/workflows/linear-research-tickets.yml` to modify the Claude prompt to output only the specified terse format.
>     - Added a `CRITICAL:` section in the prompt to specify the exact output format.
>     - Emphasized that only the specified message should be outputted as the final response.
>   - **Misc**:
>     - No changes to parsing logic, Linear CLI, or `/research_codebase` command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for d5dd10cf58a74764fa5156964df1b5380e102b6b. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->