### PR TITLE
fix(hld): improve session search to match UI display logic

### DIFF
--- a/hld/api/openapi.yaml
+++ b/hld/api/openapi.yaml
@@ -519,9 +519,10 @@ paths:
   /sessions/search:
     get:
       operationId: searchSessions
-      summary: Search sessions by title
+      summary: Search sessions
       description: |
-        Search for sessions using SQL LIKE queries against the title field.
+        Search for sessions using SQL LIKE queries across title, summary, and query fields.
+        Only returns "normal" leaf sessions (not archived, not draft, not discarded, no children).
         Returns top sessions ordered by last_activity_at descending.
         Limited to 20 most recently modified sessions for performance.
       tags:
@@ -533,7 +534,7 @@ paths:
           schema:
             type: string
             maxLength: 100
-          description: Search query for title matching (uses SQL LIKE)
+          description: Search query for matching against title, summary, or query fields (uses SQL LIKE)
         - name: limit
           in: query
           required: false


### PR DESCRIPTION
## What problem(s) was I solving?

Users couldn't find sessions in the cmd+k command palette when searching for text that was actually displayed in the UI. The disconnect happened because:

1. **UI Display Logic**: The WUI displays session text using a fallback pattern: `session.title || session.summary || session.query` (see CommandPaletteMenu.tsx:218 and formatting.ts:160)
2. **Search Logic Mismatch**: The backend `SearchSessionsByTitle` was only searching the `title` field
3. **Result**: Sessions without an explicit title (showing their summary or query instead) wouldn't appear in search results even when users typed the exact text they saw in the UI

Additionally, the search was returning sessions that shouldn't be user-facing:
- Parent sessions (which have children and aren't "real" leaf sessions)
- Archived sessions
- Draft sessions
- Discarded sessions

## What user-facing changes did I ship?

Users can now find sessions in cmd+k search by typing any part of the text they see displayed in the UI:
- Search now works across **title**, **summary**, and **query** fields
- Search results are cleaner - only shows active, leaf sessions
- No more confusing results from archived/draft/discarded sessions
- No more parent sessions cluttering results

## How I implemented it

Updated `SearchSessionsByTitle` in hld/store/sqlite.go:

1. **Expanded search scope**: Changed from single field (`title LIKE ?`) to multi-field search (`title LIKE ? OR summary LIKE ? OR query LIKE ?`)
2. **Added leaf session filter**: Added subquery to exclude sessions that have children
3. **Added status filters**: Filter out archived (`archived = 1`), draft (`status = 'draft'`), and discarded (`status = 'discarded'`) sessions
4. **Updated API documentation**: Modified openapi.yaml to reflect new search behavior and comprehensive description

Added comprehensive test coverage in hld/store/sqlite_test.go:
- Test for leaf session filtering (only children returned, not parents)
- Tests for excluding archived, draft, and discarded sessions
- Test for multi-field search across title, summary, and query
- Verified ordering by last_activity_at DESC

## How to verify it

- [x] I have ensured `make check test` passes

### Manual Testing

To verify this fix manually:

1. **Start the WUI in dev mode** (`make wui-dev`)
2. **Create test sessions** with different field combinations:
   - Session with only title set
   - Session with only summary set (no title)
   - Session with only query set (no title or summary)
3. **Open cmd+k** command palette
4. **Search for text** from each field and verify all sessions appear in results
5. **Archive a session** and verify it no longer appears in search
6. **Create a child session** and verify the parent doesn't appear in search

## Description for the changelog

fix(hld): Session search now searches across title, summary, and query fields to match UI display logic; filters to only active leaf sessions
