### PR TITLE
Reduce undo toast auto-dismiss timeout from 30s to 10s

### DIFF
--- a/humanlayer-wui/src/utils/undoToast.tsx
+++ b/humanlayer-wui/src/utils/undoToast.tsx
@@ -27,7 +27,7 @@ export function showUndoToast(options: UndoToastOptions) {
   return toast(title, {
     id: toastId,
     description,
-    duration: 30000, // 30 seconds before auto-dismiss
+    duration: 10000, // 10 seconds before auto-dismiss
     position: 'top-right', // Match CMD+SHIFT+J positioning
     action: (
       <CodeLayerToastButtons


### PR DESCRIPTION
## What problem(s) was I solving?

The undo toast notifications for archive/draft deletion operations were displaying for 30 seconds before auto-dismissing. This duration was unnecessarily long and could clutter the UI, especially when users perform multiple operations in succession. Users who are familiar with the Z hotkey for undo don't need the toast to persist for such an extended period.

## What user-facing changes did I ship?

- **Reduced auto-dismiss timeout**: Undo toasts for the following operations now auto-dismiss after 10 seconds instead of 30 seconds:
  - Session archiving/unarchiving (single and bulk operations)
  - Draft deletion/discarding (single and bulk operations)
- The Z hotkey functionality remains unchanged - users can still press Z to undo operations while the toast is visible
- The visual appearance and positioning of the toasts remain the same

## How I implemented it

Modified the `showUndoToast` function in `humanlayer-wui/src/utils/undoToast.tsx` to reduce the toast duration from 30000ms to 10000ms. This is a single-line change that affects all undo toasts consistently across the application.

The change applies to:
- Single session archive/unarchive operations
- Bulk session archive/unarchive operations
- Single draft discard operations
- Bulk draft discard operations

## How to verify it

### Automated Testing
- [x] `make check` - All linting and type checking passes
- [x] `make test` - All unit and integration tests pass

### Manual Testing

To verify the toast timeout change:

1. Launch the application
2. Create or navigate to a session
3. Archive a session (or discard a draft)
4. Observe that the undo toast appears with the "Z" hotkey indicator
5. Wait and confirm the toast auto-dismisses after 10 seconds (previously 30 seconds)
6. Test that pressing Z within the 10-second window still successfully undoes the operation

Test scenarios to verify:
- [ ] Single session archive - toast dismisses after 10 seconds
- [ ] Bulk session archive - toast dismisses after 10 seconds
- [ ] Single draft discard - toast dismisses after 10 seconds
- [ ] Bulk draft discard - toast dismisses after 10 seconds
- [ ] Z hotkey still works to undo within the 10-second window

## Description for the changelog

Reduced undo notification auto-dismiss timeout from 30 to 10 seconds for improved UI responsiveness