### PR TITLE
just fix the placeholder stable release notes

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -315,21 +315,13 @@ jobs:
 
             ### Homebrew (Recommended)
             ```bash
-            brew tap humanlayer/humanlayer
-            brew install --cask codelayer${{ steps.version.outputs.is_nightly == 'true' && '-nightly' || '' }}
+            brew install --cask --no-quarantine humanlayer/humanlayer/codelayer${{ steps.version.outputs.is_nightly == 'true' && '-nightly' || '' }}
             ```
 
-            ### Manual Installation
-            1. Download the DMG file below
-            2. Open the DMG and drag CodeLayer${{ steps.version.outputs.is_nightly == 'true' && '-Nightly' || '' }} to Applications
-            3. Launch CodeLayer${{ steps.version.outputs.is_nightly == 'true' && '-Nightly' || '' }} from Applications
+            **Note:** The private beta of humanlayer does not support app signing, so the `--no-quarantine` flag is necessary to bypass macOS Gatekeeper.
 
-            ## Troubleshooting
 
-            If you encounter "damaged app" warnings:
-            ```bash
-            xattr -rc /Applications/CodeLayer${{ steps.version.outputs.is_nightly == 'true' && '-Nightly' || '' }}.app
-            ```
+            DMG installs are not supported, please use Homebrew.
 
             ## Logs
 


### PR DESCRIPTION
these are placeholder notes that get created before the actual notes go in. But they should still be accurate
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updated `release-macos.yml` to refine Homebrew installation instructions and remove unsupported DMG installation steps.
> 
>   - **Release Notes Update**:
>     - In `release-macos.yml`, updated Homebrew installation command to include `--no-quarantine` flag.
>     - Removed manual DMG installation instructions and troubleshooting steps.
>     - Added note about the necessity of `--no-quarantine` due to lack of app signing support in private beta.
>     - Clarified that DMG installs are not supported, recommending Homebrew instead.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for e6fbaf997c7e819597aaa8e94b2d4588054ddb18. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->