### PR TITLE
feat: add Escape and Ctrl+[ hotkeys for blurring input

### DIFF
--- a/humanlayer-wui/docs/HOTKEYS.md
+++ b/humanlayer-wui/docs/HOTKEYS.md
@@ -223,4 +223,5 @@ The system handles StrictMode double-mounting automatically through:
 - `Option+A` / `Alt+A` - Toggle auto-accept edits
 - `Enter` - Focus response input
 - `Cmd+Enter` / `Ctrl+Enter` - Submit response
+- `Escape` / `Ctrl+[` - Blur response input
 - `Option+Y` / `Alt+Y` - Toggle bypass permissions

--- a/humanlayer-wui/src/components/HotkeyPanel.tsx
+++ b/humanlayer-wui/src/components/HotkeyPanel.tsx
@@ -70,6 +70,8 @@ const hotkeyData = [
   { category: 'Session Detail', key: '⌥+A', description: 'Toggle auto-accept edits' },
   { category: 'Session Detail', key: 'Enter', description: 'Focus response input' },
   { category: 'Session Detail', key: '⌘+Enter', description: 'Submit response' },
+  { category: 'Session Detail', key: 'Escape', description: 'Blur input' },
+  { category: 'Session Detail', key: 'Ctrl+[', description: 'Blur input (vim)' },
   { category: 'Session Detail', key: '⌥+Y', description: 'Toggle bypass permissions' },
 ]
 

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ActiveSession.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ActiveSession.tsx
@@ -322,7 +322,7 @@ export function ActiveSession({ session, onClose }: ActiveSessionProps) {
 
   // Escape key handler
   useHotkeys(
-    'escape',
+    'escape, ctrl+[',
     ev => {
       if ((ev.target as HTMLElement)?.dataset.slot === 'dialog-close') {
         logger.warn('Ignoring onClose triggered by dialog-close in ActiveSession')

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseEditor.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseEditor.tsx
@@ -424,6 +424,7 @@ const KeyboardShortcuts = Extension.create({
   addKeyboardShortcuts() {
     return {
       Escape: () => this.editor.commands.blur(),
+      'Ctrl-[': () => this.editor.commands.blur(),
       'Mod-Enter': editor => {
         if (!editor.editor.isEmpty) {
           this.options.onSubmit?.()


### PR DESCRIPTION
- Updated HOTKEYS.md to include new hotkeys for blurring response input.
- Enhanced HotkeyPanel to display Escape and Ctrl+[ as blur input options.
- Modified ActiveSession and ResponseEditor components to handle new hotkey actions.

## What problem(s) was I solving?

## What user-facing changes did I ship?

## How I implemented it

## How to verify it

- [x] I have ensured `make check test` passes

## Description for the changelog

## A picture of a cute animal (not mandatory but encouraged)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `Escape` and `Ctrl+[` hotkeys for blurring input in `ActiveSession.tsx` and `ResponseEditor.tsx`, with documentation and UI updates.
> 
>   - **Behavior**:
>     - Added `Escape` and `Ctrl+[` hotkeys to blur response input in `ActiveSession.tsx` and `ResponseEditor.tsx`.
>     - Updated `HOTKEYS.md` to document new hotkeys.
>   - **UI Components**:
>     - Enhanced `HotkeyPanel.tsx` to display `Escape` and `Ctrl+[` as blur input options.
>   - **Hotkey Handling**:
>     - Modified `useHotkeys` in `ActiveSession.tsx` to handle `escape, ctrl+[` for blurring input.
>     - Updated `KeyboardShortcuts` in `ResponseEditor.tsx` to include `Escape` and `Ctrl-[` for blurring input.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 40605a5197918c3f996680447de2fb94f10bebbb. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->