### PR TITLE
Restore fuzzy search width

### DIFF
--- a/humanlayer-wui/src/components/FuzzySearchInput.tsx
+++ b/humanlayer-wui/src/components/FuzzySearchInput.tsx
@@ -284,7 +284,7 @@ export function SearchInput({
           align="start"
           avoidCollisions={false}
           className={cn(
-            // 'w-[var(--radix-popover-trigger-width)]',
+            'w-[var(--radix-popover-trigger-width)]',
             className?.includes('text-xs') && '[&_[cmdk-item]]:text-xs [&_[cmdk-item]]:py-1',
           )}
         >


### PR DESCRIPTION
## What problem(s) was I solving?

The fuzzy search dropdown used for selecting directories in the draft session launcher was rendering with an extremely narrow width, making it difficult to read and select directory paths. This affected both the working directory input field and the additional directories dropdown.

The issue was introduced in PR #798 (commit `c24f2956`) when implementing directory validation and creation features. During development, the CSS class controlling the popover width (`w-[var(--radix-popover-trigger-width)]`) was commented out, likely for debugging purposes, but was never restored.

## What user-facing changes did I ship?

**Fixed**: The fuzzy search dropdown now correctly matches the width of its trigger input field, making directory paths fully readable when browsing and selecting directories in the draft session launcher.

**Affected Components**:
- Working directory input field in draft launcher
- Additional directories dropdown in draft launcher
- Any other component using `FuzzySearchInput` / `SearchInput`

## How I implemented it

Uncommented the CSS class `w-[var(--radix-popover-trigger-width)]` in `FuzzySearchInput.tsx` at line 287.

This Radix UI CSS variable contains the width of the popover's trigger element (the input field), and applying it ensures the dropdown matches the input width instead of defaulting to content-based width.

**Technical Details**:
- File: `humanlayer-wui/src/components/FuzzySearchInput.tsx`
- Change: Restored commented-out width class on `PopoverContent` component
- The `--radix-popover-trigger-width` CSS variable is automatically provided by Radix UI's Popover component

## How to verify it

### Automated Checks
- [x] TypeScript compilation passes (`bun run typecheck`)
- [x] Linting passes (`bun run lint`)

### Manual Testing

**To verify the fix works**:
1. Launch the WUI application
2. Navigate to Sessions page
3. Click "Create" to start a new draft session
4. In the "WORKING DIRECTORY" field, start typing a path (e.g., `/`)
5. **Expected**: The dropdown should match the width of the input field
6. **Before fix**: Dropdown was very narrow (content-width only)
7. Click "Additional Directories" and test the fuzzy search there
8. **Expected**: Same full-width behavior

**Regression testing**:
- Verify fuzzy search still filters directories correctly
- Verify keyboard navigation (up/down arrows) still works
- Verify recent directories still appear
- Verify invalid path warnings still display

## Description for the changelog

Fix fuzzy search dropdown width in draft session launcher - dropdown now correctly matches input field width instead of being too narrow to read directory paths
