### PR TITLE
Fix unwanted text selection on placeholder change

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseEditor.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ResponseEditor.tsx
@@ -910,7 +910,7 @@ export const ResponseEditor = forwardRef<{ focus: () => void; blur?: () => void 
 
     useEffect(() => {
       placeholderRef.current = placeholder
-      editor?.commands.selectAll()
+      editor?.commands.focus()
     }, [editor, placeholder])
 
     // Handle editable state


### PR DESCRIPTION
Replace selectAll() with focus() in ResponseEditor's placeholder
effect to prevent automatically selecting all text when the
placeholder updates.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `selectAll()` with `focus()` in `ResponseEditor.tsx` to prevent unwanted text selection on placeholder update.
> 
>   - **Behavior**:
>     - Replace `selectAll()` with `focus()` in `ResponseEditor.tsx` to prevent unwanted text selection when the placeholder updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 0030dc99aa3f4fc2d4260beb7db5b64483656f58. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->