### PR TITLE
chore: remove cron for linear layer (leave workflow disaptch enabled)

### DIFF
--- a/.github/workflows/linear-create-plan.yml
+++ b/.github/workflows/linear-create-plan.yml
@@ -1,10 +1,5 @@
 name: "Linear: Create Plan for Task"
 on:
-  push:
-    branches:
-      - kyle/eng-2175-auto-create-worktree-and-checkout-for-linear
-  schedule:
-    - cron: "*/15 * * * *"
   workflow_dispatch:
     inputs:
       num_tickets:

--- a/.github/workflows/linear-implement-plan.yml
+++ b/.github/workflows/linear-implement-plan.yml
@@ -1,10 +1,5 @@
 name: "Linear: Implement Plan for Task"
 on:
-  push:
-    branches:
-      - kyle/eng-2175-auto-create-worktree-and-checkout-for-linear
-  schedule:
-    - cron: "*/15 * * * *"
   workflow_dispatch:
     inputs:
       num_tickets:

--- a/.github/workflows/linear-research-tickets.yml
+++ b/.github/workflows/linear-research-tickets.yml
@@ -1,10 +1,5 @@
 name: "Linear: Research Task"
 on:
-  push:
-    branches:
-      - kyle/eng-2175-auto-create-worktree-and-checkout-for-linear
-  schedule:
-    - cron: "*/15 * * * *"
   workflow_dispatch:
     inputs:
       num_tickets:
@@ -17,7 +12,7 @@ jobs:
   fetch-tickets:
     runs-on: ubuntu-latest
     env:
-      RESEARCH_WIP_LIMIT: 5  # Configurable WIP limit
+      RESEARCH_WIP_LIMIT: 5 # Configurable WIP limit
     outputs:
       ticket_ids: ${{ steps.fetch-tickets.outputs.ticket_ids }}
     steps:


### PR DESCRIPTION
## What problem(s) was I solving?

## What user-facing changes did I ship?

## How I implemented it

## How to verify it

- [ ] I have ensured `make check test` passes

## Description for the changelog

## A picture of a cute animal (not mandatory but encouraged)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove cron and push triggers from Linear workflows, retaining only manual dispatch.
> 
>   - **Workflows**:
>     - Remove `cron` schedule and `push` triggers from `linear-create-plan.yml`, `linear-implement-plan.yml`, and `linear-research-tickets.yml`.
>     - Retain `workflow_dispatch` trigger in all three workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 605a4ef4280a06fffc4b48ffdfed8c634c009fc4. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->