### PR TITLE
Improve date fetching in .claude/commands

### DIFF
--- a/.claude/commands/create_handoff.md
+++ b/.claude/commands/create_handoff.md
@@ -11,7 +11,7 @@ You are tasked with writing a handoff document to hand off your work to another 
 ### 1. Filepath & Metadata
 Use the following information to understand how to create your document:
     - create your file under `thoughts/shared/handoffs/ENG-XXXX/YYYY-MM-DD_HH-MM-SS_ENG-ZZZZ_description.md`, where:
-        - YYYY-MM-DD is today's date
+        - YYYY-MM-DD is today's date (get with `date +"%Y-%m-%d"`)
         - HH-MM-SS is the hours, minutes and seconds based on the current time, in 24-hour format (i.e. use `13:00` for `1:00 pm`)
         - ENG-XXXX is the ticket number (replace with `general` if no ticket)
         - ENG-ZZZZ is the ticket number (omit if no ticket)

--- a/.claude/commands/create_handoff.md
+++ b/.claude/commands/create_handoff.md
@@ -11,8 +11,7 @@ You are tasked with writing a handoff document to hand off your work to another 
 ### 1. Filepath & Metadata
 Use the following information to understand how to create your document:
     - create your file under `thoughts/shared/handoffs/ENG-XXXX/YYYY-MM-DD_HH-MM-SS_ENG-ZZZZ_description.md`, where:
-        - YYYY-MM-DD is today's date (get with `date +"%Y-%m-%d"`)
-        - HH-MM-SS is the hours, minutes and seconds based on the current time, in 24-hour format (i.e. use `13:00` for `1:00 pm`)
+        - YYYY-MM-DD_HH-MM-SS is the current date and time (get with `date +"%Y-%m-%d_%H-%M-%S"`)
         - ENG-XXXX is the ticket number (replace with `general` if no ticket)
         - ENG-ZZZZ is the ticket number (omit if no ticket)
         - description is a brief kebab-case description

--- a/.claude/commands/create_plan.md
+++ b/.claude/commands/create_plan.md
@@ -171,7 +171,7 @@ After structure approval:
 
 1. **Write the plan** to `thoughts/shared/plans/YYYY-MM-DD-ENG-XXXX-description.md`
    - Format: `YYYY-MM-DD-ENG-XXXX-description.md` where:
-     - YYYY-MM-DD is today's date
+     - YYYY-MM-DD is today's date (get with `date +"%Y-%m-%d"`)
      - ENG-XXXX is the ticket number (omit if no ticket)
      - description is a brief kebab-case description
    - Examples:

--- a/.claude/commands/create_plan_generic.md
+++ b/.claude/commands/create_plan_generic.md
@@ -170,7 +170,7 @@ After structure approval:
 
 1. **Write the plan** to `thoughts/shared/plans/YYYY-MM-DD-ENG-XXXX-description.md`
    - Format: `YYYY-MM-DD-ENG-XXXX-description.md` where:
-     - YYYY-MM-DD is today's date
+     - YYYY-MM-DD is today's date (get with `date +"%Y-%m-%d"`)
      - ENG-XXXX is the ticket number (omit if no ticket)
      - description is a brief kebab-case description
    - Examples:

--- a/.claude/commands/create_plan_nt.md
+++ b/.claude/commands/create_plan_nt.md
@@ -166,7 +166,7 @@ After structure approval:
 
 1. **Write the plan** to `thoughts/shared/plans/YYYY-MM-DD-ENG-XXXX-description.md`
    - Format: `YYYY-MM-DD-ENG-XXXX-description.md` where:
-     - YYYY-MM-DD is today's date
+     - YYYY-MM-DD is today's date (get with `date +"%Y-%m-%d"`)
      - ENG-XXXX is the ticket number (omit if no ticket)
      - description is a brief kebab-case description
    - Examples:

--- a/.claude/commands/ralph_research.md
+++ b/.claude/commands/ralph_research.md
@@ -34,7 +34,7 @@ think deeply about the research needs
 2f. Be unbiased - don't think too much about an ideal implementation plan, just document all related files and how the systems work today
 2g. document findings in a new thoughts document: `thoughts/shared/research/YYYY-MM-DD-ENG-XXXX-description.md`
    - Format: `YYYY-MM-DD-ENG-XXXX-description.md` where:
-     - YYYY-MM-DD is today's date
+     - YYYY-MM-DD is today's date (get with `date +"%Y-%m-%d"`)
      - ENG-XXXX is the ticket number (omit if no ticket)
      - description is a brief kebab-case description of the research topic
    - Examples:

--- a/.claude/commands/research_codebase.md
+++ b/.claude/commands/research_codebase.md
@@ -86,7 +86,7 @@ Then wait for the user's research query.
    - Run the `hack/spec_metadata.sh` script to generate all relevant metadata
    - Filename: `thoughts/shared/research/YYYY-MM-DD-ENG-XXXX-description.md`
      - Format: `YYYY-MM-DD-ENG-XXXX-description.md` where:
-       - YYYY-MM-DD is today's date
+       - YYYY-MM-DD is today's date (get with `date +"%Y-%m-%d"`)
        - ENG-XXXX is the ticket number (omit if no ticket)
        - description is a brief kebab-case description of the research topic
      - Examples:

--- a/.claude/commands/research_codebase_generic.md
+++ b/.claude/commands/research_codebase_generic.md
@@ -56,7 +56,7 @@ Then wait for the user's research query.
    - generate all relevant metadata
    - Filename: `thoughts/shared/research/YYYY-MM-DD-ENG-XXXX-description.md`
      - Format: `YYYY-MM-DD-ENG-XXXX-description.md` where:
-       - YYYY-MM-DD is today's date
+       - YYYY-MM-DD is today's date (get with `date +"%Y-%m-%d"`)
        - ENG-XXXX is the ticket number (omit if no ticket)
        - description is a brief kebab-case description of the research topic
      - Examples:

--- a/.claude/commands/research_codebase_nt.md
+++ b/.claude/commands/research_codebase_nt.md
@@ -80,7 +80,7 @@ Then wait for the user's research query.
    - Run Bash() tools to generate all relevant metadata
    - Filename: `thoughts/shared/research/YYYY-MM-DD-ENG-XXXX-description.md`
      - Format: `YYYY-MM-DD-ENG-XXXX-description.md` where:
-       - YYYY-MM-DD is today's date
+       - YYYY-MM-DD is today's date (get with `date +"%Y-%m-%d"`)
        - ENG-XXXX is the ticket number (omit if no ticket)
        - description is a brief kebab-case description of the research topic
      - Examples:


### PR DESCRIPTION
## What problem(s) was I solving?
Date strings (e.g. in filenames) were often incorrectly determined by the agent, requiring frequent manual correction.

## What user-facing changes did I ship?
- Updated prompts to recommend agents use unix `date` shell util to fetch date/time strings in relevant Claude commands
- Changes are dev-facing only

## How I implemented it
Added to existing prompt text where relevant:
```markdown
... (get with `date +"%Y-%m-%d_%H-%M-%S"`)
```

## How to verify it
Verified that both Cursor and Codex agents run suggested command when expected:
<img width="423" height="206" alt="Screenshot 2025-11-04 at 11 18 00 AM" src="https://github.com/user-attachments/assets/fdf0b284-da7c-4ecb-9a38-bb40b8a46368" />

## Description for the changelog
N/A (I assume DevEx changes are not mentioned in changelog?)

## A picture of a cute animal (not mandatory but encouraged)
<img width="1419" height="1414" alt="image" src="https://github.com/user-attachments/assets/42c86052-26d3-474f-8043-474f6626de1e" />
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Standardizes date fetching in `.claude/commands` by updating prompts to use the Unix `date` command for accurate date strings.
> 
>   - **Prompts Update**:
>     - In `create_handoff.md`, `create_plan.md`, `create_plan_generic.md`, `create_plan_nt.md`, `ralph_research.md`, `research_codebase.md`, `research_codebase_generic.md`, and `research_codebase_nt.md`, updated prompts to suggest using `date +"%Y-%m-%d_%H-%M-%S"` or `date +"%Y-%m-%d"` for fetching current date/time.
>   - **Behavior**:
>     - Standardizes date fetching method across various command prompts to reduce manual errors in date string determination.
>   - **Misc**:
>     - Changes are developer-facing and do not affect end-user functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for e2567b2edd0bd4435274f5071662017f06619535. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->