### PR TITLE
Added language specifiers to all fenced code blocks in .claude/

### DIFF
--- a/.claude/agents/codebase-analyzer.md
+++ b/.claude/agents/codebase-analyzer.md
@@ -62,7 +62,7 @@ You are a specialist at understanding HOW code works. Your job is to analyze imp
 
 Structure your analysis like this:
 
-```
+```md
 ## Analysis: [Feature/Component Name]
 
 ### Overview

--- a/.claude/agents/codebase-locator.md
+++ b/.claude/agents/codebase-locator.md
@@ -65,7 +65,7 @@ First, think deeply about the most effective search patterns for the requested f
 
 Structure your findings like this:
 
-```
+```md
 ## File Locations for [Feature/Topic]
 
 ### Implementation Files

--- a/.claude/agents/codebase-pattern-finder.md
+++ b/.claude/agents/codebase-pattern-finder.md
@@ -59,9 +59,9 @@ What to look for based on request:
 
 Structure your findings like this:
 
-```
 ## Pattern Examples: [Pattern Type]
 
+````md
 ### Pattern 1: [Descriptive Name]
 **Found in**: `src/api/users.js:45-67`
 **Used for**: User listing with pagination
@@ -91,6 +91,7 @@ router.get('/users', async (req, res) => {
   });
 });
 ```
+````
 
 **Key aspects**:
 - Uses query parameters for page/limit
@@ -98,6 +99,7 @@ router.get('/users', async (req, res) => {
 - Returns pagination metadata
 - Handles defaults
 
+````md
 ### Pattern 2: [Alternative Approach]
 **Found in**: `src/api/products.js:89-120`
 **Used for**: Product listing with cursor-based pagination
@@ -129,6 +131,7 @@ router.get('/products', async (req, res) => {
   });
 });
 ```
+````
 
 **Key aspects**:
 - Uses cursor instead of page numbers
@@ -165,7 +168,6 @@ describe('Pagination', () => {
 ### Related Utilities
 - `src/utils/pagination.js:12` - Shared pagination helpers
 - `src/middleware/validate.js:34` - Query parameter validation
-```
 
 ## Pattern Categories to Search
 

--- a/.claude/agents/thoughts-analyzer.md
+++ b/.claude/agents/thoughts-analyzer.md
@@ -57,7 +57,7 @@ Remove:
 
 Structure your analysis like this:
 
-```
+```md
 ## Analysis of: [Document Path]
 
 ### Document Context
@@ -117,7 +117,7 @@ Structure your analysis like this:
 "I've been thinking about rate limiting and there are so many options. We could use Redis, or maybe in-memory, or perhaps a distributed solution. Redis seems nice because it's battle-tested, but adds a dependency. In-memory is simple but doesn't work for multiple instances. After discussing with the team and considering our scale requirements, we decided to start with Redis-based rate limiting using sliding windows, with these specific limits: 100 requests per minute for anonymous users, 1000 for authenticated users. We'll revisit if we need more granular controls. Oh, and we should probably think about websockets too at some point."
 
 ### To Analysis:
-```
+```md
 ### Key Decisions
 1. **Rate Limiting Implementation**: Redis-based with sliding windows
    - Rationale: Battle-tested, works across multiple instances

--- a/.claude/agents/thoughts-locator.md
+++ b/.claude/agents/thoughts-locator.md
@@ -34,7 +34,7 @@ You are a specialist at finding documents in the thoughts/ directory. Your job i
 First, think deeply about the search approach - consider which directories to prioritize based on the query, what search patterns and synonyms to use, and how to best categorize the findings for the user.
 
 ### Directory Structure
-```
+```md
 thoughts/
 ├── shared/          # Team-shared documents
 │   ├── research/    # Research documents
@@ -66,7 +66,7 @@ Only remove "searchable/" from the path - preserve all other directory structure
 
 Structure your findings like this:
 
-```
+```md
 ## Thought Documents about [Topic]
 
 ### Tickets

--- a/.claude/agents/web-search-researcher.md
+++ b/.claude/agents/web-search-researcher.md
@@ -65,7 +65,7 @@ When you receive a research query, you will:
 
 Structure your findings as:
 
-```
+```md
 ## Summary
 [Brief overview of key findings]
 

--- a/.claude/commands/create_handoff.md
+++ b/.claude/commands/create_handoff.md
@@ -25,7 +25,7 @@ Use the following information to understand how to create your document:
 using the above conventions, write your document. use the defined filepath, and the following YAML frontmatter pattern. Use the metadata gathered in step 1, Structure the document with YAML frontmatter followed by content:
 
 Use the following template structure:
-```markdown
+```md
 ---
 date: [Current date and time with timezone in ISO format]
 researcher: [Researcher name from thoughts status]

--- a/.claude/commands/create_plan.md
+++ b/.claude/commands/create_plan.md
@@ -17,7 +17,7 @@ When this command is invoked:
    - Begin the research process
 
 2. **If no parameters provided**, respond with:
-```
+```md
 I'll help you create a detailed implementation plan. Let me start by understanding what we're building.
 
 Please provide:
@@ -72,7 +72,7 @@ Then wait for the user's input.
    - Determine true scope based on codebase reality
 
 5. **Present informed understanding and focused questions**:
-   ```
+   ```md
    Based on the ticket and my research of the codebase, I understand we need to [accurate summary].
 
    I've found that:
@@ -126,7 +126,7 @@ After getting initial clarifications:
 3. **Wait for ALL sub-tasks to complete** before proceeding
 
 4. **Present findings and design options**:
-   ```
+   ```md
    Based on my research, here's what I found:
 
    **Current State:**
@@ -149,7 +149,7 @@ After getting initial clarifications:
 Once aligned on approach:
 
 1. **Create initial plan outline**:
-   ```
+   ```md
    Here's my proposed plan structure:
 
    ## Overview
@@ -434,7 +434,7 @@ tasks = [
 
 ## Example Interaction Flow
 
-```
+```md
 User: /implementation_plan
 Assistant: I'll help you create a detailed implementation plan...
 

--- a/.claude/commands/create_plan_generic.md
+++ b/.claude/commands/create_plan_generic.md
@@ -17,7 +17,7 @@ When this command is invoked:
    - Begin the research process
 
 2. **If no parameters provided**, respond with:
-```
+```md
 I'll help you create a detailed implementation plan. Let me start by understanding what we're building.
 
 Please provide:
@@ -71,7 +71,7 @@ Then wait for the user's input.
    - Determine true scope based on codebase reality
 
 5. **Present informed understanding and focused questions**:
-   ```
+   ```md
    Based on the ticket and my research of the codebase, I understand we need to [accurate summary].
 
    I've found that:
@@ -125,7 +125,7 @@ After getting initial clarifications:
 3. **Wait for ALL sub-tasks to complete** before proceeding
 
 4. **Present findings and design options**:
-   ```
+   ```md
    Based on my research, here's what I found:
 
    **Current State:**
@@ -148,7 +148,7 @@ After getting initial clarifications:
 Once aligned on approach:
 
 1. **Create initial plan outline**:
-   ```
+   ```md
    Here's my proposed plan structure:
 
    ## Overview
@@ -178,7 +178,7 @@ After structure approval:
      - Without ticket: `2025-01-08-improve-error-handling.md`
 2. **Use this template structure**:
 
-````markdown
+````md
 # [Feature/Task Name] Implementation Plan
 
 ## Overview
@@ -355,7 +355,7 @@ After structure approval:
    - User acceptance criteria
 
 **Format example:**
-```markdown
+```md
 ### Success Criteria:
 
 #### Automated Verification:
@@ -427,7 +427,7 @@ tasks = [
 
 ## Example Interaction Flow
 
-```
+```md
 User: /implementation_plan
 Assistant: I'll help you create a detailed implementation plan...
 

--- a/.claude/commands/create_plan_nt.md
+++ b/.claude/commands/create_plan_nt.md
@@ -17,7 +17,7 @@ When this command is invoked:
    - Begin the research process
 
 2. **If no parameters provided**, respond with:
-```
+```md
 I'll help you create a detailed implementation plan. Let me start by understanding what we're building.
 
 Please provide:
@@ -71,7 +71,7 @@ Then wait for the user's input.
    - Determine true scope based on codebase reality
 
 5. **Present informed understanding and focused questions**:
-   ```
+   ```md
    Based on the ticket and my research of the codebase, I understand we need to [accurate summary].
 
    I've found that:
@@ -121,7 +121,7 @@ After getting initial clarifications:
 3. **Wait for ALL sub-tasks to complete** before proceeding
 
 4. **Present findings and design options**:
-   ```
+   ```md
    Based on my research, here's what I found:
 
    **Current State:**
@@ -144,7 +144,7 @@ After getting initial clarifications:
 Once aligned on approach:
 
 1. **Create initial plan outline**:
-   ```
+   ```md
    Here's my proposed plan structure:
 
    ## Overview
@@ -424,7 +424,7 @@ tasks = [
 
 ## Example Interaction Flow
 
-```
+```md
 User: /create_plan
 Assistant: I'll help you create a detailed implementation plan...
 

--- a/.claude/commands/create_worktree.md
+++ b/.claude/commands/create_worktree.md
@@ -21,7 +21,7 @@ command to run
 
 3a. confirm with the user by sending a message to the Human
 
-```
+```md
 based on the input, I plan to create a worktree with the following details:
 
 worktree path: ~/wt/humanlayer/ENG-XXXX

--- a/.claude/commands/debug.md
+++ b/.claude/commands/debug.md
@@ -9,7 +9,7 @@ You are tasked with helping debug issues during manual testing or implementation
 ## Initial Response
 
 When invoked WITH a plan/ticket file:
-```
+```md
 I'll help debug issues with [file name]. Let me understand the current state.
 
 What specific problem are you encountering?
@@ -21,7 +21,7 @@ I'll investigate the logs, database, and git state to help figure out what's hap
 ```
 
 When invoked WITHOUT parameters:
-```
+```md
 I'll help debug your current issue.
 
 Please describe what's going wrong:
@@ -75,7 +75,7 @@ After the user describes the issue:
 
 Spawn parallel Task agents for efficient investigation:
 
-```
+```md
 Task 1 - Check Recent Logs:
 Find and analyze the most recent logs for errors:
 1. Find latest daemon log: ls -t ~/.humanlayer/logs/daemon-*.log | head -1
@@ -86,7 +86,7 @@ Find and analyze the most recent logs for errors:
 Return: Key errors/warnings with timestamps
 ```
 
-```
+```md
 Task 2 - Database State:
 Check the current database state:
 1. Connect to database: sqlite3 ~/.humanlayer/daemon.db
@@ -99,7 +99,7 @@ Check the current database state:
 Return: Relevant database findings
 ```
 
-```
+```md
 Task 3 - Git and File State:
 Understand what changed recently:
 1. Check git status and current branch

--- a/.claude/commands/iterate_plan.md
+++ b/.claude/commands/iterate_plan.md
@@ -18,7 +18,7 @@ When this command is invoked:
 2. **Handle different input scenarios**:
 
    **If NO plan file provided**:
-   ```
+   ```md
    I'll help you iterate on an existing implementation plan.
 
    Which plan would you like to update? Please provide the path to the plan file (e.g., `thoughts/shared/plans/2025-10-16-feature.md`).
@@ -28,7 +28,7 @@ When this command is invoked:
    Wait for user input, then re-check for feedback.
 
    **If plan file provided but NO feedback**:
-   ```
+   ```md
    I've found the plan at [path]. What changes would you like to make?
 
    For example:
@@ -92,7 +92,7 @@ If the user's feedback requires understanding new code patterns or validating as
 
 Before making changes, confirm your understanding:
 
-```
+```md
 Based on your feedback, I understand you want to:
 - [Change 1 with specific detail]
 - [Change 2 with specific detail]
@@ -225,13 +225,13 @@ When spawning research sub-tasks:
 ## Example Interaction Flows
 
 **Scenario 1: User provides everything upfront**
-```
+```md
 User: /iterate_plan thoughts/shared/plans/2025-10-16-feature.md - add phase for error handling
 Assistant: [Reads plan, researches error handling patterns, updates plan]
 ```
 
 **Scenario 2: User provides just plan file**
-```
+```md
 User: /iterate_plan thoughts/shared/plans/2025-10-16-feature.md
 Assistant: I've found the plan. What changes would you like to make?
 User: Split Phase 2 into two phases - one for backend, one for frontend
@@ -239,7 +239,7 @@ Assistant: [Proceeds with update]
 ```
 
 **Scenario 3: User provides no arguments**
-```
+```md
 User: /iterate_plan
 Assistant: Which plan would you like to update? Please provide the path...
 User: thoughts/shared/plans/2025-10-16-feature.md

--- a/.claude/commands/iterate_plan_nt.md
+++ b/.claude/commands/iterate_plan_nt.md
@@ -18,7 +18,7 @@ When this command is invoked:
 2. **Handle different input scenarios**:
 
    **If NO plan file provided**:
-   ```
+   ```md
    I'll help you iterate on an existing implementation plan.
 
    Which plan would you like to update? Please provide the path to the plan file (e.g., `thoughts/shared/plans/2025-10-16-feature.md`).
@@ -28,7 +28,7 @@ When this command is invoked:
    Wait for user input, then re-check for feedback.
 
    **If plan file provided but NO feedback**:
-   ```
+   ```md
    I've found the plan at [path]. What changes would you like to make?
 
    For example:
@@ -86,7 +86,7 @@ If the user's feedback requires understanding new code patterns or validating as
 
 Before making changes, confirm your understanding:
 
-```
+```md
 Based on your feedback, I understand you want to:
 - [Change 1 with specific detail]
 - [Change 2 with specific detail]
@@ -214,13 +214,13 @@ When spawning research sub-tasks:
 ## Example Interaction Flows
 
 **Scenario 1: User provides everything upfront**
-```
+```md
 User: /iterate_plan thoughts/shared/plans/2025-10-16-feature.md - add phase for error handling
 Assistant: [Reads plan, researches error handling patterns, updates plan]
 ```
 
 **Scenario 2: User provides just plan file**
-```
+```md
 User: /iterate_plan thoughts/shared/plans/2025-10-16-feature.md
 Assistant: I've found the plan. What changes would you like to make?
 User: Split Phase 2 into two phases - one for backend, one for frontend
@@ -228,7 +228,7 @@ Assistant: [Proceeds with update]
 ```
 
 **Scenario 3: User provides no arguments**
-```
+```md
 User: /iterate_plan
 Assistant: Which plan would you like to update? Please provide the path...
 User: thoughts/shared/plans/2025-10-16-feature.md

--- a/.claude/commands/linear.md
+++ b/.claude/commands/linear.md
@@ -9,14 +9,14 @@ You are tasked with managing Linear tickets, including creating tickets from tho
 ## Initial Setup
 
 First, verify that Linear MCP tools are available by checking if any `mcp__linear__` tools exist. If not, respond:
-```
+```md
 I need access to Linear tools to help with ticket management. Please run the `/mcp` command to enable the Linear MCP server, then try again.
 ```
 
 If tools are available, respond based on the user's request:
 
 ### For general requests:
-```
+```md
 I can help you with Linear tickets. What would you like to do?
 1. Create a new ticket from a thoughts document
 2. Add a comment to a ticket (I'll use our conversation context)
@@ -25,7 +25,7 @@ I can help you with Linear tickets. What would you like to do?
 ```
 
 ### For specific create requests:
-```
+```md
 I'll help you create a Linear ticket from your thoughts document. Please provide:
 1. The path to the thoughts document (or topic to search for)
 2. Any specific focus or angle for the ticket (optional)
@@ -110,7 +110,7 @@ Note: meta is mutually exclusive with hld/wui. Tickets can have both hld and wui
 
 5. **Draft the ticket summary:**
    Present a draft to the user:
-   ```
+   ```md
    ## Draft Linear Ticket
 
    **Title**: [Clear, action-oriented title]
@@ -178,7 +178,7 @@ Note: meta is mutually exclusive with hld/wui. Tickets can have both hld and wui
 ## Example transformations:
 
 ### From verbose thoughts:
-```
+```md
 "I've been thinking about how our resumed sessions don't inherit permissions properly.
 This is causing issues where users have to re-specify everything. We should probably
 store all the config in the database and then pull it when resuming. Maybe we need
@@ -186,7 +186,7 @@ new columns for permission_prompt_tool and allowed_tools..."
 ```
 
 ### To concise ticket:
-```
+```md
 Title: Fix resumed sessions to inherit all configuration from parent
 
 Description:
@@ -222,7 +222,7 @@ When user wants to add a comment to a ticket:
    - Do this for both thoughts/ and code files mentioned
 
 4. **Comment structure example:**
-   ```markdown
+   ```md
    Implemented retry logic in webhook handler to address rate limit issues.
 
    Key insight: The 429 responses were clustered during batch operations,
@@ -239,7 +239,7 @@ When user wants to add a comment to a ticket:
    - Always add links to the issue itself using the `links` parameter
 
 6. **For comments with links:**
-   ```
+   ```md
    # First, update the issue with the link
    mcp__linear__update_issue with:
    - id: [ticket ID]
@@ -252,7 +252,7 @@ When user wants to add a comment to a ticket:
    ```
 
 7. **For links only:**
-   ```
+   ```md
    # Update the issue with the link
    mcp__linear__update_issue with:
    - id: [ticket ID]
@@ -275,7 +275,7 @@ When user wants to find tickets:
    - Date ranges (createdAt, updatedAt)
 
 2. **Execute search:**
-   ```
+   ```md
    mcp__linear__list_issues with:
    - query: [search text]
    - teamId: [if specified]
@@ -309,7 +309,7 @@ When moving tickets through the workflow:
    - Ready for Dev → In Dev (work started)
 
 3. **Update with context:**
-   ```
+   ```md
    mcp__linear__update_issue with:
    - id: [ticket ID]
    - stateId: [new status ID]

--- a/.claude/commands/local_review.md
+++ b/.claude/commands/local_review.md
@@ -38,7 +38,7 @@ When invoked with a parameter like `gh_username:branchName`:
 
 ## Example Usage
 
-```
+```md
 /local_review samdickson22:sam/eng-1696-hotkey-for-yolo-mode
 ```
 

--- a/.claude/commands/ralph_plan.md
+++ b/.claude/commands/ralph_plan.md
@@ -38,7 +38,7 @@ think deeply, use TodoWrite to track your tasks. When fetching from linear, get 
 
 Print a message for the user (replace placeholders with actual values):
 
-```
+```md
 ✅ Completed implementation plan for ENG-XXXX: [ticket title]
 
 Approach: [selected approach description]

--- a/.claude/commands/ralph_research.md
+++ b/.claude/commands/ralph_research.md
@@ -60,7 +60,7 @@ think deeply, use TodoWrite to track your tasks. When fetching from linear, get 
 
 Print a message for the user (replace placeholders with actual values):
 
-```
+```md
 ✅ Completed research for ENG-XXXX: [ticket title]
 
 Research topic: [research topic description]

--- a/.claude/commands/research_codebase.md
+++ b/.claude/commands/research_codebase.md
@@ -19,7 +19,7 @@ You are tasked with conducting comprehensive research across the codebase to ans
 ## Initial Setup:
 
 When this command is invoked, respond with:
-```
+```md
 I'm ready to research the codebase. Please provide your research question or area of interest, and I'll analyze it thoroughly by exploring relevant components and connections.
 ```
 

--- a/.claude/commands/research_codebase_generic.md
+++ b/.claude/commands/research_codebase_generic.md
@@ -10,7 +10,7 @@ You are tasked with conducting comprehensive research across the codebase to ans
 ## Initial Setup:
 
 When this command is invoked, respond with:
-```
+```md
 I'm ready to research the codebase. Please provide your research question or area of interest, and I'll analyze it thoroughly by exploring relevant components and connections.
 ```
 

--- a/.claude/commands/research_codebase_nt.md
+++ b/.claude/commands/research_codebase_nt.md
@@ -19,7 +19,7 @@ You are tasked with conducting comprehensive research across the codebase to ans
 ## Initial Setup:
 
 When this command is invoked, respond with:
-```
+```md
 I'm ready to research the codebase. Please provide your research question or area of interest, and I'll analyze it thoroughly by exploring relevant components and connections.
 ```
 

--- a/.claude/commands/resume_handoff.md
+++ b/.claude/commands/resume_handoff.md
@@ -30,7 +30,7 @@ When this command is invoked:
    - Then propose a course of action to the user and confirm, or ask for clarification on direction.
 
 3. **If no parameters provided**, respond with:
-```
+```md
 I'll help you resume work from a handoff document. Let me find the available handoffs.
 
 Which handoff would you like to resume from?
@@ -59,7 +59,7 @@ Then wait for the user's input.
 2. **Spawn focused research tasks**:
    Based on the handoff content, spawn parallel research tasks to verify current state:
 
-   ```
+   ```md
    Task 1 - Gather artifact context:
    Read all artifacts mentioned in the handoff.
    1. Read feature documents listed in "Artifacts"
@@ -80,7 +80,7 @@ Then wait for the user's input.
 ### Step 2: Synthesize and Present Analysis
 
 1. **Present comprehensive analysis**:
-   ```
+   ```md
    I've analyzed the handoff from [date] by [researcher]. Here's the current situation:
 
    **Original Tasks:**
@@ -122,7 +122,7 @@ Then wait for the user's input.
    - Prioritize based on dependencies and handoff guidance
 
 2. **Present the plan**:
-   ```
+   ```md
    I've created a task list based on the handoff and current analysis:
 
    [Show todo list]
@@ -197,7 +197,7 @@ Then wait for the user's input.
 
 ## Example Interaction Flow
 
-```
+```md
 User: /resume_handoff specification/feature/handoffs/handoff-0.md
 Assistant: Let me read and analyze that handoff document...
 

--- a/.claude/commands/validate_plan.md
+++ b/.claude/commands/validate_plan.md
@@ -40,7 +40,7 @@ If starting fresh or need more context:
    - Identify key functionality to verify
 
 3. **Spawn parallel research tasks** to discover implementation:
-   ```
+   ```md
    Task 1 - Verify database changes:
    Research if migration [N] was added and schema changes match plan.
    Check: migration files, schema version, table structure
@@ -83,7 +83,7 @@ For each phase in the plan:
 
 Create comprehensive validation summary:
 
-```markdown
+```md
 ## Validation Report: [Plan Name]
 
 ### Implementation Status


### PR DESCRIPTION
## What problem(s) was I solving?
Not a real problem, but Coderabbit yelled at me when I was doing the G workshop using a few of these agents & commands. Take it or leave it!

## What user-facing changes did I ship?
Adds syntax highlighting when viewing these md files.

## How I implemented it
Cursor Auto free one-shot

## How to verify it

- [unrelated failure] I have ensured `make check test` passes

```shell
  ✗ Lint check passed
api/integration_test.go:2:1: buildtag: +build line is no longer needed (govet)
// +build integration
^
daemon/daemon_conversation_integration_test.go:2:1: buildtag: +build line is no longer needed (govet)
// +build integration
^
daemon/daemon_degraded_test.go:2:1: buildtag: +build line is no longer needed (govet)
// +build integration
^
3 issues:
* govet: 3
make[2]: *** [check-quiet] Error 1
make[1]: *** [check] Error 2
make: *** [check-hld] Error 2
```

## Description for the changelog
Added language specifiers to all fenced code blocks in .claude/ agents & commands

## A picture of a cute animal (not mandatory but encouraged)
<img width="1269" height="1595" alt="image" src="https://github.com/user-attachments/assets/8b811eb2-973a-42e9-a5d3-b95ac3081947" />
