### PR TITLE
feat: add theme 'Framer Light HC' with high contrast colors

### DIFF
--- a/humanlayer-wui/src/App.css
+++ b/humanlayer-wui/src/App.css
@@ -298,6 +298,42 @@
   --terminal-color-15: #000000; /* Bright White (pure black) */
 }
 
+/* Framer Light High Contrast - Framer Light with stronger text contrast */
+[data-theme='framer-light-hc'] {
+  --terminal-bg: #ffffff;
+  --terminal-bg-alt: #f8f9fa;
+  --terminal-fg: #000000;
+  --terminal-fg-dim: #0f0f0f;
+  --terminal-accent: #0066cc;
+  --terminal-accent-dim: rgba(0, 102, 204, 0.3);
+  --terminal-accent-alt: #006bb3;
+  --terminal-border: #e0e0e0;
+  --terminal-success: #22a06b;
+  --terminal-warning: #cc7722;
+  --terminal-error: #dc3545;
+  --terminal-selection: #0066cc26;
+
+  /* Standard colors - Clean professional palette with high contrast */
+  --terminal-color-0: #f8f9fa; /* Black (light bg) */
+  --terminal-color-1: #dc3545; /* Red */
+  --terminal-color-2: #22a06b; /* Green */
+  --terminal-color-3: #cc7722; /* Yellow/Orange */
+  --terminal-color-4: #0066cc; /* Blue */
+  --terminal-color-5: #7b61ff; /* Magenta/Purple */
+  --terminal-color-6: #006bb3; /* Cyan */
+  --terminal-color-7: #000000; /* White (dark text) */
+
+  /* Bright colors - High contrast variants */
+  --terminal-color-8: #e0e0e0; /* Bright Black */
+  --terminal-color-9: #e74856; /* Bright Red */
+  --terminal-color-10: #3db88b; /* Bright Green */
+  --terminal-color-11: #e6a045; /* Bright Yellow */
+  --terminal-color-12: #3399ff; /* Bright Blue */
+  --terminal-color-13: #9b81ff; /* Bright Magenta */
+  --terminal-color-14: #0099ff; /* Bright Cyan */
+  --terminal-color-15: #000000; /* Bright White (pure black) */
+}
+
 /* Gruvbox Dark - Material palette, medium contrast */
 [data-theme='gruvbox-dark'] {
   --terminal-bg: #282828;

--- a/humanlayer-wui/src/components/ThemeSelector.tsx
+++ b/humanlayer-wui/src/components/ThemeSelector.tsx
@@ -32,6 +32,7 @@ const themes: { value: Theme; label: string; icon: React.ComponentType<{ classNa
   { value: 'high-contrast', label: 'High Contrast', icon: ScanEye },
   { value: 'framer-dark', label: 'Framer Dark', icon: Framer },
   { value: 'framer-light', label: 'Framer Light', icon: Framer },
+  { value: 'framer-light-hc', label: 'Framer Light HC', icon: Framer },
   { value: 'gruvbox-dark', label: 'Gruvbox Dark', icon: Box },
   { value: 'gruvbox-light', label: 'Gruvbox Light', icon: Box },
   { value: 'monokai', label: 'Monokai', icon: Palette },

--- a/humanlayer-wui/src/contexts/ThemeContext.tsx
+++ b/humanlayer-wui/src/contexts/ThemeContext.tsx
@@ -9,6 +9,7 @@ export type Theme =
   | 'high-contrast'
   | 'framer-dark'
   | 'framer-light'
+  | 'framer-light-hc'
   | 'gruvbox-dark'
   | 'gruvbox-light'
   | 'monokai'

--- a/humanlayer-wui/src/stores/demo/slices/themeSlice.ts
+++ b/humanlayer-wui/src/stores/demo/slices/themeSlice.ts
@@ -18,11 +18,12 @@ const AVAILABLE_THEMES: Theme[] = [
   'solarized-light',
   'catppuccin',
   'framer-dark',
+  'framer-light-hc',
   'gruvbox-dark',
   'high-contrast',
 ]
 
-const LIGHT_THEMES: Theme[] = ['solarized-light', 'framer-light', 'gruvbox-light']
+const LIGHT_THEMES: Theme[] = ['solarized-light', 'framer-light', 'framer-light-hc', 'gruvbox-light']
 
 export const createThemeSlice: StateCreator<ThemeSlice, [], [], ThemeSlice> = (set, get) => ({
   theme: 'solarized-dark',


### PR DESCRIPTION
## What problem(s) was I solving?
- The existing Framer Light theme lacked contrast for readability and accessibility.

## What user-facing changes did I ship?
- Added a new “Framer Light HC” option to the theme selector with higher text/UI contrast on a light background.

## How I implemented it
- Added a high-contrast Framer Light variable set in `humanlayer-wui/src/App.css` (stronger foreground and status colors).
- Extended theme type and selector options with `framer-light-hc` in `humanlayer-wui/src/contexts/ThemeContext.tsx` and `humanlayer-wui/src/components/ThemeSelector.tsx`.
- Updated store theme lists to include the new light theme in `humanlayer-wui/src/stores/demo/slices/themeSlice.ts`.

## How to verify it
- Start the UI (`cd humanlayer-wui && npm run dev` or your usual start command).
- Select “Framer Light HC” in the Theme Selector.
- Confirm text, icons, and success/warning/error colors are clearly legible on light backgrounds and hover/selection states are obvious.
- Optionally switch among light themes to ensure the new entry is treated as a light theme.

- [x] I have ensured `make check test` passes

## Description for the changelog
- Added a high-contrast “Framer Light HC” theme for improved readability.

## A picture of a cute animal (not mandatory but encouraged)
- ![Sleepy puppy in a blanket](https://images.unsplash.com/photo-1507146426996-ef05306b995a?auto=format&fit=crop&w=600&q=80)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add 'Framer Light HC' theme with high contrast colors for improved readability.
> 
>   - **Behavior**:
>     - Added 'Framer Light HC' theme with high contrast colors in `App.css`.
>     - Updated theme selection to include 'Framer Light HC' in `ThemeSelector.tsx`.
>     - Extended theme type with 'framer-light-hc' in `ThemeContext.tsx`.
>     - Included 'framer-light-hc' in available and light themes in `themeSlice.ts`.
>   - **Misc**:
>     - Updated store theme lists to include the new light theme in `themeSlice.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for aaaaae612e47e791a1b910a0e4682802d350a041. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->