### PR TITLE
fix: Read() tool calls show "Read 2 lines" when many more were read

### DIFF
--- a/humanlayer-wui/src/components/internal/ConversationStream/EventContent/ReadToolCallContent.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/EventContent/ReadToolCallContent.tsx
@@ -16,7 +16,7 @@ export function ReadToolCallContent({
   isFocused,
   isGroupItem,
 }: ToolCallContentProps<ReadToolInput>) {
-  const lineCount = toolResultContent ? formatLineCount(toolResultContent, 1) : null // Subtract 1 for system reminder
+  const lineCount = toolResultContent ? formatLineCount(toolResultContent) : null
 
   const approvalStatusColor = getApprovalStatusColor(approvalStatus)
   let statusColor =

--- a/humanlayer-wui/src/components/internal/ConversationStream/EventContent/utils/formatters.ts
+++ b/humanlayer-wui/src/components/internal/ConversationStream/EventContent/utils/formatters.ts
@@ -109,6 +109,21 @@ export function formatLineCount(content: string, subtractSystemLines: number = 0
 }
 
 /**
+ * Strip system reminder from content
+ * @param content The content to strip system reminder from
+ * @returns The content without the system reminder
+ */
+
+export function stripSystemReminder(content: string): string {
+  const reminderStart = content.indexOf('<system-reminder>')
+  if (reminderStart === -1) {
+    return content
+  }
+
+  return content.slice(0, reminderStart).trimEnd()
+}
+
+/**
  * Format file count for display
  * @param count Number of files
  * @returns Formatted file count string

--- a/humanlayer-wui/src/components/internal/SessionDetail/__tests__/formatToolResult.test.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/__tests__/formatToolResult.test.tsx
@@ -91,9 +91,19 @@ describe('formatToolResult - Regression Tests for Other Tools', () => {
       }
       const result = formatToolResult('Read', toolResult as ConversationEvent)
       const { container } = render(<>{result}</>)
-      // Should count lines properly (total lines - 5 for system reminder)
-      expect(container.textContent).toContain('Read 2 lines')
+      // Should count only actual content lines (system reminder stripped)
+      expect(container.textContent).toContain('Read 3 lines')
       expect(container.querySelector('.text-destructive')).toBeNull()
+    })
+
+    it('should count all lines when no system reminder is present', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent: '     1→line one\n     2→line two\n     3→line three\n',
+        isCompleted: true,
+      }
+      const result = formatToolResult('Read', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      expect(container.textContent).toContain('Read 3 lines')
     })
 
     it('should handle empty Read content', () => {

--- a/humanlayer-wui/src/components/internal/SessionDetail/formatToolResult.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/formatToolResult.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { ConversationEvent } from '@/lib/daemon/types'
 import { truncate, parseMcpToolName } from '@/utils/formatting'
+import { stripSystemReminder } from '@/components/internal/ConversationStream/EventContent/utils/formatters'
 import { hasAnsiCodes, AnsiText } from '@/utils/ansiParser'
 
 // TODO(2): Consider creating tool-specific formatters in separate files
@@ -104,9 +105,13 @@ export function formatToolResult(
 
   switch (toolName) {
     case 'Read': {
-      // Count lines with the arrow format (e.g., "     1→content")
-      // Subtract 5 for the system reminder message appended at the end
-      const lineCount = Math.max(0, content.split('\n').length - 5)
+      const cleanedContent = stripSystemReminder(content)
+      const lineCount = cleanedContent
+        ? cleanedContent
+            .split('\n')
+            .map(line => line.trim())
+            .filter(Boolean).length
+        : 0
       abbreviated = `Read ${lineCount} lines`
       break
     }


### PR DESCRIPTION
## What problem(s) was I solving?

- This PR address issue https://github.com/humanlayer/humanlayer/issues/858
- Earlier the UI showed read 2 lines 

## What user-facing changes did I ship?

- Now Read more shows actual line count instead of 2 lines

## How I implemented it

- added stripSystemReminder util func which strips system-reminder block and counts the actual number of lines
- updated formatToolResult to call new func which updated the lines

## How to verify it

- [x] I have ensured `make check test` passes

## Description for the changelog

## A picture of a cute animal (not mandatory but encouraged)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes line count display for Read tool to show actual lines read by stripping system reminders.
> 
>   - **Behavior**:
>     - Fixes line count display in `ReadToolCallContent` to show actual lines read instead of defaulting to 2.
>     - Updates `formatToolResult` to strip system reminders and count actual content lines.
>   - **Functions**:
>     - Adds `stripSystemReminder` in `formatters.ts` to remove system reminder blocks from content.
>     - Modifies `formatLineCount` in `formatters.ts` to no longer subtract system lines by default.
>   - **Tests**:
>     - Adds test cases in `formatToolResult.test.tsx` to verify correct line count with and without system reminders.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 1b2747469fd04fd68ccf106f806ccff9b35401f3. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->