### PR TITLE
fix(wui): Display MCP errors with suggestions (#654)

### DIFF
--- a/humanlayer-wui/src/components/internal/ConversationStream/EventContent/EditToolCallContent.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/EventContent/EditToolCallContent.tsx
@@ -44,7 +44,8 @@ export function EditToolCallContent({
         name="Edit"
         description={toolInput.replace_all ? 'Replace all occurrences' : undefined}
         primaryParam={<span className="font-mono text-sm">{toolInput.file_path}</span>}
-        nameColor={statusColor}
+        nameColor={hasError ? undefined : statusColor}
+        nameStyle={hasError ? { color: 'var(--terminal-error)' } : undefined}
         status={
           <div className="flex items-center gap-2">
             <StatusBadge status={approvalStatus} />

--- a/humanlayer-wui/src/components/internal/ConversationStream/EventContent/MCPToolCallContent.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/EventContent/MCPToolCallContent.tsx
@@ -37,13 +37,13 @@ export function MCPToolCallContent({
       const mcpError = extractMcpError(toolResultContent)
       if (mcpError) {
         return {
-          text: `✗ ${service} failed: ${mcpError.message}`,
+          text: `${service} failed: ${mcpError.message}`,
           suggestion: mcpError.suggestion,
           isError: true,
         }
       }
       return {
-        text: `✗ ${service} ${formattedMethod} failed`,
+        text: `${service} ${formattedMethod} failed`,
         isError: true,
       }
     }
@@ -55,7 +55,7 @@ export function MCPToolCallContent({
       toolResultContent.includes('updated') ||
       toolResultContent.includes('completed')
     ) {
-      return { text: '✓ Success', isError: false }
+      return { text: 'Success', isError: false }
     }
 
     // Return first line of result for preview
@@ -72,7 +72,11 @@ export function MCPToolCallContent({
 
   return (
     <div>
-      <ToolHeader name={displayName} nameColor={approvalStatus ? statusColor : undefined} />
+      <ToolHeader
+        name={displayName}
+        nameColor={resultPreview?.isError ? undefined : (approvalStatus ? statusColor : undefined)}
+        nameStyle={resultPreview?.isError ? { color: 'var(--terminal-error)' } : undefined}
+      />
       {toolInput && Object.keys(toolInput).length > 0 && (
         <MCPToolCallParamPreview toolInput={toolInput} isDim={isCompleted && !isFocused} />
       )}

--- a/humanlayer-wui/src/components/internal/ConversationStream/EventContent/MCPToolCallContent.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/EventContent/MCPToolCallContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ToolHeader } from './ToolHeader'
 import type { ToolCallContentProps } from './types'
-import { getApprovalStatusColor } from './utils/formatters'
+import { getApprovalStatusColor, detectToolError, extractMcpError } from './utils/formatters'
 import { parseMcpToolName } from '@/utils/formatting'
 import { KeyboardShortcut } from '@/components/ui/keyboard-shortcut'
 import { MCPToolCallParamPreview } from './MCPToolCallParamPreview'
@@ -29,8 +29,24 @@ export function MCPToolCallContent({
   const displayName = `${service} - ${formattedMethod}`
 
   // Format result preview for completed MCP calls
-  const resultPreview = React.useMemo(() => {
+  const resultPreview = React.useMemo((): { text: string; isError: boolean; suggestion?: string | null } | null => {
     if (!isCompleted || !toolResultContent) return null
+
+    // Check for errors FIRST using centralized detection
+    if (detectToolError(toolName, toolResultContent)) {
+      const mcpError = extractMcpError(toolResultContent)
+      if (mcpError) {
+        return {
+          text: `✗ ${service} failed: ${mcpError.message}`,
+          suggestion: mcpError.suggestion,
+          isError: true,
+        }
+      }
+      return {
+        text: `✗ ${service} ${formattedMethod} failed`,
+        isError: true,
+      }
+    }
 
     // Check for common success indicators
     if (
@@ -39,21 +55,16 @@ export function MCPToolCallContent({
       toolResultContent.includes('updated') ||
       toolResultContent.includes('completed')
     ) {
-      return '✓ Success'
-    }
-
-    // Check for error indicators
-    if (toolResultContent.includes('error') || toolResultContent.includes('failed')) {
-      return `✗ ${service} ${formattedMethod} failed`
+      return { text: '✓ Success', isError: false }
     }
 
     // Return first line of result for preview
     const firstLine = toolResultContent.split('\n')[0]
     if (firstLine.length > 50) {
-      return firstLine.substring(0, 50) + '...'
+      return { text: firstLine.substring(0, 50) + '...', isError: false }
     }
-    return firstLine
-  }, [isCompleted, toolResultContent, service, formattedMethod])
+    return { text: firstLine, isError: false }
+  }, [isCompleted, toolResultContent, toolName, service, formattedMethod])
 
   const approvalStatusColor = getApprovalStatusColor(approvalStatus)
   let statusColor =
@@ -66,7 +77,16 @@ export function MCPToolCallContent({
         <MCPToolCallParamPreview toolInput={toolInput} isDim={isCompleted && !isFocused} />
       )}
       {isCompleted && resultPreview && (
-        <div className="text-sm text-muted-foreground mt-1">{resultPreview}</div>
+        <div>
+          <div className={`text-sm mt-1 ${resultPreview.isError ? 'text-destructive' : 'text-muted-foreground'}`}>
+            {resultPreview.text}
+          </div>
+          {resultPreview.isError && resultPreview.suggestion && (
+            <div className="text-xs text-muted-foreground mt-1">
+              {resultPreview.suggestion}
+            </div>
+          )}
+        </div>
       )}
       <div
         className={`text-xs text-muted-foreground/70 mt-1 ${isFocused && !isCompleted && toolInput ? 'visible' : 'invisible'}`}

--- a/humanlayer-wui/src/components/internal/ConversationStream/EventContent/ToolHeader.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/EventContent/ToolHeader.tsx
@@ -7,6 +7,7 @@ interface ToolHeaderProps {
   secondaryParam?: React.ReactNode
   status?: React.ReactNode
   nameColor?: string
+  nameStyle?: React.CSSProperties
 }
 
 export function ToolHeader({
@@ -16,12 +17,13 @@ export function ToolHeader({
   secondaryParam,
   status,
   nameColor,
+  nameStyle,
 }: ToolHeaderProps) {
   return (
     <div className="flex items-start justify-between">
       <div className="flex-1">
         <div className="flex items-baseline gap-2">
-          <span className={`font-semibold ${nameColor || ''}`}>{name}</span>
+          <span className={`font-semibold ${nameColor || ''}`} style={nameStyle}>{name}</span>
           {description && <span className="text-sm text-muted-foreground">{description}</span>}
         </div>
         {primaryParam && (

--- a/humanlayer-wui/src/components/internal/ConversationStream/EventContent/WebFetchToolCallContent.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/EventContent/WebFetchToolCallContent.tsx
@@ -1,7 +1,7 @@
 import { ToolHeader } from './ToolHeader'
 import { StatusBadge } from './StatusBadge'
 import { ToolCallContentProps } from './types'
-import { getApprovalStatusColor } from './utils/formatters'
+import { getApprovalStatusColor, detectToolError, extractMcpError } from './utils/formatters'
 
 interface WebFetchToolInput {
   url: string
@@ -20,14 +20,27 @@ export function WebFetchToolCallContent({
   let statusColor =
     isGroupItem && !approvalStatusColor ? 'text-[var(--terminal-accent)]' : approvalStatusColor
 
-  const formatFetchResult = (content: string) => {
+  const formatFetchResult = (content: string): { text: string; isError: boolean; suggestion?: string | null } => {
+    // Check for errors FIRST using centralized detection
+    if (detectToolError('WebFetch', content)) {
+      const mcpError = extractMcpError(content)
+      if (mcpError) {
+        return {
+          text: `Fetch failed: ${mcpError.message}`,
+          suggestion: mcpError.suggestion,
+          isError: true,
+        }
+      }
+      return { text: 'Fetch failed', isError: true }
+    }
+
     // Try to extract character count or size info
     const charCount = content.length
     if (charCount > 0) {
       const kbSize = (charCount / 1024).toFixed(1)
-      return `Fetched ${kbSize}KB of content`
+      return { text: `Fetched ${kbSize}KB of content`, isError: false }
     }
-    return 'No content retrieved'
+    return { text: 'No content retrieved', isError: false }
   }
 
   const formattedResult = toolResultContent ? formatFetchResult(toolResultContent) : null
@@ -62,14 +75,21 @@ export function WebFetchToolCallContent({
       {formattedResult && (
         <div className="mt-1 text-sm text-muted-foreground font-mono flex items-start gap-1">
           <span className="text-muted-foreground/50">⎿</span>
-          <span>
-            {formattedResult}
-            {isFocused && toolResultContent && toolResultContent.length > 100 && (
-              <span className="text-xs text-muted-foreground/50 ml-2">
-                <kbd className="px-1 py-0.5 text-xs bg-muted/50 rounded">i</kbd> expand
-              </span>
+          <div>
+            <span className={formattedResult.isError ? 'text-destructive' : ''}>
+              {formattedResult.text}
+              {isFocused && toolResultContent && toolResultContent.length > 100 && (
+                <span className="text-xs text-muted-foreground/50 ml-2">
+                  <kbd className="px-1 py-0.5 text-xs bg-muted/50 rounded">i</kbd> expand
+                </span>
+              )}
+            </span>
+            {formattedResult.isError && formattedResult.suggestion && (
+              <div className="text-xs text-muted-foreground mt-1">
+                {formattedResult.suggestion}
+              </div>
             )}
-          </span>
+          </div>
         </div>
       )}
     </div>

--- a/humanlayer-wui/src/components/internal/ConversationStream/EventContent/WebFetchToolCallContent.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/EventContent/WebFetchToolCallContent.tsx
@@ -49,7 +49,8 @@ export function WebFetchToolCallContent({
     <div className="space-y-2">
       <ToolHeader
         name="Web Fetch"
-        nameColor={statusColor}
+        nameColor={formattedResult?.isError ? undefined : statusColor}
+        nameStyle={formattedResult?.isError ? { color: 'var(--terminal-error)' } : undefined}
         primaryParam={
           <div className="flex items-center gap-2">
             <span className="text-sm">

--- a/humanlayer-wui/src/components/internal/ConversationStream/EventContent/WebSearchToolCallContent.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/EventContent/WebSearchToolCallContent.tsx
@@ -1,6 +1,6 @@
 import { StatusBadge } from './StatusBadge'
 import { ToolCallContentProps } from './types'
-import { getApprovalStatusColor } from './utils/formatters'
+import { getApprovalStatusColor, detectToolError, extractMcpError } from './utils/formatters'
 
 interface WebSearchToolInput {
   query: string
@@ -20,21 +20,38 @@ export function WebSearchToolCallContent({
   let statusColor =
     isGroupItem && !approvalStatusColor ? 'text-[var(--terminal-accent)]' : approvalStatusColor
 
-  const formatSearchResult = (content: string) => {
+  const formatSearchResult = (content: string): { text: string; isError: boolean; suggestion?: string | null } => {
+    // Check for errors FIRST before assuming success
+    if (detectToolError('WebSearch', content)) {
+      const mcpError = extractMcpError(content)
+      if (mcpError) {
+        // Use specific MCP error message if available
+        return {
+          text: `Search failed: ${mcpError.message}`,
+          suggestion: mcpError.suggestion,
+          isError: true,
+        }
+      }
+      return { text: 'Search failed', isError: true }
+    }
+
     const lines = content.split('\n').filter(l => l.trim())
 
     // Try to extract result count from the response
     const countMatch = content.match(/(\d+)\s+result/i)
     if (countMatch) {
-      return `Found ${countMatch[1]} result${countMatch[1] !== '1' ? 's' : ''}`
+      return {
+        text: `Found ${countMatch[1]} result${countMatch[1] !== '1' ? 's' : ''}`,
+        isError: false,
+      }
     }
 
     // Fallback to generic response length indicator
     if (lines.length === 0) {
-      return 'No results found'
+      return { text: 'No results found', isError: false }
     }
 
-    return `Retrieved search results`
+    return { text: 'Retrieved search results', isError: false }
   }
 
   const formattedResult = toolResultContent ? formatSearchResult(toolResultContent) : null
@@ -76,14 +93,21 @@ export function WebSearchToolCallContent({
       {formattedResult && (
         <div className="mt-1 text-sm text-muted-foreground font-mono flex items-start gap-1">
           <span className="text-muted-foreground/50">⎿</span>
-          <span>
-            {formattedResult}
-            {isFocused && toolResultContent && toolResultContent.split('\n').length > 1 && (
-              <span className="text-xs text-muted-foreground/50 ml-2">
-                <kbd className="px-1 py-0.5 text-xs bg-muted/50 rounded">i</kbd> expand
-              </span>
+          <div>
+            <span className={formattedResult.isError ? 'text-destructive' : ''}>
+              {formattedResult.text}
+              {isFocused && toolResultContent && toolResultContent.split('\n').length > 1 && (
+                <span className="text-xs text-muted-foreground/50 ml-2">
+                  <kbd className="px-1 py-0.5 text-xs bg-muted/50 rounded">i</kbd> expand
+                </span>
+              )}
+            </span>
+            {formattedResult.isError && formattedResult.suggestion && (
+              <div className="text-xs text-muted-foreground mt-1">
+                {formattedResult.suggestion}
+              </div>
             )}
-          </span>
+          </div>
         </div>
       )}
     </div>

--- a/humanlayer-wui/src/components/internal/ConversationStream/EventContent/WebSearchToolCallContent.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/EventContent/WebSearchToolCallContent.tsx
@@ -76,7 +76,10 @@ export function WebSearchToolCallContent({
       <div className="flex items-start justify-between">
         <div className="flex-1">
           <div className="flex items-baseline gap-2">
-            <span className={`font-semibold ${statusColor || ''}`}>Web Search</span>
+            <span
+              className={`font-semibold ${formattedResult?.isError ? '' : statusColor || ''}`}
+              style={formattedResult?.isError ? { color: 'var(--terminal-error)' } : undefined}
+            >Web Search</span>
           </div>
           <div className="mt-1">
             <span className="italic text-muted-foreground">{toolInput.query}</span>

--- a/humanlayer-wui/src/components/internal/ConversationStream/EventContent/utils/formatters.test.ts
+++ b/humanlayer-wui/src/components/internal/ConversationStream/EventContent/utils/formatters.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from 'bun:test'
+import {
+  detectToolError,
+  hasMcpError,
+  extractMcpError,
+  formatToolResultPreview,
+} from './formatters'
+
+describe('MCP Error Detection', () => {
+  describe('hasMcpError', () => {
+    it('should detect MCP error code -32603', () => {
+      const content = 'MCP error -32603: Internal error occurred'
+      expect(hasMcpError(content)).toBe(true)
+    })
+
+    it('should detect MCP error with various codes', () => {
+      expect(hasMcpError('MCP error -32700')).toBe(true)
+      expect(hasMcpError('MCP error -32600')).toBe(true)
+      expect(hasMcpError('MCP error -32601')).toBe(true)
+      expect(hasMcpError('MCP error -32602')).toBe(true)
+    })
+
+    it('should detect tool_use_error pattern', () => {
+      const content = 'Response contained tool_use_error: something went wrong'
+      expect(hasMcpError(content)).toBe(true)
+    })
+
+    it('should detect "Failed to process" pattern', () => {
+      const content = 'Failed to process WebSearch request'
+      expect(hasMcpError(content)).toBe(true)
+    })
+
+    it('should detect JSON-RPC error format', () => {
+      const content = '{"error": {"code": -32603, "message": "Internal error"}}'
+      expect(hasMcpError(content)).toBe(true)
+    })
+
+    it('should detect MCP protocol error', () => {
+      const content = 'MCP protocol error during communication'
+      expect(hasMcpError(content)).toBe(true)
+    })
+
+    it('should detect tool execution failed', () => {
+      const content = 'Tool execution failed: timeout'
+      expect(hasMcpError(content)).toBe(true)
+    })
+
+    it('should detect connection errors', () => {
+      expect(hasMcpError('Connection refused by server')).toBe(true)
+      expect(hasMcpError('Connection reset during request')).toBe(true)
+      expect(hasMcpError('Connection timed out')).toBe(true)
+    })
+
+    it('should NOT flag successful WebSearch results as errors', () => {
+      const successContent = `
+        Title: Example Result
+        URL: https://example.com
+        Snippet: This is a successful search result
+        Links: [Example](https://example.com)
+      `
+      expect(hasMcpError(successContent)).toBe(false)
+    })
+
+    it('should NOT flag results containing "error" in content (false positive prevention)', () => {
+      // Content that mentions "error" but is not an MCP error
+      const falsePositiveContent = 'Search results for "common javascript error handling patterns"'
+      expect(hasMcpError(falsePositiveContent)).toBe(false)
+
+      // Another false positive case
+      const tutorialContent = 'How to handle error cases in your application'
+      expect(hasMcpError(tutorialContent)).toBe(false)
+    })
+
+    it('should NOT flag normal content with numbers', () => {
+      const content = 'Found 32603 results for your query'
+      expect(hasMcpError(content)).toBe(false)
+    })
+  })
+
+  describe('extractMcpError', () => {
+    it('should extract error code from MCP error message', () => {
+      const content = 'MCP error -32603: Internal error'
+      const result = extractMcpError(content)
+
+      expect(result).not.toBeNull()
+      expect(result!.code).toBe(-32603)
+      expect(result!.message).toBe('Internal error')
+      expect(result!.suggestion).toBeTruthy()
+    })
+
+    it('should extract error code from JSON-RPC format', () => {
+      const content = '{"error": {"code": -32601, "message": "Method not found"}}'
+      const result = extractMcpError(content)
+
+      expect(result).not.toBeNull()
+      expect(result!.code).toBe(-32601)
+      expect(result!.message).toBe('Method not found')
+    })
+
+    it('should return null for non-MCP error content', () => {
+      const content = 'Search completed successfully with 10 results'
+      const result = extractMcpError(content)
+
+      expect(result).toBeNull()
+    })
+
+    it('should handle unknown error codes', () => {
+      const content = 'MCP error -99999: Unknown error type'
+      const result = extractMcpError(content)
+
+      expect(result).not.toBeNull()
+      expect(result!.code).toBe(-99999)
+      expect(result!.message).toBe('MCP error -99999')
+      expect(result!.suggestion).toBeTruthy()
+    })
+
+    it('should handle MCP errors without numeric code', () => {
+      const content = 'tool_use_error: Something went wrong'
+      const result = extractMcpError(content)
+
+      expect(result).not.toBeNull()
+      expect(result!.code).toBeNull()
+      expect(result!.message).toBe('MCP tool error')
+    })
+
+    it('should provide appropriate suggestions for known error codes', () => {
+      const testCases = [
+        { code: -32700, expectedSubstring: 'invalid JSON' },
+        { code: -32600, expectedSubstring: 'format is invalid' },
+        { code: -32601, expectedSubstring: 'not available' },
+        { code: -32602, expectedSubstring: 'parameters' },
+        { code: -32603, expectedSubstring: 'internal error' },
+      ]
+
+      for (const { code, expectedSubstring } of testCases) {
+        const content = `MCP error ${code}: Test error`
+        const result = extractMcpError(content)
+
+        expect(result).not.toBeNull()
+        expect(result!.suggestion?.toLowerCase()).toContain(expectedSubstring.toLowerCase())
+      }
+    })
+  })
+
+  describe('detectToolError', () => {
+    it('should detect MCP error code -32603', () => {
+      const result = detectToolError('WebSearch', 'MCP error -32603: Internal error')
+      expect(result).toBe(true)
+    })
+
+    it('should detect tool_use_error pattern', () => {
+      const result = detectToolError('mcp__searxng__search', 'tool_use_error: Request failed')
+      expect(result).toBe(true)
+    })
+
+    it('should detect "Failed to process" pattern', () => {
+      const result = detectToolError('WebSearch', 'Failed to process search request')
+      expect(result).toBe(true)
+    })
+
+    it('should NOT flag successful WebSearch results as errors', () => {
+      const successContent = `
+        Title: Example
+        URL: https://example.com
+        Snippet: Search results found
+        Links: [Link](https://example.com)
+      `
+      const result = detectToolError('WebSearch', successContent)
+      expect(result).toBe(false)
+    })
+
+    it('should NOT flag results containing "error" in content (false positive prevention)', () => {
+      // Content that discusses errors but is not itself an error
+      const content = 'Search results for "javascript error handling best practices"'
+      const result = detectToolError('WebSearch', content)
+      expect(result).toBe(false)
+    })
+
+    it('should still detect generic errors for non-MCP tools', () => {
+      const result = detectToolError('Bash', 'error: command not found')
+      expect(result).toBe(true)
+    })
+
+    it('should detect Edit tool failures', () => {
+      const result = detectToolError('Edit', 'Error: File has not been read yet')
+      expect(result).toBe(true)
+    })
+
+    it('should recognize successful Edit operations', () => {
+      const successContent = "The file has been updated. Here's the result of running `cat -n` on a snippet of the edited file:"
+      const result = detectToolError('Edit', successContent)
+      expect(result).toBe(false)
+    })
+
+    it('should handle Write tool success (empty content)', () => {
+      const result = detectToolError('Write', '')
+      expect(result).toBe(false)
+    })
+
+    it('should detect Write tool errors', () => {
+      const result = detectToolError('Write', 'Error: File has not been read')
+      expect(result).toBe(true)
+    })
+
+    it('should detect Grep errors', () => {
+      const result = detectToolError('Grep', 'grep: Invalid regular expression')
+      expect(result).toBe(true)
+    })
+
+    it('should not flag Grep results as errors', () => {
+      const result = detectToolError('Grep', '/path/to/file.ts:10:const error = new Error()')
+      expect(result).toBe(false)
+    })
+
+    it('should handle false positives with "0 errors"', () => {
+      const result = detectToolError('Bash', 'Build completed with 0 errors')
+      expect(result).toBe(false)
+    })
+  })
+})
+
+describe('formatToolResultPreview', () => {
+  it('should return null for empty content', () => {
+    expect(formatToolResultPreview('')).toBeNull()
+    expect(formatToolResultPreview('   ')).toBeNull()
+  })
+
+  it('should truncate long single lines', () => {
+    const longLine = 'a'.repeat(100)
+    const result = formatToolResultPreview(longLine)
+    expect(result).not.toBeNull()
+    expect(result!.length).toBeLessThanOrEqual(80)
+    expect(result!.endsWith('...')).toBe(true)
+  })
+
+  it('should show line count for multiple lines', () => {
+    const content = 'line1\nline2\nline3'
+    const result = formatToolResultPreview(content)
+    expect(result).toContain('(3 lines)')
+  })
+
+  it('should respect custom truncate length', () => {
+    const content = 'a'.repeat(50)
+    const result = formatToolResultPreview(content, { truncateLength: 30 })
+    expect(result).not.toBeNull()
+    expect(result!.length).toBeLessThanOrEqual(30)
+  })
+})

--- a/humanlayer-wui/src/components/internal/SessionDetail/__tests__/formatToolResult.test.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/__tests__/formatToolResult.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'bun:test'
 import { render } from '@testing-library/react'
 import { formatToolResult } from '../formatToolResult'
-import { ConversationEvent } from '@/lib/daemon/types'
+import type { ConversationEvent } from '@/lib/daemon/types'
 
 describe('formatToolResult - Write Tool', () => {
   it('should show success for empty content with isCompleted=true', () => {
@@ -137,6 +137,135 @@ describe('formatToolResult - Regression Tests for Other Tools', () => {
       const result = formatToolResult('Bash', toolResult as ConversationEvent)
       const { container } = render(<>{result}</>)
       expect(container.textContent).toContain('line1 ... (3 lines)')
+    })
+  })
+})
+
+describe('formatToolResult - MCP Error Detection', () => {
+  describe('WebSearch Tool', () => {
+    it('should show error for WebSearch with MCP error code and text-destructive class', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent: 'MCP error -32603: Internal error occurred during search',
+        isCompleted: true,
+      }
+      const result = formatToolResult('WebSearch', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      expect(container.textContent).toContain('Search failed')
+      expect(container.querySelector('.text-destructive')).not.toBeNull()
+    })
+
+    it('should show error for WebSearch with tool_use_error pattern', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent: 'tool_use_error: Search request failed',
+        isCompleted: true,
+      }
+      const result = formatToolResult('WebSearch', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      expect(container.textContent).toContain('Search failed')
+      expect(container.querySelector('.text-destructive')).not.toBeNull()
+    })
+
+    it('should NOT show error for successful WebSearch', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent: `
+          Title: Example Result
+          URL: https://example.com
+          Snippet: This is a test result
+          Links: [Example](https://example.com)
+        `,
+        isCompleted: true,
+      }
+      const result = formatToolResult('WebSearch', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      expect(container.textContent).toContain('results')
+      expect(container.querySelector('.text-destructive')).toBeNull()
+    })
+
+    it('should NOT flag content containing "error" word as failure', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent: `
+          Title: JavaScript Error Handling Best Practices
+          URL: https://example.com/error-handling
+          Snippet: Learn how to handle errors in your code
+          Links: [Guide](https://example.com)
+        `,
+        isCompleted: true,
+      }
+      const result = formatToolResult('WebSearch', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      expect(container.querySelector('.text-destructive')).toBeNull()
+    })
+  })
+
+  describe('MCP Tools (mcp__* prefix)', () => {
+    it('should show error for mcp__ tool with tool_use_error', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent: 'tool_use_error: Request to SearXNG failed',
+        isCompleted: true,
+      }
+      const result = formatToolResult('mcp__searxng__search', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      expect(container.textContent).toContain('searxng')
+      expect(container.textContent).toContain('failed')
+      expect(container.querySelector('.text-destructive')).not.toBeNull()
+    })
+
+    it('should show MCP error message for known error code', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent: 'MCP error -32603: Something went wrong',
+        isCompleted: true,
+      }
+      const result = formatToolResult('mcp__linear__create_issue', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      expect(container.textContent).toContain('linear')
+      expect(container.textContent).toContain('failed')
+      expect(container.querySelector('.text-destructive')).not.toBeNull()
+    })
+
+    it('should NOT show error for successful MCP tool call', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent: 'Issue created successfully with ID: LIN-123',
+        isCompleted: true,
+      }
+      const result = formatToolResult('mcp__linear__create_issue', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      expect(container.textContent).toContain('completed')
+      expect(container.querySelector('.text-destructive')).toBeNull()
+    })
+  })
+
+  describe('WebFetch Tool', () => {
+    it('should show error for WebFetch with MCP error', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent: 'MCP error -32603: Failed to fetch URL',
+        isCompleted: true,
+      }
+      const result = formatToolResult('WebFetch', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      expect(container.textContent).toContain('Fetch failed')
+      expect(container.querySelector('.text-destructive')).not.toBeNull()
+    })
+
+    it('should show error for WebFetch with connection error', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent: 'Connection timed out while fetching resource',
+        isCompleted: true,
+      }
+      const result = formatToolResult('WebFetch', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      expect(container.textContent).toContain('Fetch failed')
+      expect(container.querySelector('.text-destructive')).not.toBeNull()
+    })
+
+    it('should NOT show error for successful WebFetch', () => {
+      const toolResult: Partial<ConversationEvent> = {
+        toolResultContent: 'This is the content of the fetched page with lots of text...',
+        isCompleted: true,
+      }
+      const result = formatToolResult('WebFetch', toolResult as ConversationEvent)
+      const { container } = render(<>{result}</>)
+      expect(container.textContent).toContain('Fetched')
+      expect(container.querySelector('.text-destructive')).toBeNull()
     })
   })
 })

--- a/humanlayer-wui/src/constants/mcpErrors.ts
+++ b/humanlayer-wui/src/constants/mcpErrors.ts
@@ -1,0 +1,128 @@
+/**
+ * MCP (Model Context Protocol) Error Constants
+ *
+ * This file centralizes all MCP error patterns to ensure consistent error detection
+ * across the codebase and prevent pattern drift between components.
+ *
+ * Reference: JSON-RPC 2.0 error codes used by MCP
+ * https://www.jsonrpc.org/specification#error_object
+ */
+
+/**
+ * Known MCP error codes with user-friendly messages and remediation suggestions
+ */
+export const MCP_ERROR_CODES: Record<
+  number,
+  { message: string; suggestion: string }
+> = {
+  // Standard JSON-RPC errors
+  [-32700]: {
+    message: 'Parse error',
+    suggestion: 'The request contains invalid JSON. Try again.',
+  },
+  [-32600]: {
+    message: 'Invalid request',
+    suggestion: 'The request format is invalid. Check the tool parameters.',
+  },
+  [-32601]: {
+    message: 'Method not found',
+    suggestion: 'This tool is not available. The MCP server may not support it.',
+  },
+  [-32602]: {
+    message: 'Invalid params',
+    suggestion: 'The parameters provided are invalid. Check the input format.',
+  },
+  [-32603]: {
+    message: 'Internal error',
+    suggestion: 'The MCP server encountered an internal error. Try again or check server logs.',
+  },
+
+  // Server errors (reserved range -32000 to -32099)
+  [-32000]: {
+    message: 'Server error',
+    suggestion: 'The server encountered an error. Check your configuration.',
+  },
+  [-32001]: {
+    message: 'Rate limited',
+    suggestion: 'Too many requests. Wait a moment before trying again.',
+  },
+  [-32002]: {
+    message: 'Not authorized',
+    suggestion: 'Authentication required. Check your API key or credentials.',
+  },
+}
+
+/**
+ * Regex patterns for detecting MCP-specific errors in tool result content
+ *
+ * These patterns are designed to be specific enough to avoid false positives
+ * while catching the common error formats from MCP servers.
+ */
+export const MCP_ERROR_PATTERNS = {
+  // Matches "MCP error -XXXXX" format (e.g., "MCP error -32603")
+  mcpErrorCode: /MCP error -?\d+/i,
+
+  // Matches "tool_use_error" which is Claude's way of signaling tool failures
+  toolUseError: /tool_use_error/i,
+
+  // Matches "Failed to process" prefix commonly used in MCP error messages
+  failedToProcess: /failed to process/i,
+
+  // Matches JSON-RPC error format embedded in content
+  jsonRpcError: /"error":\s*\{\s*"code":\s*-?\d+/,
+
+  // Matches explicit MCP protocol errors
+  mcpProtocolError: /mcp protocol error/i,
+
+  // Matches tool execution failures
+  toolExecutionFailed: /tool execution failed/i,
+
+  // Matches connection/transport errors
+  connectionError: /connection (refused|reset|timed out)/i,
+}
+
+/**
+ * Combined regex pattern for quick MCP error detection
+ * Use this for efficient single-pass checking
+ */
+export const MCP_ERROR_COMBINED_PATTERN = new RegExp(
+  [
+    MCP_ERROR_PATTERNS.mcpErrorCode.source,
+    MCP_ERROR_PATTERNS.toolUseError.source,
+    MCP_ERROR_PATTERNS.failedToProcess.source,
+    MCP_ERROR_PATTERNS.jsonRpcError.source,
+    MCP_ERROR_PATTERNS.mcpProtocolError.source,
+    MCP_ERROR_PATTERNS.toolExecutionFailed.source,
+    MCP_ERROR_PATTERNS.connectionError.source,
+  ].join('|'),
+  'i'
+)
+
+/**
+ * Extract error code from MCP error message
+ * @param content The content to search for error code
+ * @returns The error code number or null if not found
+ */
+export function extractMcpErrorCode(content: string): number | null {
+  const match = content.match(/MCP error (-?\d+)/i)
+  if (match) {
+    return parseInt(match[1], 10)
+  }
+
+  // Also check for JSON-RPC error format
+  const jsonMatch = content.match(/"error":\s*\{\s*"code":\s*(-?\d+)/)
+  if (jsonMatch) {
+    return parseInt(jsonMatch[1], 10)
+  }
+
+  return null
+}
+
+/**
+ * Get user-friendly error info for an MCP error code
+ * @param code The MCP error code
+ * @returns Error info object or null if code is unknown
+ */
+export function getMcpErrorInfo(code: number): { message: string; suggestion: string } | null {
+  return MCP_ERROR_CODES[code] || null
+}


### PR DESCRIPTION
## Summary
- Display accurate error status ("Search failed: Internal error") instead of false success messages ("Retrieved search results")
- Show actionable remediation suggestions below error messages (e.g., "Try again or check server logs")
- Apply visual highlighting (red `text-destructive` class) for failed tool calls

## Changes
- **`mcpErrors.ts`** (NEW): Centralized MCP error patterns and user-friendly messages with suggestions
- **`formatters.ts`**: Added `hasMcpError()`, `extractMcpError()` functions for error detection
- **`formatters.test.ts`** (NEW): Unit tests for MCP error detection
- **`WebSearchToolCallContent.tsx`**: Error-first checking with suggestion display
- **`MCPToolCallContent.tsx`**: Error-first checking with suggestion display
- **`WebFetchToolCallContent.tsx`**: Error-first checking with suggestion display
- **`formatToolResult.tsx`**: MCP error detection in event list

## Test plan
- [ ] Unit tests pass (`bun test formatters.test.ts`)
- [ ] MCP errors display red "Failed" status instead of green success
- [ ] Suggestions appear below error messages (e.g., "The MCP server encountered an internal error. Try again or check server logs.")
- [ ] Successful results still display normally

Fixes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Centralizes MCP error handling with improved detection and user feedback across components.
> 
>   - **Behavior**:
>     - Displays accurate error status and suggestions for MCP errors in `MCPToolCallContent.tsx`, `WebFetchToolCallContent.tsx`, and `WebSearchToolCallContent.tsx`.
>     - Applies `text-destructive` class for failed tool calls.
>   - **Error Handling**:
>     - Adds `mcpErrors.ts` for centralized MCP error patterns and messages.
>     - Adds `hasMcpError()`, `extractMcpError()` in `formatters.ts` for error detection.
>     - Updates `formatToolResult.tsx` to handle MCP errors in tool results.
>   - **Testing**:
>     - Adds `formatters.test.ts` for unit tests on MCP error detection.
>     - Updates `formatToolResult.test.tsx` to test MCP error handling in tool results.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for a61830e30bb9017f49e243d9cfe42926853b35eb. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->