### PR TITLE
fix(hld): use correct path for global slash commands

### DIFF
--- a/hld/api/handlers/sessions.go
+++ b/hld/api/handlers/sessions.go
@@ -1619,16 +1619,16 @@ func (h *SessionHandlers) GetSlashCommands(ctx context.Context, req api.GetSlash
 	// Build command directory paths
 	localCommandsDir := filepath.Join(expandTilde(workingDir), ".claude", "commands")
 
-	// Respect CLAUDE_CONFIG_DIR for global commands
-	configDir := os.Getenv("CLAUDE_CONFIG_DIR")
-	if configDir == "" {
-		// Fall back to default Claude Code location
+	// Global commands - respect CLAUDE_CONFIG_DIR override, default to ~/.claude/commands
+	globalCommandsDir := ""
+	if configDir := os.Getenv("CLAUDE_CONFIG_DIR"); configDir != "" {
+		globalCommandsDir = filepath.Join(expandTilde(configDir), "commands")
+	} else {
 		homeDir, err := os.UserHomeDir()
 		if err == nil {
-			configDir = filepath.Join(homeDir, ".config", "claude-code")
+			globalCommandsDir = filepath.Join(homeDir, ".claude", "commands")
 		}
 	}
-	globalCommandsDir := filepath.Join(expandTilde(configDir), "commands")
 
 	// Use a map to track commands and handle deduplication
 	// Key is command name, value is the command with source

--- a/hld/api/handlers/sessions_slash_commands_test.go
+++ b/hld/api/handlers/sessions_slash_commands_test.go
@@ -367,9 +367,9 @@ func TestGetSlashCommandsWithGlobalCommands(t *testing.T) {
 	tempDir := t.TempDir()
 	localCommandsDir := filepath.Join(tempDir, ".claude", "commands")
 
-	// Create a temp home directory for global commands
+	// Create a temp home directory for global commands (default is ~/.claude/commands)
 	tempHomeDir := t.TempDir()
-	globalCommandsDir := filepath.Join(tempHomeDir, ".config", "claude-code", "commands")
+	globalCommandsDir := filepath.Join(tempHomeDir, ".claude", "commands")
 
 	// Set HOME env var temporarily for this test
 	originalHome := os.Getenv("HOME")
@@ -528,9 +528,9 @@ func TestGetSlashCommandsGlobalOverridesLocal(t *testing.T) {
 	tempDir := t.TempDir()
 	localCommandsDir := filepath.Join(tempDir, ".claude", "commands")
 
-	// Create a temp home directory for global commands
+	// Create a temp home directory for global commands (default is ~/.claude/commands)
 	tempHomeDir := t.TempDir()
-	globalCommandsDir := filepath.Join(tempHomeDir, ".config", "claude-code", "commands")
+	globalCommandsDir := filepath.Join(tempHomeDir, ".claude", "commands")
 
 	// Set HOME env var temporarily for this test
 	originalHome := os.Getenv("HOME")
@@ -740,9 +740,8 @@ func TestGetSlashCommandsFallsBackToDefaultWhenCLAUDE_CONFIG_DIRNotSet(t *testin
 	tempDir := t.TempDir()
 	tempHomeDir := t.TempDir()
 
-	// Set up directory structure in default location (~/.config/claude-code/commands)
-	defaultConfigDir := filepath.Join(tempHomeDir, ".config", "claude-code")
-	defaultCommandsDir := filepath.Join(defaultConfigDir, "commands")
+	// Set up directory structure in default location (~/.claude/commands)
+	defaultCommandsDir := filepath.Join(tempHomeDir, ".claude", "commands")
 	assert.NoError(t, os.MkdirAll(defaultCommandsDir, 0755))
 
 	// Create test commands in default location


### PR DESCRIPTION
## What problem(s) was I solving?

Fixes #841

Global slash commands from `~/.claude/commands` were not being discovered in CodeLayer. Users saw "Failed to load commands" when typing `/`.

The root cause was that hld was looking for global commands at `~/.config/claude-code/commands` instead of `~/.claude/commands` where Claude Code actually stores them.

## What user-facing changes did I ship?

Global slash commands now appear correctly when typing `/` in CodeLayer.

## How I implemented it

Changed the default global commands path in `hld/api/handlers/sessions.go` from:
- `~/.config/claude-code/commands` (incorrect default)

To:
- `~/.claude/commands` (matching Claude Code's actual location)

`CLAUDE_CONFIG_DIR` is still respected as an override when set, providing flexibility for non-standard configurations.

Updated tests to use the correct default path.

## How to verify it

- [x] I have ensured `make check test` passes
- [ ] Place a `.md` file in `~/.claude/commands/` and verify it appears when typing `/` in CodeLayer
- [ ] (Optional) Set `CLAUDE_CONFIG_DIR` to a custom path and verify commands are discovered from `$CLAUDE_CONFIG_DIR/commands`

## Description for the changelog

Fixed global slash commands not being discovered from `~/.claude/commands`

## A picture of a cute animal (not mandatory but encouraged)

🦔
