### PR TITLE
fix: Use dynamic log file name based on product name

### DIFF
--- a/humanlayer-wui/CLAUDE.md
+++ b/humanlayer-wui/CLAUDE.md
@@ -5,8 +5,11 @@ The WUI connects to the HumanLayer daemon (hld) to provide a graphical interface
 When the WUI is running, logs are written to:
 
 - Development: `~/.humanlayer/logs/wui-{branch-id}/codelayer.log` (e.g., `wui-eng-1784/codelayer.log`)
-- Production: Platform-specific directories:
-  - macOS: `~/Library/Logs/dev.humanlayer.wui/`
+- Production: Platform-specific directories with product-specific log file names:
+  - macOS:
+    - Standard: `~/Library/Logs/dev.humanlayer.wui/CodeLayer.log`
+    - Nightly: `~/Library/Logs/dev.humanlayer.wui.nightly/CodeLayer-Nightly.log`
+    - PRO: `~/Library/Logs/dev.humanlayer.wui.pro/CodeLayer-Pro.log`
   - Windows: `%APPDATA%\dev.humanlayer.wui\logs\`
   - Linux: `~/.config/dev.humanlayer.wui/logs/`
 

--- a/humanlayer-wui/src-tauri/src/lib.rs
+++ b/humanlayer-wui/src-tauri/src/lib.rs
@@ -313,6 +313,21 @@ async fn get_log_directory() -> Result<String, String> {
 }
 
 #[tauri::command]
+fn get_log_file_name(app: tauri::AppHandle) -> String {
+    let is_dev = cfg!(debug_assertions);
+
+    if is_dev {
+        // Dev mode always uses "codelayer.log"
+        "codelayer.log".to_string()
+    } else {
+        // Production: use product name from package info
+        // Tauri uses <ProductName>.log as the log file name when file_name is None
+        let config = app.config();
+        format!("{}.log", config.product_name.as_ref().unwrap_or(&"CodeLayer".to_string()))
+    }
+}
+
+#[tauri::command]
 async fn read_last_log_lines(n: usize, log_path: Option<String>) -> Result<String, String> {
     use std::fs::File;
     use std::io::{BufReader, BufRead};
@@ -602,6 +617,7 @@ pub fn run() {
             get_daemon_info,
             is_daemon_running,
             get_log_directory,
+            get_log_file_name,
             read_last_log_lines,
             show_quick_launcher,
             set_window_background_color,

--- a/humanlayer-wui/src/components/SettingsDialog.tsx
+++ b/humanlayer-wui/src/components/SettingsDialog.tsx
@@ -69,12 +69,14 @@ export function SettingsDialog({ open, onOpenChange, onConfigUpdate }: SettingsD
   async function loadLogPath() {
     try {
       const path = await invoke<string>('get_log_directory')
-      setLogPath(path + '/codelayer.log')
+      const fileName = await invoke<string>('get_log_file_name')
+      setLogPath(path + '/' + fileName)
     } catch {
       // In production, use appLogDir
       try {
         const appLog = await appLogDir()
-        setLogPath(appLog + '/codelayer.log')
+        const fileName = await invoke<string>('get_log_file_name')
+        setLogPath(appLog + '/' + fileName)
       } catch (e) {
         console.error('Failed to get log directory:', e)
         setLogPath('')


### PR DESCRIPTION
## What problem(s) was I solving?

Fixes incorrect log file path display in Settings for CodeLayer PRO and other build variants. Previously hardcoded to "codelayer.log", now dynamically uses the product name (e.g., "CodeLayer-Pro.log", "CodeLayer-Nightly.log").

Fixes #884

## What user-facing changes did I ship?

No new user-facing changes.

## How I implemented it

### Changes Made

1. **Added new Rust command** (`humanlayer-wui/src-tauri/src/lib.rs:315-328`):
   - Created `get_log_file_name()` command that dynamically returns the correct log file name based on the Tauri product name
   - In development mode: always returns `codelayer.log`
   - In production mode: returns `{ProductName}.log` (e.g., `CodeLayer-Pro.log`, `CodeLayer-Nightly.log`, or `CodeLayer.log`)

2. **Updated TypeScript code** (`humanlayer-wui/src/components/SettingsDialog.tsx:69-85`):
   - Modified `loadLogPath()` function to call the new `get_log_file_name` command
   - Now dynamically constructs the full log path using the correct filename for each build variant

3. **Updated documentation** (`humanlayer-wui/CLAUDE.md:5-14`):
   - Documented the correct log paths for all build variants (Standard, Nightly, and PRO)

### How It Works

The fix leverages the fact that Tauri automatically uses the `productName` from the config as the log file name when `file_name: None` is set in the log plugin configuration. The new code:

- Reads the product name from Tauri's config at runtime
- Formats it as `{ProductName}.log`
- Returns the correct filename for each build variant:
  - Standard: `CodeLayer.log`
  - Nightly: `CodeLayer-Nightly.log`
  - PRO: `CodeLayer-Pro.log`

## How to verify it

> [!NOTE]
> I'm not sure how to build a PRO version of CodeLayer locally to verify the fix. I did do a dev build locally to ensure that everything still worked.

### Testing

1. Built the dev version of CodeLayer 
2. Went to Settings
4. Verified the log path shows: `~/Library/Logs/dev.humanlayer.wui.pro/codelayer.log`
5. Tested the "Copy last N lines" button to ensure it correctly reads from the log file

- [x] I have ensured `make check test` passes

I did get a failure on the daemon lint checks, but assume this was already present?

```
=== Running Checks ===


[hlyr] CLI tool checks:
  ✓ Format check passed
  ✓ Lint check passed
  ✓ Tests passed (3 test files)
  ✓ Build completed

[humanlayer-wui] Web UI checks:
  ✓ Format check passed
  ✓ Lint check passed
  ✓ Type checking passed
  ✓ Rust check passed
  ✓ Rust clippy passed

[hld] Daemon checks:
  Installing golangci-lint...
  ✓ Format check passed
  ✓ Vet check passed
  ✗ Lint check passed
api/integration_test.go:2:1: buildtag: +build line is no longer needed (govet)
// +build integration
^
daemon/daemon_conversation_integration_test.go:2:1: buildtag: +build line is no longer needed (govet)
// +build integration
^
daemon/daemon_degraded_test.go:2:1: buildtag: +build line is no longer needed (govet)
// +build integration
^
3 issues:
* govet: 3
make[2]: *** [check-quiet] Error 1
make[1]: *** [check] Error 2
make: *** [check-hld] Error 2
```

## Description for the changelog

## A picture of a cute animal (not mandatory but encouraged)

My dog Milo having his morning coffee.
![milo_coffee](https://github.com/user-attachments/assets/d774fd37-816f-4b49-8f37-c215bde15f13)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Dynamic log file naming based on product name implemented in Rust and TypeScript, with documentation updates.
> 
>   - **Behavior**:
>     - `get_log_file_name()` command in `lib.rs` dynamically returns log file name based on Tauri product name.
>     - In development, returns `codelayer.log`; in production, returns `{ProductName}.log`.
>   - **TypeScript**:
>     - `loadLogPath()` in `SettingsDialog.tsx` updated to use `get_log_file_name()` for dynamic log path construction.
>   - **Documentation**:
>     - Updated `CLAUDE.md` to document log paths for Standard, Nightly, and PRO builds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for eab8a6bf282b933e7bab38024f000d49b9ac9ac6. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->