### PR TITLE
Add close button to all toast notifications

### DIFF
--- a/humanlayer-wui/src/components/internal/CodeLayerToaster.tsx
+++ b/humanlayer-wui/src/components/internal/CodeLayerToaster.tsx
@@ -18,6 +18,7 @@ export function CodeLayerToaster() {
       }}
       toastOptions={{
         unstyled: true,
+        closeButton: true,
         classNames: {
           // Base toast container - Sonner default: padding: 16px, gap: 6px, border-radius: 8px
           toast: `


### PR DESCRIPTION
## What problem(s) was I solving?

Toast notifications couldn't be dismissed manually - users had to wait for them to auto-dismiss.

## What user-facing changes did I ship?

All toast notifications now have a close button (X) in the top-left corner.

## How I implemented it

Added closeButton: true to the global Sonner Toaster config in CodeLayerToaster.tsx.

## How to verify it

- [x] I have ensured make check test passes

1. Trigger any toast (clipboard operation, settings change, etc.)
2. Verify the X button appears
3. Click X to dismiss immediately

## Description for the changelog

Added close button to all toast notifications for easier dismissal.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add close button to toast notifications in `CodeLayerToaster` for manual dismissal.
> 
>   - **Behavior**:
>     - Added `closeButton: true` to `toastOptions` in `CodeLayerToaster` to enable manual dismissal of toast notifications.
>   - **User Interface**:
>     - All toast notifications now display a close button (X) in the top-left corner for immediate dismissal.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 712f31a25eadde498e62b916629d05f841a32f43. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->