### PR TITLE
Add clipboard image paste support

### DIFF
--- a/humanlayer-wui/src-tauri/Cargo.lock
+++ b/humanlayer-wui/src-tauri/Cargo.lock
@@ -1837,6 +1837,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4373,6 +4379,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http 1.3.1",
+ "http-range",
  "jni",
  "libc",
  "log",

--- a/humanlayer-wui/src-tauri/Cargo.toml
+++ b/humanlayer-wui/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["devtools"] }
+tauri = { version = "2", features = [ "protocol-asset", "devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2.3.0"
 tauri-plugin-fs = "2"

--- a/humanlayer-wui/src-tauri/capabilities/default.json
+++ b/humanlayer-wui/src-tauri/capabilities/default.json
@@ -5,6 +5,10 @@
   "windows": ["main", "quick-launcher"],
   "permissions": [
     "core:default",
+    "core:app:allow-app-show",
+    "core:app:allow-app-hide",
+    "core:resources:default",
+    "core:path:default",
     "opener:default",
     {
       "identifier": "opener:allow-open-path",
@@ -17,11 +21,18 @@
     "notification:default",
     "core:webview:allow-set-webview-zoom",
     "fs:default",
+    "fs:allow-exists",
+    "fs:allow-mkdir",
+    "fs:allow-read-file",
+    "fs:allow-temp-write-recursive",
     {
       "identifier": "fs:scope",
       "allow": [
         {
           "path": "**/*"
+        },
+        {
+          "path": "$TEMP/**"
         }
       ]
     },

--- a/humanlayer-wui/src-tauri/tauri.conf.json
+++ b/humanlayer-wui/src-tauri/tauri.conf.json
@@ -25,7 +25,11 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; img-src 'self' asset: http://asset.localhost blob: data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'",
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["**/*", "$TEMP/**"]
+      }
     },
     "withGlobalTauri": true
   },

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/FileMentionNode.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/FileMentionNode.tsx
@@ -1,5 +1,8 @@
 import { NodeViewWrapper } from '@tiptap/react'
-import { FileIcon, FolderIcon, HatGlasses } from 'lucide-react'
+import { FileIcon, FolderIcon, HatGlasses, ImageIcon, X } from 'lucide-react'
+import { useState, useEffect } from 'react'
+import { convertFileSrc } from '@tauri-apps/api/core'
+import { isTauri } from '@/lib/utils'
 
 interface FileMentionNodeProps {
   node: {
@@ -9,13 +12,100 @@ interface FileMentionNodeProps {
       isDirectory: boolean
     }
   }
+  deleteNode: () => void
 }
 
-export const FileMentionNode = ({ node }: FileMentionNodeProps) => {
+// Image file extensions
+const IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'svg', 'ico']
+
+function isImageFile(filePath: string): boolean {
+  const ext = filePath.split('.').pop()?.toLowerCase() || ''
+  return IMAGE_EXTENSIONS.includes(ext)
+}
+
+export const FileMentionNode = ({ node, deleteNode }: FileMentionNodeProps) => {
   const { label, id, isDirectory } = node.attrs
+  const [imageSrc, setImageSrc] = useState<string | null>(null)
+  const [imageError, setImageError] = useState(false)
 
   // Check if this is an agent mention (id starts with "@agent-")
   const isAgent = id.startsWith('@agent-')
+  const isImage = !isDirectory && !isAgent && isImageFile(id)
+
+  // Load image preview for image files
+  useEffect(() => {
+    if (isImage && isTauri()) {
+      try {
+        // Convert file path to asset URL for Tauri
+        const assetUrl = convertFileSrc(id)
+        setImageSrc(assetUrl)
+      } catch (error) {
+        console.error('Failed to convert file path to asset URL:', error)
+        setImageError(true)
+      }
+    }
+  }, [id, isImage])
+
+  // Render image mention with preview
+  if (isImage && imageSrc && !imageError) {
+    return (
+      <NodeViewWrapper
+        as="span"
+        className="inline-flex items-center gap-1 align-middle"
+        contentEditable={false}
+        data-mention={id}
+      >
+        <span className="relative group inline-block">
+          <img
+            src={imageSrc}
+            alt={label || 'Image preview'}
+            className="h-16 max-w-32 object-contain rounded border border-border"
+            onError={() => setImageError(true)}
+          />
+          <button
+            onClick={e => {
+              e.preventDefault()
+              e.stopPropagation()
+              deleteNode()
+            }}
+            className="absolute -top-1.5 -right-1.5 p-0.5 rounded-full bg-background border border-border opacity-0 group-hover:opacity-100 transition-opacity hover:bg-destructive hover:text-destructive-foreground hover:border-destructive"
+            title="Remove image"
+            type="button"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </span>
+      </NodeViewWrapper>
+    )
+  }
+
+  // Fallback for images that failed to load - show as regular mention with image icon
+  if (isImage) {
+    return (
+      <NodeViewWrapper
+        as="span"
+        className="mention inline-flex items-center gap-1"
+        contentEditable={false}
+        data-mention={id}
+        title={`Open ${id}`}
+      >
+        <ImageIcon className="inline-block h-3.5 w-3.5" />
+        <span>@{label || id}</span>
+        <button
+          onClick={e => {
+            e.preventDefault()
+            e.stopPropagation()
+            deleteNode()
+          }}
+          className="ml-0.5 p-0.5 rounded hover:bg-destructive hover:text-destructive-foreground"
+          title="Remove"
+          type="button"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      </NodeViewWrapper>
+    )
+  }
 
   return (
     <NodeViewWrapper


### PR DESCRIPTION
## What problem(s) was I solving?

Users couldn't paste images from clipboard into the chat other than drag-drop which isnt always as convenient as cmd+V.

## What user-facing changes did I ship?

- Cmd+V with image in clipboard saves to temp file and inserts file mention
- Image files show thumbnail preview in the editor
- Delete button on hover to remove pasted images
- Works with screenshots, copied images, etc.

## How I implemented it

- Added paste handler in ResponseEditor that detects image clipboard data
- Saves image to temp directory using Tauri filesystem APIs
- Inserts file mention node (reuses existing drag-and-drop infrastructure)
- FileMentionNode detects image extensions and shows thumbnail via Tauri asset protocol
- Configured Tauri CSP and asset protocol scope for local image display
- Simplified editor text extraction to use getText() with renderText

## How to verify it

- [x] I have ensured `make check test` passes

1. Take a screenshot (Cmd+Shift+4 on Mac)
2. Paste into chat input (Cmd+V)
3. Verify file mention appears (e.g., `@pasted-image-xxx.png`)
4. Verify thumbnail preview shows
5. Hover and click X to remove
6. Submit message - verify Claude can see/describe the image

## Description for the changelog

Added clipboard image paste support with thumbnail previews in chat input for sanity checks
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds clipboard image paste support with thumbnail previews in chat input, updating `ResponseEditor.tsx` and `FileMentionNode.tsx`, and configuring Tauri for local image display.
> 
>   - **Behavior**:
>     - `ResponseEditor.tsx`: Adds paste handler for image clipboard data, saves images to temp directory, inserts file mention node.
>     - `FileMentionNode.tsx`: Detects image extensions, shows thumbnail preview, adds delete button on hover.
>   - **Configuration**:
>     - `Cargo.toml`: Adds `protocol-asset` feature to `tauri` dependency.
>     - `tauri.conf.json`: Configures CSP and asset protocol for local image display.
>     - `default.json`: Updates permissions for filesystem access.
>   - **Misc**:
>     - Simplifies text extraction in `ResponseEditor.tsx` using `getText()` with `renderText`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 7346ee01e1fb2bfa5de29f514efc79bef9d38275. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->