### PR TITLE
Minor internal reference edit. 

### DIFF
--- a/.claude/commands/research_codebase_generic.md
+++ b/.claude/commands/research_codebase_generic.md
@@ -64,7 +64,7 @@ Then wait for the user's research query.
        - Without ticket: `2025-01-08-authentication-flow.md`
 
 6. **Generate research document:**
-   - Use the metadata gathered in step 4
+   - Use the metadata gathered in step 5
    - Structure the document with YAML frontmatter followed by content:
      ```markdown
      ---
@@ -82,10 +82,10 @@ Then wait for the user's research query.
 
      # Research: [User's Question/Topic]
 
-     **Date**: [Current date and time with timezone from step 4]
+     **Date**: [Current date and time with timezone from step 5]
      **Researcher**: [Researcher name]
-     **Git Commit**: [Current commit hash from step 4]
-     **Branch**: [Current branch name from step 4]
+     **Git Commit**: [Current commit hash from step 5]
+     **Branch**: [Current branch name from step 5]
      **Repository**: [Repository name]
 
      ## Research Question


### PR DESCRIPTION
Minor edit: Step 6 referenced metadata from step 4 instead of step 5 (metadata step). 

## What problem(s) was I solving?

Seeming incorrect reference.

## What user-facing changes did I ship?

None. Minor internal consistency edit

## How I implemented it

Markdown edit

## How to verify it

na

## Description for the changelog

Minor edit to internal command

## A picture of a cute animal (not mandatory but encouraged)

:3

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects step reference in `.claude/commands/research_codebase_generic.md` to ensure metadata is gathered from the correct step.
> 
>   - **Markdown Edit**:
>     - Corrects step reference in `.claude/commands/research_codebase_generic.md` from step 4 to step 5 for metadata usage in step 6.
>     - Updates references to current date, commit hash, and branch name to use metadata from step 5 instead of step 4.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 6b399d835ce016b0f5bf3952aaec4cdb87a9f772. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->