### PR TITLE
Elaborate the Welcome message and add it as an About Dialog...

### DIFF
--- a/humanlayer-wui/src-tauri/src/lib.rs
+++ b/humanlayer-wui/src-tauri/src/lib.rs
@@ -6,7 +6,8 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
-use tauri::{Manager, State, WebviewUrl, WebviewWindowBuilder};
+use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
+use tauri::menu::{Menu, MenuBuilder, MenuItemBuilder};
 use tauri_plugin_store::StoreExt;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -440,6 +441,154 @@ fn show_quick_launcher(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+// Build application menu with default items plus custom About
+fn build_app_menu(app: &tauri::AppHandle) -> Result<Menu<tauri::Wry>, tauri::Error> {
+    // Create menu builder
+    let menu = MenuBuilder::new(app);
+
+    #[cfg(target_os = "macos")]
+    {
+        // On macOS, create the full menu bar with default menus
+        use tauri::menu::{Submenu, PredefinedMenuItem};
+
+        // App menu (macOS only) with standard items
+        let app_menu = Submenu::with_items(
+            app,
+            "CodeLayer",
+            true,
+            &[
+                // About item will be in the Help menu instead
+                &PredefinedMenuItem::separator(app)?,
+                &PredefinedMenuItem::services(app, None)?,
+                &PredefinedMenuItem::separator(app)?,
+                &PredefinedMenuItem::hide(app, None)?,
+                &PredefinedMenuItem::hide_others(app, None)?,
+                &PredefinedMenuItem::show_all(app, None)?,
+                &PredefinedMenuItem::separator(app)?,
+                &PredefinedMenuItem::quit(app, None)?,
+            ],
+        )?;
+
+        // Edit menu with standard items
+        let edit_menu = Submenu::with_items(
+            app,
+            "Edit",
+            true,
+            &[
+                &PredefinedMenuItem::undo(app, None)?,
+                &PredefinedMenuItem::redo(app, None)?,
+                &PredefinedMenuItem::separator(app)?,
+                &PredefinedMenuItem::cut(app, None)?,
+                &PredefinedMenuItem::copy(app, None)?,
+                &PredefinedMenuItem::paste(app, None)?,
+                &PredefinedMenuItem::select_all(app, None)?,
+            ],
+        )?;
+
+        // View menu with standard items
+        let view_menu = Submenu::with_items(
+            app,
+            "View",
+            true,
+            &[
+                &PredefinedMenuItem::fullscreen(app, None)?,
+            ],
+        )?;
+
+        // Window menu with standard items
+        let window_menu = Submenu::with_items(
+            app,
+            "Window",
+            true,
+            &[
+                &PredefinedMenuItem::minimize(app, None)?,
+                &PredefinedMenuItem::maximize(app, None)?,
+                &PredefinedMenuItem::separator(app)?,
+                &PredefinedMenuItem::close_window(app, None)?,
+            ],
+        )?;
+
+        // Help menu with custom About item
+        let about_item = MenuItemBuilder::with_id("about", "About CodeLayer")
+            .build(app)?;
+
+        let help_menu = Submenu::with_items(
+            app,
+            "Help",
+            true,
+            &[&about_item],
+        )?;
+
+        menu
+            .item(&app_menu)
+            .item(&edit_menu)
+            .item(&view_menu)
+            .item(&window_menu)
+            .item(&help_menu)
+            .build()
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        // On Windows/Linux, simpler menu structure
+        use tauri::menu::{Submenu, PredefinedMenuItem};
+
+        // File menu
+        let file_menu = Submenu::with_items(
+            app,
+            "File",
+            true,
+            &[
+                &PredefinedMenuItem::quit(app, None)?,
+            ],
+        )?;
+
+        // Edit menu
+        let edit_menu = Submenu::with_items(
+            app,
+            "Edit",
+            true,
+            &[
+                &PredefinedMenuItem::undo(app, None)?,
+                &PredefinedMenuItem::redo(app, None)?,
+                &PredefinedMenuItem::separator(app)?,
+                &PredefinedMenuItem::cut(app, None)?,
+                &PredefinedMenuItem::copy(app, None)?,
+                &PredefinedMenuItem::paste(app, None)?,
+                &PredefinedMenuItem::select_all(app, None)?,
+            ],
+        )?;
+
+        // View menu
+        let view_menu = Submenu::with_items(
+            app,
+            "View",
+            true,
+            &[
+                &PredefinedMenuItem::fullscreen(app, None)?,
+            ],
+        )?;
+
+        // Help menu with custom About item
+        let about_item = MenuItemBuilder::with_id("about", "About CodeLayer")
+            .build(app)?;
+
+        let help_menu = Submenu::with_items(
+            app,
+            "Help",
+            true,
+            &[&about_item],
+        )?;
+
+        menu
+            .item(&file_menu)
+            .item(&edit_menu)
+            .item(&view_menu)
+            .item(&help_menu)
+            .build()
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Create daemon manager outside of builder
@@ -503,6 +652,20 @@ pub fn run() {
         .setup(move |app| {
             // Register the daemon manager as managed state
             app.manage(daemon_manager.clone());
+
+            // Build and set the application menu
+            let menu = build_app_menu(app.handle())?;
+            app.set_menu(menu)?;
+
+            // Handle menu events
+            app.on_menu_event(move |app_handle, event| {
+                if event.id() == "about" {
+                    // Emit event to frontend to show About dialog
+                    if let Some(window) = app_handle.get_webview_window("main") {
+                        let _ = window.emit("show-about", ());
+                    }
+                }
+            });
 
             // Restore window state if it exists
             if let Some(main_window) = app.get_webview_window("main") {

--- a/humanlayer-wui/src/components/AboutDialog.tsx
+++ b/humanlayer-wui/src/components/AboutDialog.tsx
@@ -1,0 +1,128 @@
+import { useRef } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Info, Terminal, Zap } from 'lucide-react'
+import { useHotkeys } from 'react-hotkeys-hook'
+import { HotkeyScopeBoundary } from './HotkeyScopeBoundary'
+import { HOTKEY_SCOPES } from '@/hooks/hotkeys/scopes'
+import { getAppVersion, formatVersionForDisplay } from '@/lib/version'
+
+interface AboutDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function AboutDialog({ open, onOpenChange }: AboutDialogProps) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+
+  // Handle Escape and Enter to close
+  useHotkeys(
+    'escape, enter',
+    e => {
+      e.preventDefault()
+      e.stopPropagation()
+      onOpenChange(false)
+    },
+    {
+      enabled: open,
+      enableOnFormTags: true,
+      preventDefault: true,
+      scopes: [HOTKEY_SCOPES.ABOUT_DIALOG],
+    },
+  )
+
+  const version = getAppVersion()
+  const displayVersion = formatVersionForDisplay(version)
+
+  return (
+    <HotkeyScopeBoundary
+      scope={HOTKEY_SCOPES.ABOUT_DIALOG}
+      isActive={open}
+      rootScopeDisabled={true}
+      componentName="AboutDialog"
+    >
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent
+          className="max-w-lg"
+          onOpenAutoFocus={e => {
+            e.preventDefault()
+            closeButtonRef.current?.focus()
+          }}
+        >
+          <DialogHeader>
+            <div className="flex items-center gap-3">
+              <Terminal className="h-6 w-6 text-[var(--terminal-accent)]" />
+              <DialogTitle>Welcome to CodeLayer</DialogTitle>
+            </div>
+            <DialogDescription className="text-left">
+              A powerful tool for working with AI agents in your development workflow.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div>
+              <h4 className="flex items-center gap-2 text-sm font-medium text-[var(--terminal-accent)] mb-2">
+                <Zap className="h-4 w-4" />
+                What CodeLayer does:
+              </h4>
+              <ul className="text-sm text-muted-foreground space-y-1 ml-6">
+                <li>• Research codebases and gather context</li>
+                <li>• Plan implementations with detailed specifications</li>
+                <li>• Refine plans through iterative collaboration</li>
+                <li>• Implement features with human oversight</li>
+                <li>• And much more...</li>
+              </ul>
+            </div>
+
+            <div>
+              <h4 className="flex items-center gap-2 text-sm font-medium text-[var(--terminal-accent)] mb-2">
+                <Info className="h-4 w-4" />
+                Getting started:
+              </h4>
+              <div className="text-sm text-muted-foreground ml-6 space-y-2">
+                <p>
+                  <strong>1.</strong> Create a session in your working directory
+                </p>
+                <p>
+                  <strong>2.</strong> Type{' '}
+                  <kbd className="px-1.5 py-0.5 text-xs bg-muted rounded border border-border font-mono">
+                    /
+                  </kbd>{' '}
+                  to see available HumanLayer-defined commands
+                </p>
+                <p>
+                  <strong>3.</strong> Select a command to start working with Claude
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter className="mt-4">
+            <Button
+              ref={closeButtonRef}
+              variant="default"
+              onClick={() => onOpenChange(false)}
+              className="w-full sm:w-auto"
+            >
+              Got it
+              <kbd className="ml-2 px-1 py-0.5 text-xs bg-muted/50 rounded">ENTER</kbd>
+            </Button>
+          </DialogFooter>
+
+          <div className="bg-muted/50 p-3 rounded-lg">
+            <p className="text-xs text-muted-foreground text-center font-mono">
+              CodeLayer {displayVersion}
+            </p>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </HotkeyScopeBoundary>
+  )
+}

--- a/humanlayer-wui/src/components/internal/SessionsEmptyState.tsx
+++ b/humanlayer-wui/src/components/internal/SessionsEmptyState.tsx
@@ -4,6 +4,7 @@ import { getLastWorkingDir } from '@/hooks'
 import { useSessionLauncher } from '@/hooks/useSessionLauncher'
 import { useHotkeyUnicodeChars } from '@/hooks/useHotkeyUnicodeChars'
 import { KeyboardShortcut } from '../HotkeyPanel'
+import { Terminal, Zap, Info } from 'lucide-react'
 
 export function SessionsEmptyState() {
   const { open } = useSessionLauncher()
@@ -24,20 +25,59 @@ export function SessionsEmptyState() {
 
   return (
     <div className="flex justify-center py-20 px-8">
-      <div className="flex flex-col items-start w-full max-w-xl">
-        <h1 className="text-2xl font-semibold mb-8">Welcome</h1>
+      <div className="flex flex-col items-start w-full max-w-2xl">
+        <div className="flex items-center gap-3 mb-2">
+          <Terminal className="h-8 w-8 text-[var(--terminal-accent)]" />
+          <h1 className="text-2xl font-semibold">Welcome to CodeLayer</h1>
+        </div>
 
-        <div className="text-sm text-muted-foreground mb-8 space-y-4">
-          <p>
-            CodeLayer is a tool for using AI Coding Agents to solve hard problems in complex codebases.
-          </p>
+        <p className="text-sm text-muted-foreground mb-8">
+          A powerful tool for working with AI agents in your development workflow.
+        </p>
 
-          <p>
-            It uses your default claude code settings and api keys and supports any agents / slash
-            commands you have configured.
-          </p>
+        <div className="space-y-6 mb-8 w-full">
+          <div>
+            <h3 className="flex items-center gap-2 text-sm font-medium text-[var(--terminal-accent)] mb-3">
+              <Zap className="h-4 w-4" />
+              What CodeLayer does:
+            </h3>
+            <ul className="text-sm text-muted-foreground space-y-2 ml-6">
+              <li>• Research codebases and gather context</li>
+              <li>• Plan implementations with detailed specifications</li>
+              <li>• Refine plans through iterative collaboration</li>
+              <li>• Implement features with human oversight</li>
+              <li>• And much more...</li>
+            </ul>
+          </div>
 
-          <p>Create a session to get started.</p>
+          <div>
+            <h3 className="flex items-center gap-2 text-sm font-medium text-[var(--terminal-accent)] mb-3">
+              <Info className="h-4 w-4" />
+              Getting started:
+            </h3>
+            <div className="text-sm text-muted-foreground ml-6 space-y-2">
+              <p>
+                <strong>1.</strong> Create a session in your working directory
+              </p>
+              <p>
+                <strong>2.</strong> Type{' '}
+                <kbd className="px-1.5 py-0.5 text-xs bg-muted rounded border border-border font-mono">
+                  /
+                </kbd>{' '}
+                to see available HumanLayer-defined commands
+              </p>
+              <p>
+                <strong>3.</strong> Select a command to start working with Claude
+              </p>
+            </div>
+          </div>
+
+          <div className="bg-muted/50 p-4 rounded-lg">
+            <p className="text-sm text-muted-foreground">
+              CodeLayer uses your default Claude Code settings and API keys, and supports any agents or
+              slash commands you have configured.
+            </p>
+          </div>
         </div>
 
         <div className="flex gap-2">

--- a/humanlayer-wui/src/hooks/hotkeys/scopes.ts
+++ b/humanlayer-wui/src/hooks/hotkeys/scopes.ts
@@ -21,6 +21,7 @@ export const HOTKEY_SCOPES = {
   ADDITIONAL_DIRECTORIES: 'additionalDirectories',
   SESSION_LAUNCHER: 'sessions.launcher',
   TELEMETRY_MODAL: 'telemetry-modal',
+  ABOUT_DIALOG: 'about-dialog',
 } as const
 
 export type HotkeyScope = (typeof HOTKEY_SCOPES)[keyof typeof HOTKEY_SCOPES]

--- a/humanlayer-wui/src/lib/preferences.ts
+++ b/humanlayer-wui/src/lib/preferences.ts
@@ -1,5 +1,6 @@
 // Storage keys
 export const ARCHIVE_ON_FORK_KEY = 'archive-source-on-fork'
+export const ABOUT_WELCOME_SEEN = 'about-welcome-seen'
 
 // Draft Launcher preference keys
 export const DRAFT_LAUNCHER_PREFS = {


### PR DESCRIPTION
...opened by the native system "Help" menu.

## What problem(s) was I solving?
Clarifying app's purpose for new users.

## What user-facing changes did I ship?
More elaborate Welcome message on app load.
"Help" native system menu implement to resurface the same message in an About Dialog.

## How I implemented it
CodeLayer's Create Plan -> Implement Plan

## How to verify it
Launch app, see elaborated Welcome message.
Help menu -> see message in About Dialog.

<img width="1800" height="1128" alt="Screenshot 2025-12-04 at 8 15 11 PM" src="https://github.com/user-attachments/assets/ffdf039c-5e9a-407b-8903-d0304f00557f" />

<img width="457" height="157" alt="Screenshot 2025-12-04 at 8 15 26 PM" src="https://github.com/user-attachments/assets/216b787b-11ee-47ab-bf9b-558214f35059" />

<img width="1800" height="1125" alt="Screenshot 2025-12-04 at 8 15 32 PM" src="https://github.com/user-attachments/assets/1846e980-1070-41c7-8edb-e53d88147ed8" />

- [ ] I have ensured `make check test` passes
^ just a bunch of `buildtag: +build line is no longer needed (govet) // +build integration` from main repo

## Description for the changelog
Elaborate the Welcome message and add it as an About Dialog opened by the native system "Help" menu.

## A picture of a cute animal (not mandatory but encouraged)
<img width="800" height="1058" alt="image" src="https://github.com/user-attachments/assets/67f62ba8-745c-4c58-96cd-529a619a0219" />
