### PR TITLE
Create a conditional context menu for CL agent-produced file links...

### DIFF
--- a/humanlayer-wui/src/components/TerminalPane.tsx
+++ b/humanlayer-wui/src/components/TerminalPane.tsx
@@ -1,0 +1,375 @@
+import { useEffect, useRef, useCallback, useState } from 'react'
+import { Terminal, ITheme } from 'xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import { WebLinksAddon } from '@xterm/addon-web-links'
+import 'xterm/css/xterm.css'
+
+import { getDaemonUrl } from '@/lib/daemon/http-config'
+import { logger } from '@/lib/logging'
+import { useTheme } from '@/contexts/ThemeContext'
+
+interface TerminalPaneProps {
+  sessionId: string
+  className?: string
+}
+
+type ConnectionStatus = 'connecting' | 'connected' | 'disconnected' | 'error'
+
+/**
+ * Get terminal theme from CSS custom properties
+ * Uses the --terminal-* CSS variables defined in App.css themes
+ */
+function getTerminalTheme(): ITheme {
+  const computedStyle = getComputedStyle(document.documentElement)
+  const getColor = (varName: string, fallback: string) => {
+    const value = computedStyle.getPropertyValue(varName).trim()
+    return value || fallback
+  }
+
+  return {
+    // Core colors from theme
+    background: getColor('--terminal-bg', '#0a0a0a'),
+    foreground: getColor('--terminal-fg', '#fafafa'),
+    cursor: getColor('--terminal-accent', '#22c55e'),
+    cursorAccent: getColor('--terminal-bg', '#0a0a0a'),
+    selectionBackground: getColor('--terminal-selection', 'rgba(255, 255, 255, 0.2)'),
+
+    // Standard ANSI colors (0-7) from theme
+    black: getColor('--terminal-color-0', '#000000'),
+    red: getColor('--terminal-color-1', '#ef4444'),
+    green: getColor('--terminal-color-2', '#22c55e'),
+    yellow: getColor('--terminal-color-3', '#eab308'),
+    blue: getColor('--terminal-color-4', '#3b82f6'),
+    magenta: getColor('--terminal-color-5', '#a855f7'),
+    cyan: getColor('--terminal-color-6', '#06b6d4'),
+    white: getColor('--terminal-color-7', '#f5f5f5'),
+
+    // Bright ANSI colors (8-15) from theme
+    brightBlack: getColor('--terminal-color-8', '#737373'),
+    brightRed: getColor('--terminal-color-9', '#f87171'),
+    brightGreen: getColor('--terminal-color-10', '#4ade80'),
+    brightYellow: getColor('--terminal-color-11', '#facc15'),
+    brightBlue: getColor('--terminal-color-12', '#60a5fa'),
+    brightMagenta: getColor('--terminal-color-13', '#c084fc'),
+    brightCyan: getColor('--terminal-color-14', '#22d3ee'),
+    brightWhite: getColor('--terminal-color-15', '#ffffff'),
+  }
+}
+
+/**
+ * TerminalPane - Interactive terminal component using xterm.js
+ * Connects to the daemon's WebSocket terminal endpoint to provide
+ * a shell session scoped to the session's working directory.
+ */
+export function TerminalPane({ sessionId, className = '' }: TerminalPaneProps) {
+  const terminalRef = useRef<HTMLDivElement>(null)
+  const terminalInstanceRef = useRef<Terminal | null>(null)
+  const fitAddonRef = useRef<FitAddon | null>(null)
+  const wsRef = useRef<WebSocket | null>(null)
+  const onDataDisposableRef = useRef<{ dispose: () => void } | null>(null)
+  const [status, setStatus] = useState<ConnectionStatus>('connecting')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  // Get current theme from context
+  const { theme } = useTheme()
+
+  // Send resize message to server
+  const sendResize = useCallback(() => {
+    const terminal = terminalInstanceRef.current
+    const ws = wsRef.current
+
+    if (terminal && ws && ws.readyState === WebSocket.OPEN) {
+      const resizeMessage = JSON.stringify({
+        type: 'resize',
+        cols: terminal.cols,
+        rows: terminal.rows,
+      })
+      ws.send(resizeMessage)
+    }
+  }, [])
+
+  // Handle window resize
+  const handleResize = useCallback(() => {
+    const fitAddon = fitAddonRef.current
+
+    if (fitAddon) {
+      try {
+        fitAddon.fit()
+        sendResize()
+      } catch (e) {
+        // Ignore fit errors when terminal is not visible
+        logger.debug('Terminal fit error (likely not visible):', e)
+      }
+    }
+  }, [sendResize])
+
+  // Initialize terminal and WebSocket
+  useEffect(() => {
+    if (!terminalRef.current || !sessionId) {
+      return
+    }
+
+    // Create terminal with theme from CSS variables
+    const terminal = new Terminal({
+      cursorBlink: true,
+      cursorStyle: 'block',
+      fontSize: 13,
+      fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+      theme: getTerminalTheme(),
+      allowProposedApi: true,
+    })
+
+    terminalInstanceRef.current = terminal
+
+    // Add fit addon
+    const fitAddon = new FitAddon()
+    fitAddonRef.current = fitAddon
+    terminal.loadAddon(fitAddon)
+
+    // Add web links addon
+    const webLinksAddon = new WebLinksAddon()
+    terminal.loadAddon(webLinksAddon)
+
+    // Open terminal in the container
+    terminal.open(terminalRef.current)
+
+    // Initial fit
+    setTimeout(() => {
+      fitAddon.fit()
+    }, 0)
+
+    // Connect to WebSocket
+    const connect = async () => {
+      try {
+        setStatus('connecting')
+        setErrorMessage(null)
+
+        const baseUrl = await getDaemonUrl()
+        // Convert http:// to ws:// or https:// to wss://
+        const wsUrl = baseUrl.replace(/^http/, 'ws')
+        const url = `${wsUrl}/api/v1/terminal?sessionId=${encodeURIComponent(sessionId)}`
+
+        logger.log('Connecting to terminal WebSocket:', url)
+
+        const ws = new WebSocket(url)
+        ws.binaryType = 'arraybuffer'
+        wsRef.current = ws
+
+        ws.onopen = () => {
+          logger.log('Terminal WebSocket connected')
+          setStatus('connected')
+
+          // Send initial resize
+          sendResize()
+        }
+
+        ws.onmessage = event => {
+          if (event.data instanceof ArrayBuffer) {
+            // Binary data from PTY
+            const data = new Uint8Array(event.data)
+            terminal.write(data)
+          } else if (typeof event.data === 'string') {
+            // Text message (shouldn't happen with our protocol, but handle it)
+            terminal.write(event.data)
+          }
+        }
+
+        ws.onerror = event => {
+          logger.error('Terminal WebSocket error:', event)
+          setStatus('error')
+          setErrorMessage('Connection error')
+        }
+
+        ws.onclose = event => {
+          logger.log('Terminal WebSocket closed:', event.code, event.reason)
+          setStatus('disconnected')
+          wsRef.current = null
+
+          // Show disconnection message in terminal
+          terminal.write('\r\n\x1b[33m[Terminal disconnected]\x1b[0m\r\n')
+        }
+
+        // Dispose of any existing onData listener before adding a new one
+        if (onDataDisposableRef.current) {
+          onDataDisposableRef.current.dispose()
+        }
+
+        // Forward terminal input to WebSocket
+        onDataDisposableRef.current = terminal.onData(data => {
+          if (ws.readyState === WebSocket.OPEN) {
+            // Send as binary
+            const encoder = new TextEncoder()
+            ws.send(encoder.encode(data))
+          }
+        })
+      } catch (error) {
+        logger.error('Failed to connect to terminal:', error)
+        setStatus('error')
+        setErrorMessage(error instanceof Error ? error.message : 'Failed to connect')
+      }
+    }
+
+    connect()
+
+    // Set up resize observer
+    const resizeObserver = new ResizeObserver(() => {
+      handleResize()
+    })
+    resizeObserver.observe(terminalRef.current)
+
+    // Also listen to window resize
+    window.addEventListener('resize', handleResize)
+
+    // Cleanup
+    return () => {
+      window.removeEventListener('resize', handleResize)
+      resizeObserver.disconnect()
+
+      // Dispose of onData listener
+      if (onDataDisposableRef.current) {
+        onDataDisposableRef.current.dispose()
+        onDataDisposableRef.current = null
+      }
+
+      if (wsRef.current) {
+        wsRef.current.close()
+        wsRef.current = null
+      }
+
+      if (terminalInstanceRef.current) {
+        terminalInstanceRef.current.dispose()
+        terminalInstanceRef.current = null
+      }
+
+      fitAddonRef.current = null
+    }
+  }, [sessionId, handleResize, sendResize])
+
+  // Update terminal theme when app theme changes
+  useEffect(() => {
+    const terminal = terminalInstanceRef.current
+    if (!terminal) return
+
+    // Small delay to ensure CSS variables are updated
+    const timeoutId = setTimeout(() => {
+      terminal.options.theme = getTerminalTheme()
+    }, 20)
+
+    return () => clearTimeout(timeoutId)
+  }, [theme])
+
+  // Reconnect handler
+  const handleReconnect = useCallback(async () => {
+    if (wsRef.current) {
+      wsRef.current.close()
+    }
+
+    // Clear terminal
+    if (terminalInstanceRef.current) {
+      terminalInstanceRef.current.clear()
+      terminalInstanceRef.current.write('\x1b[33m[Reconnecting...]\x1b[0m\r\n')
+    }
+
+    // Re-run the connection logic by re-mounting
+    // This is handled by React re-render when status changes
+    setStatus('connecting')
+
+    try {
+      const baseUrl = await getDaemonUrl()
+      const wsUrl = baseUrl.replace(/^http/, 'ws')
+      const url = `${wsUrl}/api/v1/terminal?sessionId=${encodeURIComponent(sessionId)}`
+
+      const ws = new WebSocket(url)
+      ws.binaryType = 'arraybuffer'
+      wsRef.current = ws
+
+      ws.onopen = () => {
+        setStatus('connected')
+        sendResize()
+        if (terminalInstanceRef.current) {
+          terminalInstanceRef.current.write('\x1b[32m[Connected]\x1b[0m\r\n')
+        }
+      }
+
+      ws.onmessage = event => {
+        if (event.data instanceof ArrayBuffer && terminalInstanceRef.current) {
+          const data = new Uint8Array(event.data)
+          terminalInstanceRef.current.write(data)
+        }
+      }
+
+      ws.onerror = () => {
+        setStatus('error')
+        setErrorMessage('Connection error')
+      }
+
+      ws.onclose = () => {
+        setStatus('disconnected')
+        wsRef.current = null
+        if (terminalInstanceRef.current) {
+          terminalInstanceRef.current.write('\r\n\x1b[33m[Terminal disconnected]\x1b[0m\r\n')
+        }
+      }
+
+      // Dispose of any existing onData listener before adding a new one
+      if (onDataDisposableRef.current) {
+        onDataDisposableRef.current.dispose()
+      }
+
+      if (terminalInstanceRef.current) {
+        onDataDisposableRef.current = terminalInstanceRef.current.onData(data => {
+          if (ws.readyState === WebSocket.OPEN) {
+            const encoder = new TextEncoder()
+            ws.send(encoder.encode(data))
+          }
+        })
+      }
+    } catch (error) {
+      setStatus('error')
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to reconnect')
+    }
+  }, [sessionId, sendResize])
+
+  return (
+    <div className={`relative flex flex-col h-full ${className}`}>
+      {/* Status bar */}
+      <div className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-secondary/30">
+        <div className="flex items-center gap-2 font-mono text-xs uppercase tracking-wider text-muted-foreground">
+          <span>Terminal</span>
+          <span
+            className={`w-1.5 h-1.5 rounded-full ${
+              status === 'connected'
+                ? 'bg-[--terminal-success]'
+                : status === 'connecting'
+                  ? 'bg-yellow-500 animate-pulse'
+                  : 'bg-[--terminal-error]'
+            }`}
+          />
+          <span className="text-[10px]">
+            {status === 'connected' && 'Connected'}
+            {status === 'connecting' && 'Connecting...'}
+            {status === 'disconnected' && 'Disconnected'}
+            {status === 'error' && (errorMessage || 'Error')}
+          </span>
+        </div>
+        {(status === 'disconnected' || status === 'error') && (
+          <button
+            onClick={handleReconnect}
+            className="px-2 py-0.5 text-xs font-mono border border-border bg-background text-foreground hover:bg-accent/10 transition-colors"
+          >
+            Reconnect
+          </button>
+        )}
+      </div>
+
+      {/* Terminal container */}
+      <div
+        ref={terminalRef}
+        className="flex-1 overflow-hidden bg-background"
+        style={{ minHeight: 0 }}
+      />
+    </div>
+  )
+}
+
+export default TerminalPane

--- a/humanlayer-wui/src/components/internal/SessionDetail/ResearchPlanToken.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/ResearchPlanToken.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { FileText } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+interface ResearchPlanTokenProps {
+  path: string
+  workingDir?: string
+}
+
+export function ResearchPlanToken({ path, workingDir }: ResearchPlanTokenProps) {
+  const navigate = useNavigate()
+  const [open, setOpen] = React.useState(false)
+
+  // Determine if this is a research path or a plan path
+  const isResearchPath = path.includes('thoughts/shared/research/')
+  const isPlanPath = path.includes('thoughts/shared/plans/')
+
+  // Use /create_plan for research paths, /implement_plan for plan paths
+  const commandPrefix = isResearchPath
+    ? '/create_plan'
+    : isPlanPath
+      ? '/implement_plan'
+      : '/create_plan'
+  const menuLabel = isResearchPath ? 'Create Plan' : isPlanPath ? 'Implement Plan' : 'Create Plan'
+
+  const handleAction = React.useCallback(() => {
+    const fileName = path.split('/').pop() || path
+    const titlePrefix = isResearchPath ? 'research/' : isPlanPath ? 'plans/' : ''
+    navigate('/sessions/draft', {
+      state: {
+        prompt: `${commandPrefix} ${path}`,
+        title: `${titlePrefix}${fileName}`,
+        workingDir: workingDir || undefined,
+      },
+    })
+    setOpen(false)
+  }, [navigate, path, workingDir, commandPrefix, isResearchPath, isPlanPath])
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <span
+          role="button"
+          tabIndex={0}
+          className="inline-flex items-center gap-1 group cursor-pointer"
+          onContextMenu={event => {
+            event.preventDefault()
+            setOpen(true)
+          }}
+        >
+          <code className="px-2 py-0.5 rounded font-mono text-xs bg-[var(--terminal-bg-alt)] text-[var(--terminal-accent)] border border-[var(--terminal-border)] tracking-tight shadow-sm mr-1 align-middle wrap-anywhere box-decoration-clone">
+            {path}
+          </code>
+          <button
+            type="button"
+            className="p-0.5 rounded opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-foreground"
+            onClick={event => {
+              event.preventDefault()
+              setOpen(true)
+            }}
+            aria-label={isPlanPath ? 'Open plan menu' : 'Open research plan menu'}
+          >
+            <FileText className="h-3.5 w-3.5" />
+          </button>
+        </span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" sideOffset={4}>
+        <DropdownMenuItem
+          onSelect={event => {
+            event.preventDefault()
+            handleAction()
+          }}
+        >
+          <FileText className="h-4 w-4" />
+          {menuLabel}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/humanlayer-wui/src/pages/DraftSessionPage.tsx
+++ b/humanlayer-wui/src/pages/DraftSessionPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import { useStore } from '@/AppStore'
 import { DraftLauncherForm } from '@/components/internal/SessionDetail/components/DraftLauncherForm'
 import { usePostHogTracking } from '@/hooks/usePostHogTracking'
@@ -7,10 +7,27 @@ import { daemonClient } from '@/lib/daemon'
 import { type Session, SessionStatus } from '@/lib/daemon/types'
 import { POSTHOG_EVENTS } from '@/lib/telemetry/events'
 
+// Type for location state passed via navigate()
+interface DraftLocationState {
+  prompt?: string
+  workingDir?: string
+  title?: string
+}
+
 export function DraftSessionPage() {
   const [searchParams] = useSearchParams()
+  const location = useLocation()
   const navigate = useNavigate()
+
+  // Read draft ID from URL params (for resuming existing drafts)
   const draftId = searchParams.get('id')
+
+  // Read initial values from location.state (passed via navigate())
+  const locationState = location.state as DraftLocationState | null
+  const initialPrompt = locationState?.prompt?.trim()
+  const initialWorkingDir = locationState?.workingDir?.trim()
+  const initialTitle = locationState?.title?.trim()
+
   const { trackEvent } = usePostHogTracking()
 
   const [draftSession, setDraftSession] = useState<Session | null>(null)
@@ -126,6 +143,9 @@ export function DraftSessionPage() {
       session={draftSession}
       key={draftSession?.id} // this avoids us needing a useEffect when the session changes
       onSessionUpdated={handleSessionUpdated}
+      initialPrompt={initialPrompt}
+      initialWorkingDir={initialWorkingDir}
+      initialTitle={initialTitle}
     />
   )
 }


### PR DESCRIPTION
...for thoughts/shared/research/ and /plans/, to automatically open new sessions with pre-filled content.

## What problem(s) was I solving?
Manually copying produced file path -> opening new session -> typing title -> typing `/create_plan` or `/implement_plan` -> pasting file path

## What user-facing changes did I ship?
Context menu when clicking on 

## How I implemented it
Cursor Opus 4.5 Plan

## How to verify it
Click on a `/thoughts/shared/research/` block

<img width="734" height="208" alt="Screenshot 2025-12-04 at 7 51 48 PM" src="https://github.com/user-attachments/assets/14a51e16-8009-40d8-a0d3-58e02ecf6e28" />

<img width="794" height="433" alt="Screenshot 2025-12-04 at 7 51 52 PM" src="https://github.com/user-attachments/assets/fdfa3561-3eed-4d99-8bb3-4051dca62247" />

Click on a `thoughts/shared/plans` block

<img width="529" height="195" alt="Screenshot 2025-12-04 at 8 02 43 PM" src="https://github.com/user-attachments/assets/62e72485-2826-4099-8aa5-16d08b5dcff2" />

<img width="708" height="406" alt="Screenshot 2025-12-04 at 8 02 48 PM" src="https://github.com/user-attachments/assets/43ce7a76-293b-4932-b5d6-3508b1909655" />

(ignore the Haiku selection, I do not use it for plans xD)

- [ ] I have ensured `make check test` passes
^ just a bunch of `buildtag: +build line is no longer needed (govet) // +build integration` from main repo

## Description for the changelog
Create a conditional context menu for CL agent-produced file links for thoughts/shared/research/ and /plans/, to automatically open new sessions with pre-filled content.

## A picture of a cute animal (not mandatory but encouraged)
<img width="1080" height="1350" alt="image" src="https://github.com/user-attachments/assets/b79ae54a-61b8-43ed-822f-dc505eb93ddd" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a context menu for file links in specific directories to open new sessions with pre-filled content, updating several components to support this functionality.
> 
>   - **Behavior**:
>     - Adds a context menu for file links in `/thoughts/shared/research/` and `/thoughts/shared/plans/` in `MarkdownRenderer.tsx`.
>     - `ResearchPlanToken.tsx` handles the context menu actions, navigating to a draft session with pre-filled content.
>   - **Components**:
>     - `DraftLauncherForm.tsx` and `DraftLauncherInput.tsx` updated to support initial prompt, title, and working directory from navigation state.
>     - `DraftSessionPage.tsx` reads initial values from navigation state and manages draft session loading.
>   - **Misc**:
>     - Adds `TerminalPane.tsx` for interactive terminal sessions, though not directly related to the context menu feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 94a9ff15183ef193fcf34c52a5c8135039db28aa. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->