### PR TITLE
Create new themes Starscape Light and Starscape Dark

### DIFF
--- a/humanlayer-wui/src/App.css
+++ b/humanlayer-wui/src/App.css
@@ -667,6 +667,88 @@
   --terminal-color-15: #e5e5e5; /* Bright White */
 }
 
+/* Starscape Dark - Brand-aligned cosmic dark */
+[data-theme='starscape-dark'] {
+  /* Core background/foreground colors */
+  --terminal-bg: hsl(222, 84%, 5%); /* Deep space */
+  --terminal-bg-alt: hsl(222, 84%, 8%); /* Elevated surface */
+  --terminal-fg: hsl(210, 40%, 98%); /* Primary text */
+  --terminal-fg-dim: hsl(215, 20%, 65%); /* Muted text */
+
+  /* Accent and UI colors */
+  --terminal-accent: #a855f7; /* Cosmic purple */
+  --terminal-accent-dim: rgba(168, 85, 247, 0.25); /* Soft glow */
+  --terminal-accent-alt: #06b6d4; /* Cosmic cyan */
+  --terminal-border: rgba(255, 255, 255, 0.12); /* Glass border */
+
+  /* Status colors */
+  --terminal-success: #22c55e; /* Emerald */
+  --terminal-warning: #eab308; /* Yellow highlight */
+  --terminal-error: #ec4899; /* Cosmic pink */
+  --terminal-selection: rgba(168, 85, 247, 0.2);
+
+  /* Terminal ANSI colors - Starscape palette */
+  --terminal-color-0: #0b1221; /* Black */
+  --terminal-color-1: #ec4899; /* Red/Pink */
+  --terminal-color-2: #22c55e; /* Green */
+  --terminal-color-3: #eab308; /* Yellow */
+  --terminal-color-4: #8b5cf6; /* Blue/Violet */
+  --terminal-color-5: #f472b6; /* Magenta/Pink */
+  --terminal-color-6: #06b6d4; /* Cyan */
+  --terminal-color-7: #e2e8f0; /* White */
+
+  /* Bright colors */
+  --terminal-color-8: #1f2937; /* Bright Black */
+  --terminal-color-9: #f472b6; /* Bright Red/Pink */
+  --terminal-color-10: #4ade80; /* Bright Green */
+  --terminal-color-11: #facc15; /* Bright Yellow */
+  --terminal-color-12: #60a5fa; /* Bright Blue */
+  --terminal-color-13: #c084fc; /* Bright Magenta */
+  --terminal-color-14: #22d3ee; /* Bright Cyan */
+  --terminal-color-15: #ffffff; /* Bright White */
+}
+
+/* Starscape Light - Brand-aligned light */
+[data-theme='starscape-light'] {
+  /* Core background/foreground colors */
+  --terminal-bg: #f8fafc; /* Soft light */
+  --terminal-bg-alt: #eef2ff; /* Lavender wash */
+  --terminal-fg: #0f172a; /* Primary text */
+  --terminal-fg-dim: #475569; /* Muted text */
+
+  /* Accent and UI colors */
+  --terminal-accent: #8b5cf6; /* Cosmic violet */
+  --terminal-accent-dim: rgba(139, 92, 246, 0.25);
+  --terminal-accent-alt: #06b6d4; /* Cosmic cyan */
+  --terminal-border: #cbd5e1; /* Subtle border */
+
+  /* Status colors */
+  --terminal-success: #22c55e; /* Emerald */
+  --terminal-warning: #eab308; /* Yellow highlight */
+  --terminal-error: #ec4899; /* Cosmic pink */
+  --terminal-selection: #eae7ff;
+
+  /* Terminal ANSI colors - Starscape palette (light) */
+  --terminal-color-0: #e2e8f0; /* Black */
+  --terminal-color-1: #ec4899; /* Red/Pink */
+  --terminal-color-2: #22c55e; /* Green */
+  --terminal-color-3: #eab308; /* Yellow */
+  --terminal-color-4: #6366f1; /* Blue/Violet */
+  --terminal-color-5: #a855f7; /* Magenta/Purple */
+  --terminal-color-6: #06b6d4; /* Cyan */
+  --terminal-color-7: #0f172a; /* White (dark text) */
+
+  /* Bright colors */
+  --terminal-color-8: #cbd5e1; /* Bright Black */
+  --terminal-color-9: #f472b6; /* Bright Red/Pink */
+  --terminal-color-10: #4ade80; /* Bright Green */
+  --terminal-color-11: #facc15; /* Bright Yellow */
+  --terminal-color-12: #60a5fa; /* Bright Blue */
+  --terminal-color-13: #c084fc; /* Bright Magenta */
+  --terminal-color-14: #22d3ee; /* Bright Cyan */
+  --terminal-color-15: #111827; /* Bright White (deep text) */
+}
+
 /* L33t - Classic hacker terminal theme */
 [data-theme='l33t'] {
   /* Core background/foreground colors */

--- a/humanlayer-wui/src/components/ThemeSelector.tsx
+++ b/humanlayer-wui/src/components/ThemeSelector.tsx
@@ -16,6 +16,7 @@ import {
   CloudLightning,
   Heart,
   Terminal,
+  Sparkles,
 } from 'lucide-react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -27,6 +28,8 @@ import { useHotkeyUnicodeChars } from '../hooks/useHotkeyUnicodeChars'
 const themes: { value: Theme; label: string; icon: React.ComponentType<{ className?: string }> }[] = [
   { value: 'solarized-dark', label: 'Solarized Dark', icon: Moon },
   { value: 'solarized-light', label: 'Solarized Light', icon: Sun },
+  { value: 'starscape-dark', label: 'Starscape Dark', icon: Sparkles },
+  { value: 'starscape-light', label: 'Starscape Light', icon: Sun },
   { value: 'cappuccino', label: 'Cappuccino', icon: Coffee },
   { value: 'catppuccin', label: 'Catppuccin', icon: Cat },
   { value: 'high-contrast', label: 'High Contrast', icon: ScanEye },

--- a/humanlayer-wui/src/contexts/ThemeContext.tsx
+++ b/humanlayer-wui/src/contexts/ThemeContext.tsx
@@ -21,6 +21,8 @@ export type Theme =
   | 'bubblegum'
   | 'l33t'
   | 'vesper'
+  | 'starscape-dark'
+  | 'starscape-light'
 
 interface ThemeContextType {
   theme: Theme

--- a/humanlayer-wui/src/stores/demo/slices/themeSlice.ts
+++ b/humanlayer-wui/src/stores/demo/slices/themeSlice.ts
@@ -16,13 +16,15 @@ export interface ThemeSlice {
 const AVAILABLE_THEMES: Theme[] = [
   'solarized-dark',
   'solarized-light',
+  'starscape-dark',
+  'starscape-light',
   'catppuccin',
   'framer-dark',
   'gruvbox-dark',
   'high-contrast',
 ]
 
-const LIGHT_THEMES: Theme[] = ['solarized-light', 'framer-light', 'gruvbox-light']
+const LIGHT_THEMES: Theme[] = ['solarized-light', 'starscape-light', 'framer-light', 'gruvbox-light']
 
 export const createThemeSlice: StateCreator<ThemeSlice, [], [], ThemeSlice> = (set, get) => ({
   theme: 'solarized-dark',


### PR DESCRIPTION
## Description for the changelog
Added two new themes: Starscape Light and Starscape Dark

<img width="205" height="68" alt="Screenshot 2025-12-06 at 7 56 22 PM" src="https://github.com/user-attachments/assets/0c89ccaa-aef0-4e83-b6f7-776a86e80af2" />

<img width="1800" height="1127" alt="Screenshot 2025-12-06 at 7 56 09 PM" src="https://github.com/user-attachments/assets/b559cf92-7db4-4a27-b8c4-ccdbe8e9b052" />

<img width="1800" height="1126" alt="Screenshot 2025-12-06 at 7 55 59 PM" src="https://github.com/user-attachments/assets/7c3d9dc7-da13-480b-bd9f-32c4f5ebe7ba" />

## A picture of a cute animal (not mandatory but encouraged)
<img width="1280" height="1834" alt="image" src="https://github.com/user-attachments/assets/574e7353-bef0-45e0-9afb-6019c306695e" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Starscape Light and Starscape Dark themes to the application with full integration into theme management.
> 
>   - **Themes**:
>     - Add `starscape-dark` and `starscape-light` themes to `App.css` with specific color variables for background, foreground, accents, and ANSI colors.
>   - **Theme Management**:
>     - Update `ThemeSelector.tsx` to include `starscape-dark` and `starscape-light` in the theme options.
>     - Add `starscape-dark` and `starscape-light` to `Theme` type in `ThemeContext.tsx`.
>     - Include `starscape-dark` and `starscape-light` in `AVAILABLE_THEMES` and `LIGHT_THEMES` in `themeSlice.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for c2c5d61c3aaf1fc884a83a0eb7944eb1918a3ac7. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->