### PR TITLE
feat: add humanlayer opencode init command (fixes #904)

### DIFF
--- a/.claude/commands/research_codebase.md
+++ b/.claude/commands/research_codebase.md
@@ -205,6 +205,7 @@ Then wait for the user's research query.
     - `thoughts/searchable/global/shared/templates.md` → `thoughts/global/shared/templates.md`
   - NEVER change allison/ to shared/ or vice versa - preserve the exact directory structure
   - This ensures paths are correct for editing and navigation
+  - Ensure research documents are created inside the `thoughts/shared/research/` folder
 - **Frontmatter consistency**:
   - Always include frontmatter at the beginning of research documents
   - Keep frontmatter fields consistent across all research documents

--- a/hlyr/src/commands/opencode.ts
+++ b/hlyr/src/commands/opencode.ts
@@ -1,0 +1,20 @@
+import { Command } from 'commander'
+import { opencodeInitCommand } from './opencode/init.js'
+
+export function opencodeCommand(program: Command): void {
+  const opencode = program.command('opencode').description('Manage OpenCode configuration')
+
+  opencode
+    .command('init')
+    .description('Initialize OpenCode configuration in current directory')
+    .option('--force', 'Force overwrite of existing .opencode directory')
+    .option('--all', 'Copy all files without prompting')
+    .option('--model <model>', 'Default model: haiku, sonnet, or opus (default: opus)')
+    // Accept but ignore thinking flags for CLI consistency
+    .option('--always-thinking', '(Ignored - for CLI compatibility)')
+    .option('--no-always-thinking', '(Ignored - for CLI compatibility)')
+    .option('--max-thinking-tokens <number>', '(Ignored - for CLI compatibility)', value =>
+      parseInt(value, 10),
+    )
+    .action(opencodeInitCommand)
+}

--- a/hlyr/src/commands/opencode.ts
+++ b/hlyr/src/commands/opencode.ts
@@ -2,19 +2,16 @@ import { Command } from 'commander'
 import { opencodeInitCommand } from './opencode/init.js'
 
 export function opencodeCommand(program: Command): void {
-  const opencode = program.command('opencode').description('Manage OpenCode configuration')
+	const opencode = program.command('opencode').description('Manage OpenCode configuration')
 
-  opencode
-    .command('init')
-    .description('Initialize OpenCode configuration in current directory')
-    .option('--force', 'Force overwrite of existing .opencode directory')
-    .option('--all', 'Copy all files without prompting')
-    .option('--model <model>', 'Default model: haiku, sonnet, or opus (default: opus)')
-    // Accept but ignore thinking flags for CLI consistency
-    .option('--always-thinking', '(Ignored - for CLI compatibility)')
-    .option('--no-always-thinking', '(Ignored - for CLI compatibility)')
-    .option('--max-thinking-tokens <number>', '(Ignored - for CLI compatibility)', value =>
-      parseInt(value, 10),
-    )
-    .action(opencodeInitCommand)
+	opencode
+		.command('init')
+		.description('Initialize OpenCode configuration in current directory')
+		.option('--force', 'Force overwrite of existing .opencode directory')
+		.option('--all', 'Copy all files without prompting')
+		// Accept but ignore thinking flags for CLI consistency
+		.option('--always-thinking', '(Ignored - for CLI compatibility)')
+		.option('--no-always-thinking', '(Ignored - for CLI compatibility)')
+		.option('--max-thinking-tokens <number>', '(Ignored - for CLI compatibility)', (value) => parseInt(value, 10))
+		.action(opencodeInitCommand)
 }

--- a/hlyr/src/commands/opencode/init.ts
+++ b/hlyr/src/commands/opencode/init.ts
@@ -1,0 +1,426 @@
+import fs from 'fs'
+import path from 'path'
+import chalk from 'chalk'
+import * as p from '@clack/prompts'
+import { fileURLToPath } from 'url'
+import { dirname } from 'path'
+import {
+  transformCommandFile,
+  transformAgentFile,
+  transformSettings,
+  generateAgentsMd,
+  type ModelType,
+} from './transform.js'
+
+// Get the directory of this module
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+interface InitOptions {
+  force?: boolean
+  all?: boolean
+  alwaysThinking?: boolean
+  maxThinkingTokens?: number
+  model?: ModelType
+}
+
+function ensureGitignoreEntry(targetDir: string, entry: string): void {
+  const gitignorePath = path.join(targetDir, '.gitignore')
+
+  // Read existing .gitignore or create empty
+  let gitignoreContent = ''
+  if (fs.existsSync(gitignorePath)) {
+    gitignoreContent = fs.readFileSync(gitignorePath, 'utf8')
+  }
+
+  // Check if entry already exists
+  const lines = gitignoreContent.split('\n')
+  if (lines.some(line => line.trim() === entry)) {
+    return // Already exists
+  }
+
+  // Add entry with section comment
+  const newContent =
+    gitignoreContent +
+    (gitignoreContent && !gitignoreContent.endsWith('\n') ? '\n' : '') +
+    '\n# OpenCode local settings\n' +
+    entry +
+    '\n'
+
+  fs.writeFileSync(gitignorePath, newContent)
+}
+
+export async function opencodeInitCommand(options: InitOptions): Promise<void> {
+  try {
+    p.intro(chalk.blue('Initialize OpenCode Configuration'))
+
+    // Validate model option if provided
+    if (options.model && !['haiku', 'sonnet', 'opus'].includes(options.model)) {
+      p.log.error(`Invalid model: ${options.model}. Must be one of: haiku, sonnet, opus`)
+      process.exit(1)
+    }
+
+    // Check if running in interactive terminal
+    if (!process.stdin.isTTY && !options.all) {
+      p.log.error('Not running in interactive terminal.')
+      p.log.info('Use --all flag to copy all files without prompting.')
+      process.exit(1)
+    }
+
+    const targetDir = process.cwd()
+    const opencodeTargetDir = path.join(targetDir, '.opencode')
+
+    // Determine source location
+    // Try multiple possible locations for the .claude directory
+    const possiblePaths = [
+      // When installed via npm: package root is one level up from dist
+      path.resolve(__dirname, '..', '..', '.claude'),
+      // When running from repo: repo root is two levels up from dist
+      path.resolve(__dirname, '..', '..', '..', '.claude'),
+    ]
+
+    let sourceClaudeDir: string | null = null
+    for (const candidatePath of possiblePaths) {
+      if (fs.existsSync(candidatePath)) {
+        sourceClaudeDir = candidatePath
+        break
+      }
+    }
+
+    // Verify source directory exists
+    if (!sourceClaudeDir) {
+      p.log.error('Source .claude directory not found in expected locations')
+      p.log.info('Searched paths:')
+      possiblePaths.forEach(candidatePath => {
+        p.log.info(`  - ${candidatePath}`)
+      })
+      p.log.info('Are you running from the humanlayer repository or npm package?')
+      process.exit(1)
+    }
+
+    // Check if .opencode already exists
+    if (fs.existsSync(opencodeTargetDir) && !options.force) {
+      const overwrite = await p.confirm({
+        message: '.opencode directory already exists. Overwrite?',
+        initialValue: false,
+      })
+
+      if (p.isCancel(overwrite) || !overwrite) {
+        p.cancel('Operation cancelled.')
+        process.exit(0)
+      }
+    }
+
+    let selectedCategories: string[]
+
+    if (options.all) {
+      // Don't include agentsmd by default in --all mode
+      selectedCategories = ['commands', 'agents', 'config', 'scripts']
+    } else {
+      // Interactive selection
+      const selection = await p.multiselect({
+        message: 'What would you like to copy?',
+        options: [
+          {
+            value: 'commands',
+            label: 'Commands',
+            hint: '27 workflow commands (planning, CI, research, etc.)',
+          },
+          {
+            value: 'agents',
+            label: 'Agents',
+            hint: '6 specialized sub-agents for code analysis',
+          },
+          {
+            value: 'config',
+            label: 'Config',
+            hint: 'Project opencode.json configuration',
+          },
+          {
+            value: 'scripts',
+            label: 'Scripts',
+            hint: 'Required hack scripts (spec_metadata.sh, create_worktree.sh)',
+          },
+          {
+            value: 'agentsmd',
+            label: 'AGENTS.md',
+            hint: 'Generate AGENTS.md with project context (optional, can be slow)',
+          },
+        ],
+        initialValues: ['commands', 'agents', 'config', 'scripts'],
+        required: false,
+      })
+
+      if (p.isCancel(selection)) {
+        p.cancel('Operation cancelled.')
+        process.exit(0)
+      }
+
+      selectedCategories = selection as string[]
+
+      if (selectedCategories.length === 0) {
+        p.cancel('No items selected.')
+        process.exit(0)
+      }
+    }
+
+    // Create .opencode directory
+    fs.mkdirSync(opencodeTargetDir, { recursive: true })
+
+    let filesCopied = 0
+    let filesSkipped = 0
+
+    // Wizard-style file selection for each category
+    const filesToCopyByCategory: Record<string, string[]> = {}
+
+    // If in interactive mode, prompt for file selection per category
+    if (!options.all) {
+      // Commands file selection (if selected)
+      if (selectedCategories.includes('commands')) {
+        const sourceDir = path.join(sourceClaudeDir, 'commands')
+        if (fs.existsSync(sourceDir)) {
+          const allFiles = fs.readdirSync(sourceDir)
+          const fileSelection = await p.multiselect({
+            message: 'Select command files to copy:',
+            options: allFiles.map(file => ({
+              value: file,
+              label: file,
+            })),
+            initialValues: allFiles,
+            required: false,
+          })
+
+          if (p.isCancel(fileSelection)) {
+            p.cancel('Operation cancelled.')
+            process.exit(0)
+          }
+
+          filesToCopyByCategory['commands'] = fileSelection as string[]
+
+          if (filesToCopyByCategory['commands'].length === 0) {
+            filesSkipped += allFiles.length
+          }
+        }
+      }
+
+      // Agents file selection (if selected)
+      if (selectedCategories.includes('agents')) {
+        const sourceDir = path.join(sourceClaudeDir, 'agents')
+        if (fs.existsSync(sourceDir)) {
+          const allFiles = fs.readdirSync(sourceDir)
+          const fileSelection = await p.multiselect({
+            message: 'Select agent files to copy:',
+            options: allFiles.map(file => ({
+              value: file,
+              label: file,
+            })),
+            initialValues: allFiles,
+            required: false,
+          })
+
+          if (p.isCancel(fileSelection)) {
+            p.cancel('Operation cancelled.')
+            process.exit(0)
+          }
+
+          filesToCopyByCategory['agents'] = fileSelection as string[]
+
+          if (filesToCopyByCategory['agents'].length === 0) {
+            filesSkipped += allFiles.length
+          }
+        }
+      }
+    }
+
+    // Configure model
+    let model = options.model
+
+    // Prompt for model if in interactive mode and not provided via flags
+    if (!options.all && selectedCategories.includes('config')) {
+      if (model === undefined) {
+        const modelPrompt = await p.select({
+          message: 'Select default model:',
+          options: [
+            { value: 'opus' as ModelType, label: 'Opus (most capable)' },
+            { value: 'sonnet' as ModelType, label: 'Sonnet (balanced)' },
+            { value: 'haiku' as ModelType, label: 'Haiku (fastest)' },
+          ],
+          initialValue: 'opus' as ModelType,
+        })
+
+        if (p.isCancel(modelPrompt)) {
+          p.cancel('Operation cancelled.')
+          process.exit(0)
+        }
+
+        model = modelPrompt as ModelType
+      }
+    } else if (selectedCategories.includes('config')) {
+      // Non-interactive mode: use default if not provided
+      if (model === undefined) {
+        model = 'opus'
+      }
+    }
+
+    // Copy selected categories
+    for (const category of selectedCategories) {
+      if (category === 'commands') {
+        const sourceDir = path.join(sourceClaudeDir, 'commands')
+        const targetCategoryDir = path.join(opencodeTargetDir, 'command') // SINGULAR
+
+        if (!fs.existsSync(sourceDir)) {
+          p.log.warn(`commands directory not found in source, skipping`)
+          continue
+        }
+
+        // Get all files in category
+        const allFiles = fs.readdirSync(sourceDir)
+
+        // Determine which files to copy
+        let filesToCopy = allFiles
+        if (!options.all && filesToCopyByCategory['commands']) {
+          filesToCopy = filesToCopyByCategory['commands']
+        }
+
+        if (filesToCopy.length === 0) {
+          continue
+        }
+
+        // Copy and transform files
+        fs.mkdirSync(targetCategoryDir, { recursive: true })
+
+        for (const file of filesToCopy) {
+          const sourcePath = path.join(sourceDir, file)
+          const targetPath = path.join(targetCategoryDir, file)
+
+          const sourceContent = fs.readFileSync(sourcePath, 'utf8')
+          const transformedContent = transformCommandFile(sourceContent)
+          fs.writeFileSync(targetPath, transformedContent)
+          filesCopied++
+        }
+
+        filesSkipped += allFiles.length - filesToCopy.length
+        p.log.success(`Copied ${filesToCopy.length} command file(s)`)
+      } else if (category === 'agents') {
+        const sourceDir = path.join(sourceClaudeDir, 'agents')
+        const targetCategoryDir = path.join(opencodeTargetDir, 'agent') // SINGULAR
+
+        if (!fs.existsSync(sourceDir)) {
+          p.log.warn(`agents directory not found in source, skipping`)
+          continue
+        }
+
+        // Get all files in category
+        const allFiles = fs.readdirSync(sourceDir)
+
+        // Determine which files to copy
+        let filesToCopy = allFiles
+        if (!options.all && filesToCopyByCategory['agents']) {
+          filesToCopy = filesToCopyByCategory['agents']
+        }
+
+        if (filesToCopy.length === 0) {
+          continue
+        }
+
+        // Copy and transform files
+        fs.mkdirSync(targetCategoryDir, { recursive: true })
+
+        for (const file of filesToCopy) {
+          const sourcePath = path.join(sourceDir, file)
+          const targetPath = path.join(targetCategoryDir, file)
+
+          const sourceContent = fs.readFileSync(sourcePath, 'utf8')
+          const transformedContent = transformAgentFile(sourceContent)
+          fs.writeFileSync(targetPath, transformedContent)
+          filesCopied++
+        }
+
+        filesSkipped += allFiles.length - filesToCopy.length
+        p.log.success(`Copied ${filesToCopy.length} agent file(s)`)
+      } else if (category === 'scripts') {
+        // Copy required hack scripts to target repo's hack directory
+        const requiredScripts = ['spec_metadata.sh', 'create_worktree.sh']
+        const sourceHackDir = path.resolve(sourceClaudeDir, '..', 'hack')
+        const targetHackDir = path.join(targetDir, 'hack')
+
+        if (!fs.existsSync(sourceHackDir)) {
+          p.log.warn('hack directory not found in source, skipping scripts')
+          continue
+        }
+
+        // Create hack directory in target
+        fs.mkdirSync(targetHackDir, { recursive: true })
+
+        let scriptsCopied = 0
+        for (const script of requiredScripts) {
+          const sourcePath = path.join(sourceHackDir, script)
+          const targetPath = path.join(targetHackDir, script)
+
+          if (!fs.existsSync(sourcePath)) {
+            p.log.warn(`Script ${script} not found in source, skipping`)
+            continue
+          }
+
+          fs.copyFileSync(sourcePath, targetPath)
+          // Make script executable (chmod +x)
+          fs.chmodSync(targetPath, 0o755)
+          scriptsCopied++
+        }
+
+        if (scriptsCopied > 0) {
+          filesCopied += scriptsCopied
+          p.log.success(`Copied ${scriptsCopied} hack script(s)`)
+        }
+      } else if (category === 'config') {
+        const settingsPath = path.join(sourceClaudeDir, 'settings.json')
+        const targetConfigPath = path.join(opencodeTargetDir, 'opencode.json')
+
+        if (fs.existsSync(settingsPath)) {
+          // Read source settings
+          const settingsContent = fs.readFileSync(settingsPath, 'utf8')
+          const settings = JSON.parse(settingsContent)
+
+          // Transform settings to OpenCode config
+          const opencodeConfig = transformSettings(settings, { model })
+
+          // Write transformed config
+          fs.writeFileSync(targetConfigPath, JSON.stringify(opencodeConfig, null, 2) + '\n')
+          filesCopied++
+          p.log.success(`Generated opencode.json with helpful comments`)
+        } else {
+          p.log.warn('settings.json not found in source, skipping')
+        }
+      } else if (category === 'agentsmd') {
+        const agentsMd = generateAgentsMd(targetDir)
+        fs.writeFileSync(path.join(targetDir, 'AGENTS.md'), agentsMd)
+        filesCopied++
+        p.log.success('Generated AGENTS.md template (customize as needed)')
+      }
+    }
+
+    // Update .gitignore to exclude opencode.local.json
+    if (selectedCategories.includes('config')) {
+      ensureGitignoreEntry(targetDir, '.opencode/opencode.local.json')
+      p.log.info('Updated .gitignore to exclude opencode.local.json')
+    }
+
+    // Update .gitignore to exclude hack scripts
+    if (selectedCategories.includes('scripts')) {
+      ensureGitignoreEntry(targetDir, 'hack/spec_metadata.sh')
+      ensureGitignoreEntry(targetDir, 'hack/create_worktree.sh')
+      p.log.info('Updated .gitignore to exclude hack scripts')
+    }
+
+    let message = `Successfully copied ${filesCopied} file(s) to ${opencodeTargetDir}`
+    if (filesSkipped > 0) {
+      message += chalk.gray(`\n   Skipped ${filesSkipped} file(s)`)
+    }
+    message += chalk.gray('\n   You can now use these commands in OpenCode.')
+
+    p.outro(message)
+  } catch (error) {
+    p.log.error(`Error during opencode init: ${error}`)
+    process.exit(1)
+  }
+}

--- a/hlyr/src/commands/opencode/init.ts
+++ b/hlyr/src/commands/opencode/init.ts
@@ -399,10 +399,10 @@ export async function opencodeInitCommand(options: InitOptions): Promise<void> {
       }
     }
 
-    // Update .gitignore to exclude opencode.local.json
-    if (selectedCategories.includes('config')) {
-      ensureGitignoreEntry(targetDir, '.opencode/opencode.local.json')
-      p.log.info('Updated .gitignore to exclude opencode.local.json')
+    // Update .gitignore to exclude .opencode directory
+    if (selectedCategories.length > 0) {
+      ensureGitignoreEntry(targetDir, '.opencode/')
+      p.log.info('Updated .gitignore to exclude .opencode/')
     }
 
     // Update .gitignore to exclude hack scripts

--- a/hlyr/src/commands/opencode/init.ts
+++ b/hlyr/src/commands/opencode/init.ts
@@ -4,423 +4,380 @@ import chalk from 'chalk'
 import * as p from '@clack/prompts'
 import { fileURLToPath } from 'url'
 import { dirname } from 'path'
-import {
-  transformCommandFile,
-  transformAgentFile,
-  transformSettings,
-  generateAgentsMd,
-  type ModelType,
-} from './transform.js'
+import { transformCommandFile, transformAgentFile, transformSettings, generateAgentsMd } from './transform.js'
 
 // Get the directory of this module
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
 interface InitOptions {
-  force?: boolean
-  all?: boolean
-  alwaysThinking?: boolean
-  maxThinkingTokens?: number
-  model?: ModelType
+	force?: boolean
+	all?: boolean
+	alwaysThinking?: boolean
+	maxThinkingTokens?: number
 }
 
 function ensureGitignoreEntry(targetDir: string, entry: string): void {
-  const gitignorePath = path.join(targetDir, '.gitignore')
+	const gitignorePath = path.join(targetDir, '.gitignore')
 
-  // Read existing .gitignore or create empty
-  let gitignoreContent = ''
-  if (fs.existsSync(gitignorePath)) {
-    gitignoreContent = fs.readFileSync(gitignorePath, 'utf8')
-  }
+	// Read existing .gitignore or create empty
+	let gitignoreContent = ''
+	if (fs.existsSync(gitignorePath)) {
+		gitignoreContent = fs.readFileSync(gitignorePath, 'utf8')
+	}
 
-  // Check if entry already exists
-  const lines = gitignoreContent.split('\n')
-  if (lines.some(line => line.trim() === entry)) {
-    return // Already exists
-  }
+	// Check if entry already exists
+	const lines = gitignoreContent.split('\n')
+	if (lines.some((line) => line.trim() === entry)) {
+		return // Already exists
+	}
 
-  // Add entry with section comment
-  const newContent =
-    gitignoreContent +
-    (gitignoreContent && !gitignoreContent.endsWith('\n') ? '\n' : '') +
-    '\n# OpenCode local settings\n' +
-    entry +
-    '\n'
+	// Add entry with section comment
+	const newContent =
+		gitignoreContent +
+		(gitignoreContent && !gitignoreContent.endsWith('\n') ? '\n' : '') +
+		'\n# OpenCode local settings\n' +
+		entry +
+		'\n'
 
-  fs.writeFileSync(gitignorePath, newContent)
+	fs.writeFileSync(gitignorePath, newContent)
 }
 
 export async function opencodeInitCommand(options: InitOptions): Promise<void> {
-  try {
-    p.intro(chalk.blue('Initialize OpenCode Configuration'))
+	try {
+		p.intro(chalk.blue('Initialize OpenCode Configuration'))
 
-    // Validate model option if provided
-    if (options.model && !['haiku', 'sonnet', 'opus'].includes(options.model)) {
-      p.log.error(`Invalid model: ${options.model}. Must be one of: haiku, sonnet, opus`)
-      process.exit(1)
-    }
+		// Check if running in interactive terminal
+		if (!process.stdin.isTTY && !options.all) {
+			p.log.error('Not running in interactive terminal.')
+			p.log.info('Use --all flag to copy all files without prompting.')
+			process.exit(1)
+		}
 
-    // Check if running in interactive terminal
-    if (!process.stdin.isTTY && !options.all) {
-      p.log.error('Not running in interactive terminal.')
-      p.log.info('Use --all flag to copy all files without prompting.')
-      process.exit(1)
-    }
+		const targetDir = process.cwd()
+		const opencodeTargetDir = path.join(targetDir, '.opencode')
 
-    const targetDir = process.cwd()
-    const opencodeTargetDir = path.join(targetDir, '.opencode')
+		// Determine source location
+		// Try multiple possible locations for the .claude directory
+		const possiblePaths = [
+			// When installed via npm: package root is one level up from dist
+			path.resolve(__dirname, '..', '..', '.claude'),
+			// When running from repo: repo root is two levels up from dist
+			path.resolve(__dirname, '..', '..', '..', '.claude'),
+		]
 
-    // Determine source location
-    // Try multiple possible locations for the .claude directory
-    const possiblePaths = [
-      // When installed via npm: package root is one level up from dist
-      path.resolve(__dirname, '..', '..', '.claude'),
-      // When running from repo: repo root is two levels up from dist
-      path.resolve(__dirname, '..', '..', '..', '.claude'),
-    ]
+		let sourceClaudeDir: string | null = null
+		for (const candidatePath of possiblePaths) {
+			if (fs.existsSync(candidatePath)) {
+				sourceClaudeDir = candidatePath
+				break
+			}
+		}
 
-    let sourceClaudeDir: string | null = null
-    for (const candidatePath of possiblePaths) {
-      if (fs.existsSync(candidatePath)) {
-        sourceClaudeDir = candidatePath
-        break
-      }
-    }
+		// Verify source directory exists
+		if (!sourceClaudeDir) {
+			p.log.error('Source .claude directory not found in expected locations')
+			p.log.info('Searched paths:')
+			possiblePaths.forEach((candidatePath) => {
+				p.log.info(`  - ${candidatePath}`)
+			})
+			p.log.info('Are you running from the humanlayer repository or npm package?')
+			process.exit(1)
+		}
 
-    // Verify source directory exists
-    if (!sourceClaudeDir) {
-      p.log.error('Source .claude directory not found in expected locations')
-      p.log.info('Searched paths:')
-      possiblePaths.forEach(candidatePath => {
-        p.log.info(`  - ${candidatePath}`)
-      })
-      p.log.info('Are you running from the humanlayer repository or npm package?')
-      process.exit(1)
-    }
+		// Check if .opencode already exists
+		if (fs.existsSync(opencodeTargetDir) && !options.force) {
+			const overwrite = await p.confirm({
+				message: '.opencode directory already exists. Overwrite?',
+				initialValue: false,
+			})
 
-    // Check if .opencode already exists
-    if (fs.existsSync(opencodeTargetDir) && !options.force) {
-      const overwrite = await p.confirm({
-        message: '.opencode directory already exists. Overwrite?',
-        initialValue: false,
-      })
+			if (p.isCancel(overwrite) || !overwrite) {
+				p.cancel('Operation cancelled.')
+				process.exit(0)
+			}
+		}
 
-      if (p.isCancel(overwrite) || !overwrite) {
-        p.cancel('Operation cancelled.')
-        process.exit(0)
-      }
-    }
+		let selectedCategories: string[]
 
-    let selectedCategories: string[]
+		if (options.all) {
+			// Don't include agentsmd by default in --all mode
+			selectedCategories = ['commands', 'agents', 'config', 'scripts']
+		} else {
+			// Interactive selection
+			const selection = await p.multiselect({
+				message: 'What would you like to copy?',
+				options: [
+					{
+						value: 'commands',
+						label: 'Commands',
+						hint: '27 workflow commands (planning, CI, research, etc.)',
+					},
+					{
+						value: 'agents',
+						label: 'Agents',
+						hint: '6 specialized sub-agents for code analysis',
+					},
+					{
+						value: 'config',
+						label: 'Config',
+						hint: 'Project opencode.json configuration',
+					},
+					{
+						value: 'scripts',
+						label: 'Scripts',
+						hint: 'Required hack scripts (spec_metadata.sh, create_worktree.sh)',
+					},
+					{
+						value: 'agentsmd',
+						label: 'AGENTS.md',
+						hint: 'Generate AGENTS.md with project context (optional, can be slow)',
+					},
+				],
+				initialValues: ['commands', 'agents', 'config', 'scripts'],
+				required: false,
+			})
 
-    if (options.all) {
-      // Don't include agentsmd by default in --all mode
-      selectedCategories = ['commands', 'agents', 'config', 'scripts']
-    } else {
-      // Interactive selection
-      const selection = await p.multiselect({
-        message: 'What would you like to copy?',
-        options: [
-          {
-            value: 'commands',
-            label: 'Commands',
-            hint: '27 workflow commands (planning, CI, research, etc.)',
-          },
-          {
-            value: 'agents',
-            label: 'Agents',
-            hint: '6 specialized sub-agents for code analysis',
-          },
-          {
-            value: 'config',
-            label: 'Config',
-            hint: 'Project opencode.json configuration',
-          },
-          {
-            value: 'scripts',
-            label: 'Scripts',
-            hint: 'Required hack scripts (spec_metadata.sh, create_worktree.sh)',
-          },
-          {
-            value: 'agentsmd',
-            label: 'AGENTS.md',
-            hint: 'Generate AGENTS.md with project context (optional, can be slow)',
-          },
-        ],
-        initialValues: ['commands', 'agents', 'config', 'scripts'],
-        required: false,
-      })
+			if (p.isCancel(selection)) {
+				p.cancel('Operation cancelled.')
+				process.exit(0)
+			}
 
-      if (p.isCancel(selection)) {
-        p.cancel('Operation cancelled.')
-        process.exit(0)
-      }
+			selectedCategories = selection as string[]
 
-      selectedCategories = selection as string[]
+			if (selectedCategories.length === 0) {
+				p.cancel('No items selected.')
+				process.exit(0)
+			}
+		}
 
-      if (selectedCategories.length === 0) {
-        p.cancel('No items selected.')
-        process.exit(0)
-      }
-    }
+		// Create .opencode directory
+		fs.mkdirSync(opencodeTargetDir, { recursive: true })
 
-    // Create .opencode directory
-    fs.mkdirSync(opencodeTargetDir, { recursive: true })
+		let filesCopied = 0
+		let filesSkipped = 0
 
-    let filesCopied = 0
-    let filesSkipped = 0
+		// Wizard-style file selection for each category
+		const filesToCopyByCategory: Record<string, string[]> = {}
 
-    // Wizard-style file selection for each category
-    const filesToCopyByCategory: Record<string, string[]> = {}
+		// If in interactive mode, prompt for file selection per category
+		if (!options.all) {
+			// Commands file selection (if selected)
+			if (selectedCategories.includes('commands')) {
+				const sourceDir = path.join(sourceClaudeDir, 'commands')
+				if (fs.existsSync(sourceDir)) {
+					const allFiles = fs.readdirSync(sourceDir)
+					const fileSelection = await p.multiselect({
+						message: 'Select command files to copy:',
+						options: allFiles.map((file) => ({
+							value: file,
+							label: file,
+						})),
+						initialValues: allFiles,
+						required: false,
+					})
 
-    // If in interactive mode, prompt for file selection per category
-    if (!options.all) {
-      // Commands file selection (if selected)
-      if (selectedCategories.includes('commands')) {
-        const sourceDir = path.join(sourceClaudeDir, 'commands')
-        if (fs.existsSync(sourceDir)) {
-          const allFiles = fs.readdirSync(sourceDir)
-          const fileSelection = await p.multiselect({
-            message: 'Select command files to copy:',
-            options: allFiles.map(file => ({
-              value: file,
-              label: file,
-            })),
-            initialValues: allFiles,
-            required: false,
-          })
+					if (p.isCancel(fileSelection)) {
+						p.cancel('Operation cancelled.')
+						process.exit(0)
+					}
 
-          if (p.isCancel(fileSelection)) {
-            p.cancel('Operation cancelled.')
-            process.exit(0)
-          }
+					filesToCopyByCategory['commands'] = fileSelection as string[]
 
-          filesToCopyByCategory['commands'] = fileSelection as string[]
+					if (filesToCopyByCategory['commands'].length === 0) {
+						filesSkipped += allFiles.length
+					}
+				}
+			}
 
-          if (filesToCopyByCategory['commands'].length === 0) {
-            filesSkipped += allFiles.length
-          }
-        }
-      }
+			// Agents file selection (if selected)
+			if (selectedCategories.includes('agents')) {
+				const sourceDir = path.join(sourceClaudeDir, 'agents')
+				if (fs.existsSync(sourceDir)) {
+					const allFiles = fs.readdirSync(sourceDir)
+					const fileSelection = await p.multiselect({
+						message: 'Select agent files to copy:',
+						options: allFiles.map((file) => ({
+							value: file,
+							label: file,
+						})),
+						initialValues: allFiles,
+						required: false,
+					})
 
-      // Agents file selection (if selected)
-      if (selectedCategories.includes('agents')) {
-        const sourceDir = path.join(sourceClaudeDir, 'agents')
-        if (fs.existsSync(sourceDir)) {
-          const allFiles = fs.readdirSync(sourceDir)
-          const fileSelection = await p.multiselect({
-            message: 'Select agent files to copy:',
-            options: allFiles.map(file => ({
-              value: file,
-              label: file,
-            })),
-            initialValues: allFiles,
-            required: false,
-          })
+					if (p.isCancel(fileSelection)) {
+						p.cancel('Operation cancelled.')
+						process.exit(0)
+					}
 
-          if (p.isCancel(fileSelection)) {
-            p.cancel('Operation cancelled.')
-            process.exit(0)
-          }
+					filesToCopyByCategory['agents'] = fileSelection as string[]
 
-          filesToCopyByCategory['agents'] = fileSelection as string[]
+					if (filesToCopyByCategory['agents'].length === 0) {
+						filesSkipped += allFiles.length
+					}
+				}
+			}
+		}
 
-          if (filesToCopyByCategory['agents'].length === 0) {
-            filesSkipped += allFiles.length
-          }
-        }
-      }
-    }
+		// Copy selected categories
+		for (const category of selectedCategories) {
+			if (category === 'commands') {
+				const sourceDir = path.join(sourceClaudeDir, 'commands')
+				const targetCategoryDir = path.join(opencodeTargetDir, 'command') // SINGULAR
 
-    // Configure model
-    let model = options.model
+				if (!fs.existsSync(sourceDir)) {
+					p.log.warn(`commands directory not found in source, skipping`)
+					continue
+				}
 
-    // Prompt for model if in interactive mode and not provided via flags
-    if (!options.all && selectedCategories.includes('config')) {
-      if (model === undefined) {
-        const modelPrompt = await p.select({
-          message: 'Select default model:',
-          options: [
-            { value: 'opus' as ModelType, label: 'Opus (most capable)' },
-            { value: 'sonnet' as ModelType, label: 'Sonnet (balanced)' },
-            { value: 'haiku' as ModelType, label: 'Haiku (fastest)' },
-          ],
-          initialValue: 'opus' as ModelType,
-        })
+				// Get all files in category
+				const allFiles = fs.readdirSync(sourceDir)
 
-        if (p.isCancel(modelPrompt)) {
-          p.cancel('Operation cancelled.')
-          process.exit(0)
-        }
+				// Determine which files to copy
+				let filesToCopy = allFiles
+				if (!options.all && filesToCopyByCategory['commands']) {
+					filesToCopy = filesToCopyByCategory['commands']
+				}
 
-        model = modelPrompt as ModelType
-      }
-    } else if (selectedCategories.includes('config')) {
-      // Non-interactive mode: use default if not provided
-      if (model === undefined) {
-        model = 'opus'
-      }
-    }
+				if (filesToCopy.length === 0) {
+					continue
+				}
 
-    // Copy selected categories
-    for (const category of selectedCategories) {
-      if (category === 'commands') {
-        const sourceDir = path.join(sourceClaudeDir, 'commands')
-        const targetCategoryDir = path.join(opencodeTargetDir, 'command') // SINGULAR
+				// Copy and transform files
+				fs.mkdirSync(targetCategoryDir, { recursive: true })
 
-        if (!fs.existsSync(sourceDir)) {
-          p.log.warn(`commands directory not found in source, skipping`)
-          continue
-        }
+				for (const file of filesToCopy) {
+					const sourcePath = path.join(sourceDir, file)
+					const targetPath = path.join(targetCategoryDir, file)
 
-        // Get all files in category
-        const allFiles = fs.readdirSync(sourceDir)
+					const sourceContent = fs.readFileSync(sourcePath, 'utf8')
+					const transformedContent = transformCommandFile(sourceContent)
+					fs.writeFileSync(targetPath, transformedContent)
+					filesCopied++
+				}
 
-        // Determine which files to copy
-        let filesToCopy = allFiles
-        if (!options.all && filesToCopyByCategory['commands']) {
-          filesToCopy = filesToCopyByCategory['commands']
-        }
+				filesSkipped += allFiles.length - filesToCopy.length
+				p.log.success(`Copied ${filesToCopy.length} command file(s)`)
+			} else if (category === 'agents') {
+				const sourceDir = path.join(sourceClaudeDir, 'agents')
+				const targetCategoryDir = path.join(opencodeTargetDir, 'agent') // SINGULAR
 
-        if (filesToCopy.length === 0) {
-          continue
-        }
+				if (!fs.existsSync(sourceDir)) {
+					p.log.warn(`agents directory not found in source, skipping`)
+					continue
+				}
 
-        // Copy and transform files
-        fs.mkdirSync(targetCategoryDir, { recursive: true })
+				// Get all files in category
+				const allFiles = fs.readdirSync(sourceDir)
 
-        for (const file of filesToCopy) {
-          const sourcePath = path.join(sourceDir, file)
-          const targetPath = path.join(targetCategoryDir, file)
+				// Determine which files to copy
+				let filesToCopy = allFiles
+				if (!options.all && filesToCopyByCategory['agents']) {
+					filesToCopy = filesToCopyByCategory['agents']
+				}
 
-          const sourceContent = fs.readFileSync(sourcePath, 'utf8')
-          const transformedContent = transformCommandFile(sourceContent)
-          fs.writeFileSync(targetPath, transformedContent)
-          filesCopied++
-        }
+				if (filesToCopy.length === 0) {
+					continue
+				}
 
-        filesSkipped += allFiles.length - filesToCopy.length
-        p.log.success(`Copied ${filesToCopy.length} command file(s)`)
-      } else if (category === 'agents') {
-        const sourceDir = path.join(sourceClaudeDir, 'agents')
-        const targetCategoryDir = path.join(opencodeTargetDir, 'agent') // SINGULAR
+				// Copy and transform files
+				fs.mkdirSync(targetCategoryDir, { recursive: true })
 
-        if (!fs.existsSync(sourceDir)) {
-          p.log.warn(`agents directory not found in source, skipping`)
-          continue
-        }
+				for (const file of filesToCopy) {
+					const sourcePath = path.join(sourceDir, file)
+					const targetPath = path.join(targetCategoryDir, file)
 
-        // Get all files in category
-        const allFiles = fs.readdirSync(sourceDir)
+					const sourceContent = fs.readFileSync(sourcePath, 'utf8')
+					const transformedContent = transformAgentFile(sourceContent)
+					fs.writeFileSync(targetPath, transformedContent)
+					filesCopied++
+				}
 
-        // Determine which files to copy
-        let filesToCopy = allFiles
-        if (!options.all && filesToCopyByCategory['agents']) {
-          filesToCopy = filesToCopyByCategory['agents']
-        }
+				filesSkipped += allFiles.length - filesToCopy.length
+				p.log.success(`Copied ${filesToCopy.length} agent file(s)`)
+			} else if (category === 'scripts') {
+				// Copy required hack scripts to target repo's hack directory
+				const requiredScripts = ['spec_metadata.sh', 'create_worktree.sh']
+				const sourceHackDir = path.resolve(sourceClaudeDir, '..', 'hack')
+				const targetHackDir = path.join(targetDir, 'hack')
 
-        if (filesToCopy.length === 0) {
-          continue
-        }
+				if (!fs.existsSync(sourceHackDir)) {
+					p.log.warn('hack directory not found in source, skipping scripts')
+					continue
+				}
 
-        // Copy and transform files
-        fs.mkdirSync(targetCategoryDir, { recursive: true })
+				// Create hack directory in target
+				fs.mkdirSync(targetHackDir, { recursive: true })
 
-        for (const file of filesToCopy) {
-          const sourcePath = path.join(sourceDir, file)
-          const targetPath = path.join(targetCategoryDir, file)
+				let scriptsCopied = 0
+				for (const script of requiredScripts) {
+					const sourcePath = path.join(sourceHackDir, script)
+					const targetPath = path.join(targetHackDir, script)
 
-          const sourceContent = fs.readFileSync(sourcePath, 'utf8')
-          const transformedContent = transformAgentFile(sourceContent)
-          fs.writeFileSync(targetPath, transformedContent)
-          filesCopied++
-        }
+					if (!fs.existsSync(sourcePath)) {
+						p.log.warn(`Script ${script} not found in source, skipping`)
+						continue
+					}
 
-        filesSkipped += allFiles.length - filesToCopy.length
-        p.log.success(`Copied ${filesToCopy.length} agent file(s)`)
-      } else if (category === 'scripts') {
-        // Copy required hack scripts to target repo's hack directory
-        const requiredScripts = ['spec_metadata.sh', 'create_worktree.sh']
-        const sourceHackDir = path.resolve(sourceClaudeDir, '..', 'hack')
-        const targetHackDir = path.join(targetDir, 'hack')
+					fs.copyFileSync(sourcePath, targetPath)
+					// Make script executable (chmod +x)
+					fs.chmodSync(targetPath, 0o755)
+					scriptsCopied++
+				}
 
-        if (!fs.existsSync(sourceHackDir)) {
-          p.log.warn('hack directory not found in source, skipping scripts')
-          continue
-        }
+				if (scriptsCopied > 0) {
+					filesCopied += scriptsCopied
+					p.log.success(`Copied ${scriptsCopied} hack script(s)`)
+				}
+			} else if (category === 'config') {
+				const settingsPath = path.join(sourceClaudeDir, 'settings.json')
+				const targetConfigPath = path.join(opencodeTargetDir, 'opencode.json')
 
-        // Create hack directory in target
-        fs.mkdirSync(targetHackDir, { recursive: true })
+				if (fs.existsSync(settingsPath)) {
+					// Read source settings
+					const settingsContent = fs.readFileSync(settingsPath, 'utf8')
+					const settings = JSON.parse(settingsContent)
 
-        let scriptsCopied = 0
-        for (const script of requiredScripts) {
-          const sourcePath = path.join(sourceHackDir, script)
-          const targetPath = path.join(targetHackDir, script)
+					// Transform settings to OpenCode config
+					const opencodeConfig = transformSettings(settings)
 
-          if (!fs.existsSync(sourcePath)) {
-            p.log.warn(`Script ${script} not found in source, skipping`)
-            continue
-          }
+					// Write transformed config
+					fs.writeFileSync(targetConfigPath, JSON.stringify(opencodeConfig, null, 2) + '\n')
+					filesCopied++
+					p.log.success(`Generated opencode.json`)
+				} else {
+					p.log.warn('settings.json not found in source, skipping')
+				}
+			} else if (category === 'agentsmd') {
+				const agentsMd = generateAgentsMd(targetDir)
+				fs.writeFileSync(path.join(targetDir, 'AGENTS.md'), agentsMd)
+				filesCopied++
+				p.log.success('Generated AGENTS.md template (customize as needed)')
+			}
+		}
 
-          fs.copyFileSync(sourcePath, targetPath)
-          // Make script executable (chmod +x)
-          fs.chmodSync(targetPath, 0o755)
-          scriptsCopied++
-        }
+		// Update .gitignore to exclude .opencode directory
+		if (selectedCategories.length > 0) {
+			ensureGitignoreEntry(targetDir, '.opencode/')
+			p.log.info('Updated .gitignore to exclude .opencode/')
+		}
 
-        if (scriptsCopied > 0) {
-          filesCopied += scriptsCopied
-          p.log.success(`Copied ${scriptsCopied} hack script(s)`)
-        }
-      } else if (category === 'config') {
-        const settingsPath = path.join(sourceClaudeDir, 'settings.json')
-        const targetConfigPath = path.join(opencodeTargetDir, 'opencode.json')
+		// Update .gitignore to exclude hack scripts
+		if (selectedCategories.includes('scripts')) {
+			ensureGitignoreEntry(targetDir, 'hack/spec_metadata.sh')
+			ensureGitignoreEntry(targetDir, 'hack/create_worktree.sh')
+			p.log.info('Updated .gitignore to exclude hack scripts')
+		}
 
-        if (fs.existsSync(settingsPath)) {
-          // Read source settings
-          const settingsContent = fs.readFileSync(settingsPath, 'utf8')
-          const settings = JSON.parse(settingsContent)
+		let message = `Successfully copied ${filesCopied} file(s) to ${opencodeTargetDir}`
+		if (filesSkipped > 0) {
+			message += chalk.gray(`\n   Skipped ${filesSkipped} file(s)`)
+		}
+		message += chalk.gray('\n   You can now use these commands in OpenCode.')
 
-          // Transform settings to OpenCode config
-          const opencodeConfig = transformSettings(settings, { model })
-
-          // Write transformed config
-          fs.writeFileSync(targetConfigPath, JSON.stringify(opencodeConfig, null, 2) + '\n')
-          filesCopied++
-          p.log.success(`Generated opencode.json`)
-        } else {
-          p.log.warn('settings.json not found in source, skipping')
-        }
-      } else if (category === 'agentsmd') {
-        const agentsMd = generateAgentsMd(targetDir)
-        fs.writeFileSync(path.join(targetDir, 'AGENTS.md'), agentsMd)
-        filesCopied++
-        p.log.success('Generated AGENTS.md template (customize as needed)')
-      }
-    }
-
-    // Update .gitignore to exclude .opencode directory
-    if (selectedCategories.length > 0) {
-      ensureGitignoreEntry(targetDir, '.opencode/')
-      p.log.info('Updated .gitignore to exclude .opencode/')
-    }
-
-    // Update .gitignore to exclude hack scripts
-    if (selectedCategories.includes('scripts')) {
-      ensureGitignoreEntry(targetDir, 'hack/spec_metadata.sh')
-      ensureGitignoreEntry(targetDir, 'hack/create_worktree.sh')
-      p.log.info('Updated .gitignore to exclude hack scripts')
-    }
-
-    let message = `Successfully copied ${filesCopied} file(s) to ${opencodeTargetDir}`
-    if (filesSkipped > 0) {
-      message += chalk.gray(`\n   Skipped ${filesSkipped} file(s)`)
-    }
-    message += chalk.gray('\n   You can now use these commands in OpenCode.')
-
-    p.outro(message)
-  } catch (error) {
-    p.log.error(`Error during opencode init: ${error}`)
-    process.exit(1)
-  }
+		p.outro(message)
+	} catch (error) {
+		p.log.error(`Error during opencode init: ${error}`)
+		process.exit(1)
+	}
 }

--- a/hlyr/src/commands/opencode/init.ts
+++ b/hlyr/src/commands/opencode/init.ts
@@ -13,8 +13,6 @@ const __dirname = dirname(__filename)
 interface InitOptions {
 	force?: boolean
 	all?: boolean
-	alwaysThinking?: boolean
-	maxThinkingTokens?: number
 }
 
 function ensureGitignoreEntry(targetDir: string, entry: string): void {

--- a/hlyr/src/commands/opencode/init.ts
+++ b/hlyr/src/commands/opencode/init.ts
@@ -387,7 +387,7 @@ export async function opencodeInitCommand(options: InitOptions): Promise<void> {
           // Write transformed config
           fs.writeFileSync(targetConfigPath, JSON.stringify(opencodeConfig, null, 2) + '\n')
           filesCopied++
-          p.log.success(`Generated opencode.json with helpful comments`)
+          p.log.success(`Generated opencode.json`)
         } else {
           p.log.warn('settings.json not found in source, skipping')
         }

--- a/hlyr/src/commands/opencode/init.ts
+++ b/hlyr/src/commands/opencode/init.ts
@@ -99,8 +99,7 @@ export async function opencodeInitCommand(options: InitOptions): Promise<void> {
 		let selectedCategories: string[]
 
 		if (options.all) {
-			// Don't include agentsmd by default in --all mode
-			selectedCategories = ['commands', 'agents', 'config', 'scripts']
+			selectedCategories = ['commands', 'agents', 'config', 'scripts', 'agentsmd']
 		} else {
 			// Interactive selection
 			const selection = await p.multiselect({
@@ -129,10 +128,10 @@ export async function opencodeInitCommand(options: InitOptions): Promise<void> {
 					{
 						value: 'agentsmd',
 						label: 'AGENTS.md',
-						hint: 'Generate AGENTS.md with project context (optional, can be slow)',
+						hint: 'Generate AGENTS.md with project context',
 					},
 				],
-				initialValues: ['commands', 'agents', 'config', 'scripts'],
+				initialValues: ['commands', 'agents', 'config', 'scripts', 'agentsmd'],
 				required: false,
 			})
 

--- a/hlyr/src/commands/opencode/transform.test.ts
+++ b/hlyr/src/commands/opencode/transform.test.ts
@@ -1,0 +1,466 @@
+import { describe, it, expect } from 'vitest'
+import {
+  transformModelName,
+  parseClaudeTools,
+  transformCommandFile,
+  transformAgentFile,
+  transformSettings,
+  generateAgentsMd,
+  needsPlatformGuidance,
+  generatePlatformGuidance,
+} from './transform.js'
+import os from 'os'
+
+const EOL = os.EOL
+
+describe('transform.ts', () => {
+  describe('transformModelName', () => {
+    it('should transform short model names to full names', () => {
+      expect(transformModelName('opus')).toBe('anthropic/claude-opus-4')
+      expect(transformModelName('sonnet')).toBe('anthropic/claude-sonnet-4-5')
+      expect(transformModelName('haiku')).toBe('anthropic/claude-haiku-4-5')
+    })
+
+    it('should pass through full model names', () => {
+      expect(transformModelName('anthropic/claude-opus-4')).toBe('anthropic/claude-opus-4')
+      expect(transformModelName('openai/gpt-4')).toBe('openai/gpt-4')
+    })
+
+    it('should return default when model is undefined', () => {
+      expect(transformModelName(undefined)).toBe('anthropic/claude-opus-4')
+    })
+  })
+
+  describe('parseClaudeTools', () => {
+    it('should parse comma-separated tool names', () => {
+      const result = parseClaudeTools('Grep, Glob, LS')
+      expect(result).toEqual({
+        grep: true,
+        glob: true,
+        list: true,
+      })
+    })
+
+    it('should handle single tool', () => {
+      const result = parseClaudeTools('Read')
+      expect(result).toEqual({
+        read: true,
+      })
+    })
+
+    it('should handle all supported tools', () => {
+      const result = parseClaudeTools(
+        'Grep, Glob, LS, Read, Write, Edit, Bash, Task, TodoWrite, TodoRead',
+      )
+      expect(result).toEqual({
+        grep: true,
+        glob: true,
+        list: true,
+        read: true,
+        write: true,
+        edit: true,
+        bash: true,
+        task: true,
+        todowrite: true,
+        todoread: true,
+      })
+    })
+
+    it('should handle whitespace', () => {
+      const result = parseClaudeTools('  Grep  ,  Glob  ,  LS  ')
+      expect(result).toEqual({
+        grep: true,
+        glob: true,
+        list: true,
+      })
+    })
+
+    it('should handle unknown tools by lowercasing them', () => {
+      const result = parseClaudeTools('CustomTool, AnotherTool')
+      expect(result).toEqual({
+        customtool: true,
+        anothertool: true,
+      })
+    })
+  })
+
+  describe('needsPlatformGuidance', () => {
+    it('should return true for agents with grep tool', () => {
+      expect(needsPlatformGuidance({ grep: true }, 'some content')).toBe(true)
+    })
+
+    it('should return true for agents with glob tool', () => {
+      expect(needsPlatformGuidance({ glob: true }, 'some content')).toBe(true)
+    })
+
+    it('should return true for agents with list tool', () => {
+      expect(needsPlatformGuidance({ list: true }, 'some content')).toBe(true)
+    })
+
+    it('should return true when body contains thoughts/ reference', () => {
+      expect(needsPlatformGuidance(undefined, 'Check thoughts/shared/research')).toBe(true)
+    })
+
+    it('should return true when body contains codebase reference', () => {
+      expect(needsPlatformGuidance(undefined, 'Search the codebase for examples')).toBe(true)
+    })
+
+    it('should return true when body mentions directories', () => {
+      expect(needsPlatformGuidance(undefined, 'Check all directories in the project')).toBe(true)
+      expect(needsPlatformGuidance(undefined, 'List the directory contents')).toBe(true)
+    })
+
+    it('should return true when body mentions file paths', () => {
+      expect(needsPlatformGuidance(undefined, 'Provide the file path to the document')).toBe(true)
+    })
+
+    it('should return true when body references codebase agents', () => {
+      expect(needsPlatformGuidance(undefined, 'Use @codebase-locator to find files')).toBe(true)
+      expect(needsPlatformGuidance(undefined, 'Use @thoughts-locator agent')).toBe(true)
+      expect(needsPlatformGuidance(undefined, 'Invoke @codebase-analyzer')).toBe(true)
+      expect(needsPlatformGuidance(undefined, 'Use @codebase-pattern-finder')).toBe(true)
+    })
+
+    it('should return false when no platform guidance is needed', () => {
+      expect(needsPlatformGuidance({ read: true, write: true }, 'Simple content without paths')).toBe(
+        false,
+      )
+    })
+
+    it('should return false for undefined tools and simple content', () => {
+      expect(needsPlatformGuidance(undefined, 'Simple task description')).toBe(false)
+    })
+  })
+
+  describe('generatePlatformGuidance', () => {
+    it('should generate platform guidance text', () => {
+      const guidance = generatePlatformGuidance()
+
+      expect(guidance).toContain('## Platform Compatibility')
+      expect(guidance).toContain('grep')
+      expect(guidance).toContain('glob')
+      expect(guidance).toContain('list')
+      expect(guidance).toContain('forward slashes')
+      expect(guidance).toContain('cross-platform')
+    })
+
+    it('should end with proper line endings', () => {
+      const guidance = generatePlatformGuidance()
+      expect(guidance).toMatch(/\n$/)
+    })
+  })
+
+  describe('transformCommandFile', () => {
+    it('should transform frontmatter', () => {
+      const input = `---
+description: Test command
+model: opus
+---
+
+Command content here`
+
+      const result = transformCommandFile(input)
+
+      expect(result).toContain('description: Test command')
+      expect(result).toContain('model: anthropic/claude-opus-4')
+      expect(result).toContain('Command content here')
+    })
+
+    it('should handle missing frontmatter', () => {
+      const input = 'Just plain content'
+      const result = transformCommandFile(input)
+
+      expect(result).toContain('description: Custom command')
+      expect(result).toContain('Just plain content')
+    })
+
+    it('should transform SlashCommand() syntax', () => {
+      const input = `---
+description: Test
+---
+
+use SlashCommand() to call /research_codebase`
+
+      const result = transformCommandFile(input)
+      expect(result).toContain('use /research_codebase')
+      expect(result).not.toContain('SlashCommand()')
+    })
+
+    it('should transform humanlayer launch commands', () => {
+      const input = `---
+description: Test
+---
+
+launch a new session with \`npx humanlayer launch --ticket ENG-123\``
+
+      const result = transformCommandFile(input)
+      expect(result).toContain('OpenCode')
+      expect(result).not.toContain('launch a new session with')
+    })
+
+    it('should inject platform guidance for commands with path references', () => {
+      const input = `---
+description: Research command
+---
+
+Use @codebase-locator to find files in the codebase.
+Check thoughts/shared/research for documentation.`
+
+      const result = transformCommandFile(input)
+
+      expect(result).toContain('## Platform Compatibility')
+      expect(result).toContain('grep')
+      expect(result).toContain('Use @codebase-locator')
+      expect(result).toContain('thoughts/shared/research')
+    })
+
+    it('should not inject platform guidance for simple commands', () => {
+      const input = `---
+description: Simple command
+---
+
+Just do something simple without paths.`
+
+      const result = transformCommandFile(input)
+
+      expect(result).not.toContain('## Platform Compatibility')
+      expect(result).toContain('Just do something simple')
+    })
+
+    it('should handle Windows line endings', () => {
+      const input = `---\r\ndescription: Test\r\n---\r\n\r\nContent`
+      const result = transformCommandFile(input)
+
+      expect(result).toContain('description: Test')
+      expect(result).toContain('Content')
+    })
+  })
+
+  describe('transformAgentFile', () => {
+    it('should transform agent frontmatter', () => {
+      const input = `---
+name: test-agent
+description: Test agent
+tools: Grep, Glob, LS
+model: sonnet
+---
+
+Agent body content`
+
+      const result = transformAgentFile(input)
+
+      expect(result).toContain('description: Test agent')
+      expect(result).toContain('mode: subagent')
+      expect(result).toContain('model: anthropic/claude-sonnet-4-5')
+      expect(result).toContain('tools:')
+      expect(result).toContain('  grep: true')
+      expect(result).toContain('  glob: true')
+      expect(result).toContain('  list: true')
+      expect(result).not.toContain('name:')
+      expect(result).toContain('Agent body content')
+    })
+
+    it('should inject platform guidance for agents with filesystem tools', () => {
+      const input = `---
+name: codebase-locator
+description: Locate files in codebase
+tools: Grep, Glob, LS
+model: sonnet
+---
+
+Search the codebase for relevant files.`
+
+      const result = transformAgentFile(input)
+
+      expect(result).toContain('## Platform Compatibility')
+      expect(result).toContain('grep')
+      expect(result).toContain('glob')
+      expect(result).toContain('list')
+      expect(result).toContain('Search the codebase')
+    })
+
+    it('should not inject platform guidance for agents without filesystem tools', () => {
+      const input = `---
+name: simple-agent
+description: Simple agent
+tools: Read, Write
+model: sonnet
+---
+
+Just read and write files.`
+
+      const result = transformAgentFile(input)
+
+      expect(result).not.toContain('## Platform Compatibility')
+      expect(result).toContain('Just read and write files')
+    })
+
+    it('should inject platform guidance when body references paths', () => {
+      const input = `---
+name: thoughts-agent
+description: Analyze thoughts
+tools: Read
+model: sonnet
+---
+
+Check thoughts/shared/research directory for documentation.`
+
+      const result = transformAgentFile(input)
+
+      expect(result).toContain('## Platform Compatibility')
+      expect(result).toContain('thoughts/shared/research')
+    })
+
+    it('should handle missing tools field', () => {
+      const input = `---
+name: no-tools
+description: Agent without tools
+model: opus
+---
+
+Content without tools`
+
+      const result = transformAgentFile(input)
+
+      expect(result).toContain('description: Agent without tools')
+      expect(result).toContain('mode: subagent')
+      expect(result).not.toContain('tools:')
+      expect(result).toContain('Content without tools')
+    })
+
+    it('should handle missing frontmatter', () => {
+      const input = 'Just content without frontmatter'
+      const result = transformAgentFile(input)
+
+      expect(result).toBe(input)
+    })
+
+    it('should use default description when missing', () => {
+      const input = `---
+name: test
+tools: Grep
+---
+
+Content`
+
+      const result = transformAgentFile(input)
+      expect(result).toContain('description: Specialized agent')
+    })
+
+    it('should handle Windows line endings', () => {
+      const input = `---\r\nname: test\r\ndescription: Test\r\ntools: Grep\r\n---\r\n\r\nContent`
+      const result = transformAgentFile(input)
+
+      expect(result).toContain('description: Test')
+      expect(result).toContain('Content')
+    })
+  })
+
+  describe('transformSettings', () => {
+    it('should transform basic settings', () => {
+      const settings = {
+        model: 'opus',
+      }
+
+      const result = transformSettings(settings, {})
+
+      expect(result.$schema).toBe('https://opencode.ai/config.json')
+      expect(result.model).toBe('anthropic/claude-opus-4')
+      expect(result.instructions).toEqual(['AGENTS.md'])
+    })
+
+    it('should use options.model over settings.model', () => {
+      const settings = {
+        model: 'sonnet',
+      }
+
+      const result = transformSettings(settings, { model: 'haiku' })
+      expect(result.model).toBe('anthropic/claude-haiku-4-5')
+    })
+
+    it('should transform bash permissions', () => {
+      const settings = {
+        model: 'opus',
+        permissions: {
+          allow: ['Bash(./hack/spec_metadata.sh)', 'Bash(./hack/create_worktree.sh)'],
+        },
+      }
+
+      const result = transformSettings(settings, {})
+
+      expect(result.permission).toBeDefined()
+      expect(result.permission.bash).toEqual({
+        './hack/spec_metadata.sh': 'allow',
+        './hack/create_worktree.sh': 'allow',
+        '*': 'ask',
+      })
+    })
+
+    it('should handle settings without permissions', () => {
+      const settings = {
+        model: 'sonnet',
+      }
+
+      const result = transformSettings(settings, {})
+      expect(result.permission).toBeUndefined()
+    })
+
+    it('should default to opus when no model specified', () => {
+      const result = transformSettings({}, {})
+      expect(result.model).toBe('anthropic/claude-opus-4')
+    })
+  })
+
+  describe('generateAgentsMd', () => {
+    it('should generate AGENTS.md content', () => {
+      const result = generateAgentsMd('/path/to/my-project')
+
+      expect(result).toContain('# my-project - OpenCode Configuration')
+      expect(result).toContain('Project Overview')
+      expect(result).toContain('Custom Commands')
+      expect(result).toContain('/create_plan')
+      expect(result).toContain('@codebase-locator')
+      expect(result).toContain('Code Conventions')
+    })
+
+    it('should use basename of project path', () => {
+      const result = generateAgentsMd('C:\\Users\\test\\projects\\awesome-app')
+      expect(result).toContain('# awesome-app - OpenCode Configuration')
+    })
+
+    it('should handle Unix paths', () => {
+      const result = generateAgentsMd('/home/user/projects/cool-project')
+      expect(result).toContain('# cool-project - OpenCode Configuration')
+    })
+  })
+
+  describe('cross-platform line ending handling', () => {
+    it('should use platform EOL in transformCommandFile', () => {
+      const input = `---
+description: Test
+---
+
+Content`
+
+      const result = transformCommandFile(input)
+
+      // Check that output uses system EOL
+      expect(result.split(EOL).length).toBeGreaterThan(1)
+    })
+
+    it('should use platform EOL in transformAgentFile', () => {
+      const input = `---
+name: test
+description: Test
+tools: Grep
+---
+
+Content`
+
+      const result = transformAgentFile(input)
+
+      // Check that output uses system EOL
+      expect(result.split(EOL).length).toBeGreaterThan(1)
+    })
+  })
+})

--- a/hlyr/src/commands/opencode/transform.test.ts
+++ b/hlyr/src/commands/opencode/transform.test.ts
@@ -1,455 +1,407 @@
 import { describe, it, expect } from 'vitest'
 import {
-  transformModelName,
-  parseClaudeTools,
-  transformCommandFile,
-  transformAgentFile,
-  transformSettings,
-  generateAgentsMd,
-  needsPlatformGuidance,
-  generatePlatformGuidance,
+	parseClaudeTools,
+	transformCommandFile,
+	transformAgentFile,
+	transformSettings,
+	generateAgentsMd,
+	needsPlatformGuidance,
+	generatePlatformGuidance,
 } from './transform.js'
 import os from 'os'
 
 const EOL = os.EOL
 
 describe('transform.ts', () => {
-  describe('transformModelName', () => {
-    it('should transform short model names to full names', () => {
-      expect(transformModelName('opus')).toBe('anthropic/claude-opus-4')
-      expect(transformModelName('sonnet')).toBe('anthropic/claude-sonnet-4-5')
-      expect(transformModelName('haiku')).toBe('anthropic/claude-haiku-4-5')
-    })
+	describe('parseClaudeTools', () => {
+		it('should parse comma-separated tool names', () => {
+			const result = parseClaudeTools('Grep, Glob, LS')
+			expect(result).toEqual({
+				grep: true,
+				glob: true,
+				list: true,
+			})
+		})
 
-    it('should pass through full model names', () => {
-      expect(transformModelName('anthropic/claude-opus-4')).toBe('anthropic/claude-opus-4')
-      expect(transformModelName('openai/gpt-4')).toBe('openai/gpt-4')
-    })
+		it('should handle single tool', () => {
+			const result = parseClaudeTools('Read')
+			expect(result).toEqual({
+				read: true,
+			})
+		})
 
-    it('should return default when model is undefined', () => {
-      expect(transformModelName(undefined)).toBe('anthropic/claude-opus-4')
-    })
-  })
+		it('should handle all supported tools', () => {
+			const result = parseClaudeTools('Grep, Glob, LS, Read, Write, Edit, Bash, Task, TodoWrite, TodoRead')
+			expect(result).toEqual({
+				grep: true,
+				glob: true,
+				list: true,
+				read: true,
+				write: true,
+				edit: true,
+				bash: true,
+				task: true,
+				todowrite: true,
+				todoread: true,
+			})
+		})
 
-  describe('parseClaudeTools', () => {
-    it('should parse comma-separated tool names', () => {
-      const result = parseClaudeTools('Grep, Glob, LS')
-      expect(result).toEqual({
-        grep: true,
-        glob: true,
-        list: true,
-      })
-    })
+		it('should handle whitespace', () => {
+			const result = parseClaudeTools('  Grep  ,  Glob  ,  LS  ')
+			expect(result).toEqual({
+				grep: true,
+				glob: true,
+				list: true,
+			})
+		})
 
-    it('should handle single tool', () => {
-      const result = parseClaudeTools('Read')
-      expect(result).toEqual({
-        read: true,
-      })
-    })
+		it('should handle unknown tools by lowercasing them', () => {
+			const result = parseClaudeTools('CustomTool, AnotherTool')
+			expect(result).toEqual({
+				customtool: true,
+				anothertool: true,
+			})
+		})
+	})
 
-    it('should handle all supported tools', () => {
-      const result = parseClaudeTools(
-        'Grep, Glob, LS, Read, Write, Edit, Bash, Task, TodoWrite, TodoRead',
-      )
-      expect(result).toEqual({
-        grep: true,
-        glob: true,
-        list: true,
-        read: true,
-        write: true,
-        edit: true,
-        bash: true,
-        task: true,
-        todowrite: true,
-        todoread: true,
-      })
-    })
+	describe('needsPlatformGuidance', () => {
+		it('should return true for agents with grep tool', () => {
+			expect(needsPlatformGuidance({ grep: true }, 'some content')).toBe(true)
+		})
 
-    it('should handle whitespace', () => {
-      const result = parseClaudeTools('  Grep  ,  Glob  ,  LS  ')
-      expect(result).toEqual({
-        grep: true,
-        glob: true,
-        list: true,
-      })
-    })
+		it('should return true for agents with glob tool', () => {
+			expect(needsPlatformGuidance({ glob: true }, 'some content')).toBe(true)
+		})
 
-    it('should handle unknown tools by lowercasing them', () => {
-      const result = parseClaudeTools('CustomTool, AnotherTool')
-      expect(result).toEqual({
-        customtool: true,
-        anothertool: true,
-      })
-    })
-  })
+		it('should return true for agents with list tool', () => {
+			expect(needsPlatformGuidance({ list: true }, 'some content')).toBe(true)
+		})
 
-  describe('needsPlatformGuidance', () => {
-    it('should return true for agents with grep tool', () => {
-      expect(needsPlatformGuidance({ grep: true }, 'some content')).toBe(true)
-    })
+		it('should return true when body contains thoughts/ reference', () => {
+			expect(needsPlatformGuidance(undefined, 'Check thoughts/shared/research')).toBe(true)
+		})
 
-    it('should return true for agents with glob tool', () => {
-      expect(needsPlatformGuidance({ glob: true }, 'some content')).toBe(true)
-    })
+		it('should return true when body contains codebase reference', () => {
+			expect(needsPlatformGuidance(undefined, 'Search the codebase for examples')).toBe(true)
+		})
 
-    it('should return true for agents with list tool', () => {
-      expect(needsPlatformGuidance({ list: true }, 'some content')).toBe(true)
-    })
+		it('should return true when body mentions directories', () => {
+			expect(needsPlatformGuidance(undefined, 'Check all directories in the project')).toBe(true)
+			expect(needsPlatformGuidance(undefined, 'List the directory contents')).toBe(true)
+		})
 
-    it('should return true when body contains thoughts/ reference', () => {
-      expect(needsPlatformGuidance(undefined, 'Check thoughts/shared/research')).toBe(true)
-    })
+		it('should return true when body mentions file paths', () => {
+			expect(needsPlatformGuidance(undefined, 'Provide the file path to the document')).toBe(true)
+		})
 
-    it('should return true when body contains codebase reference', () => {
-      expect(needsPlatformGuidance(undefined, 'Search the codebase for examples')).toBe(true)
-    })
+		it('should return true when body references codebase agents', () => {
+			expect(needsPlatformGuidance(undefined, 'Use @codebase-locator to find files')).toBe(true)
+			expect(needsPlatformGuidance(undefined, 'Use @thoughts-locator agent')).toBe(true)
+			expect(needsPlatformGuidance(undefined, 'Invoke @codebase-analyzer')).toBe(true)
+			expect(needsPlatformGuidance(undefined, 'Use @codebase-pattern-finder')).toBe(true)
+		})
 
-    it('should return true when body mentions directories', () => {
-      expect(needsPlatformGuidance(undefined, 'Check all directories in the project')).toBe(true)
-      expect(needsPlatformGuidance(undefined, 'List the directory contents')).toBe(true)
-    })
+		it('should return false when no platform guidance is needed', () => {
+			expect(needsPlatformGuidance({ read: true, write: true }, 'Simple content without paths')).toBe(false)
+		})
 
-    it('should return true when body mentions file paths', () => {
-      expect(needsPlatformGuidance(undefined, 'Provide the file path to the document')).toBe(true)
-    })
+		it('should return false for undefined tools and simple content', () => {
+			expect(needsPlatformGuidance(undefined, 'Simple task description')).toBe(false)
+		})
+	})
 
-    it('should return true when body references codebase agents', () => {
-      expect(needsPlatformGuidance(undefined, 'Use @codebase-locator to find files')).toBe(true)
-      expect(needsPlatformGuidance(undefined, 'Use @thoughts-locator agent')).toBe(true)
-      expect(needsPlatformGuidance(undefined, 'Invoke @codebase-analyzer')).toBe(true)
-      expect(needsPlatformGuidance(undefined, 'Use @codebase-pattern-finder')).toBe(true)
-    })
+	describe('generatePlatformGuidance', () => {
+		it('should generate platform guidance text', () => {
+			const guidance = generatePlatformGuidance()
 
-    it('should return false when no platform guidance is needed', () => {
-      expect(needsPlatformGuidance({ read: true, write: true }, 'Simple content without paths')).toBe(
-        false,
-      )
-    })
+			expect(guidance).toContain('## Platform Compatibility')
+			expect(guidance).toContain('grep')
+			expect(guidance).toContain('glob')
+			expect(guidance).toContain('list')
+			expect(guidance).toContain('forward slashes')
+			expect(guidance).toContain('cross-platform')
+		})
 
-    it('should return false for undefined tools and simple content', () => {
-      expect(needsPlatformGuidance(undefined, 'Simple task description')).toBe(false)
-    })
-  })
+		it('should end with proper line endings', () => {
+			const guidance = generatePlatformGuidance()
+			expect(guidance).toMatch(/\n$/)
+		})
+	})
 
-  describe('generatePlatformGuidance', () => {
-    it('should generate platform guidance text', () => {
-      const guidance = generatePlatformGuidance()
-
-      expect(guidance).toContain('## Platform Compatibility')
-      expect(guidance).toContain('grep')
-      expect(guidance).toContain('glob')
-      expect(guidance).toContain('list')
-      expect(guidance).toContain('forward slashes')
-      expect(guidance).toContain('cross-platform')
-    })
-
-    it('should end with proper line endings', () => {
-      const guidance = generatePlatformGuidance()
-      expect(guidance).toMatch(/\n$/)
-    })
-  })
-
-  describe('transformCommandFile', () => {
-    it('should transform frontmatter', () => {
-      const input = `---
+	describe('transformCommandFile', () => {
+		it('should transform frontmatter', () => {
+			const input = `---
 description: Test command
-model: opus
 ---
 
 Command content here`
 
-      const result = transformCommandFile(input)
+			const result = transformCommandFile(input)
 
-      expect(result).toContain('description: Test command')
-      expect(result).toContain('model: anthropic/claude-opus-4')
-      expect(result).toContain('Command content here')
-    })
+			expect(result).toContain('description: Test command')
+			expect(result).toContain('Command content here')
+		})
 
-    it('should handle missing frontmatter', () => {
-      const input = 'Just plain content'
-      const result = transformCommandFile(input)
+		it('should handle missing frontmatter', () => {
+			const input = 'Just plain content'
+			const result = transformCommandFile(input)
 
-      expect(result).toContain('description: Custom command')
-      expect(result).toContain('Just plain content')
-    })
+			expect(result).toContain('description: Custom command')
+			expect(result).toContain('Just plain content')
+		})
 
-    it('should transform SlashCommand() syntax', () => {
-      const input = `---
+		it('should transform SlashCommand() syntax', () => {
+			const input = `---
 description: Test
 ---
 
 use SlashCommand() to call /research_codebase`
 
-      const result = transformCommandFile(input)
-      expect(result).toContain('use /research_codebase')
-      expect(result).not.toContain('SlashCommand()')
-    })
+			const result = transformCommandFile(input)
+			expect(result).toContain('use /research_codebase')
+			expect(result).not.toContain('SlashCommand()')
+		})
 
-    it('should transform humanlayer launch commands', () => {
-      const input = `---
+		it('should transform humanlayer launch commands', () => {
+			const input = `---
 description: Test
 ---
 
 launch a new session with \`npx humanlayer launch --ticket ENG-123\``
 
-      const result = transformCommandFile(input)
-      expect(result).toContain('OpenCode')
-      expect(result).not.toContain('launch a new session with')
-    })
+			const result = transformCommandFile(input)
+			expect(result).toContain('OpenCode')
+			expect(result).not.toContain('launch a new session with')
+		})
 
-    it('should inject platform guidance for commands with path references', () => {
-      const input = `---
+		it('should inject platform guidance for commands with path references', () => {
+			const input = `---
 description: Research command
 ---
 
 Use @codebase-locator to find files in the codebase.
 Check thoughts/shared/research for documentation.`
 
-      const result = transformCommandFile(input)
+			const result = transformCommandFile(input)
 
-      expect(result).toContain('## Platform Compatibility')
-      expect(result).toContain('grep')
-      expect(result).toContain('Use @codebase-locator')
-      expect(result).toContain('thoughts/shared/research')
-    })
+			expect(result).toContain('## Platform Compatibility')
+			expect(result).toContain('grep')
+			expect(result).toContain('Use @codebase-locator')
+			expect(result).toContain('thoughts/shared/research')
+		})
 
-    it('should not inject platform guidance for simple commands', () => {
-      const input = `---
+		it('should not inject platform guidance for simple commands', () => {
+			const input = `---
 description: Simple command
 ---
 
 Just do something simple without paths.`
 
-      const result = transformCommandFile(input)
+			const result = transformCommandFile(input)
 
-      expect(result).not.toContain('## Platform Compatibility')
-      expect(result).toContain('Just do something simple')
-    })
+			expect(result).not.toContain('## Platform Compatibility')
+			expect(result).toContain('Just do something simple')
+		})
 
-    it('should handle Windows line endings', () => {
-      const input = `---\r\ndescription: Test\r\n---\r\n\r\nContent`
-      const result = transformCommandFile(input)
+		it('should handle Windows line endings', () => {
+			const input = `---\r\ndescription: Test\r\n---\r\n\r\nContent`
+			const result = transformCommandFile(input)
 
-      expect(result).toContain('description: Test')
-      expect(result).toContain('Content')
-    })
-  })
+			expect(result).toContain('description: Test')
+			expect(result).toContain('Content')
+		})
+	})
 
-  describe('transformAgentFile', () => {
-    it('should transform agent frontmatter', () => {
-      const input = `---
+	describe('transformAgentFile', () => {
+		it('should transform agent frontmatter', () => {
+			const input = `---
 name: test-agent
 description: Test agent
 tools: Grep, Glob, LS
-model: sonnet
 ---
 
 Agent body content`
 
-      const result = transformAgentFile(input)
+			const result = transformAgentFile(input)
 
-      expect(result).toContain('description: Test agent')
-      expect(result).toContain('mode: subagent')
-      expect(result).toContain('model: anthropic/claude-sonnet-4-5')
-      expect(result).toContain('tools:')
-      expect(result).toContain('  grep: true')
-      expect(result).toContain('  glob: true')
-      expect(result).toContain('  list: true')
-      expect(result).not.toContain('name:')
-      expect(result).toContain('Agent body content')
-    })
+			expect(result).toContain('description: Test agent')
+			expect(result).toContain('mode: subagent')
+			expect(result).toContain('tools:')
+			expect(result).toContain('  grep: true')
+			expect(result).toContain('  glob: true')
+			expect(result).toContain('  list: true')
+			expect(result).not.toContain('name:')
+			expect(result).not.toContain('model:')
+			expect(result).toContain('Agent body content')
+		})
 
-    it('should inject platform guidance for agents with filesystem tools', () => {
-      const input = `---
+		it('should inject platform guidance for agents with filesystem tools', () => {
+			const input = `---
 name: codebase-locator
 description: Locate files in codebase
 tools: Grep, Glob, LS
-model: sonnet
 ---
 
 Search the codebase for relevant files.`
 
-      const result = transformAgentFile(input)
+			const result = transformAgentFile(input)
 
-      expect(result).toContain('## Platform Compatibility')
-      expect(result).toContain('grep')
-      expect(result).toContain('glob')
-      expect(result).toContain('list')
-      expect(result).toContain('Search the codebase')
-    })
+			expect(result).toContain('## Platform Compatibility')
+			expect(result).toContain('grep')
+			expect(result).toContain('glob')
+			expect(result).toContain('list')
+			expect(result).toContain('Search the codebase')
+		})
 
-    it('should not inject platform guidance for agents without filesystem tools', () => {
-      const input = `---
+		it('should not inject platform guidance for agents without filesystem tools', () => {
+			const input = `---
 name: simple-agent
 description: Simple agent
 tools: Read, Write
-model: sonnet
 ---
 
 Just read and write files.`
 
-      const result = transformAgentFile(input)
+			const result = transformAgentFile(input)
 
-      expect(result).not.toContain('## Platform Compatibility')
-      expect(result).toContain('Just read and write files')
-    })
+			expect(result).not.toContain('## Platform Compatibility')
+			expect(result).toContain('Just read and write files')
+		})
 
-    it('should inject platform guidance when body references paths', () => {
-      const input = `---
+		it('should inject platform guidance when body references paths', () => {
+			const input = `---
 name: thoughts-agent
 description: Analyze thoughts
 tools: Read
-model: sonnet
 ---
 
 Check thoughts/shared/research directory for documentation.`
 
-      const result = transformAgentFile(input)
+			const result = transformAgentFile(input)
 
-      expect(result).toContain('## Platform Compatibility')
-      expect(result).toContain('thoughts/shared/research')
-    })
+			expect(result).toContain('## Platform Compatibility')
+			expect(result).toContain('thoughts/shared/research')
+		})
 
-    it('should handle missing tools field', () => {
-      const input = `---
+		it('should handle missing tools field', () => {
+			const input = `---
 name: no-tools
 description: Agent without tools
-model: opus
 ---
 
 Content without tools`
 
-      const result = transformAgentFile(input)
+			const result = transformAgentFile(input)
 
-      expect(result).toContain('description: Agent without tools')
-      expect(result).toContain('mode: subagent')
-      expect(result).not.toContain('tools:')
-      expect(result).toContain('Content without tools')
-    })
+			expect(result).toContain('description: Agent without tools')
+			expect(result).toContain('mode: subagent')
+			expect(result).not.toContain('tools:')
+			expect(result).toContain('Content without tools')
+		})
 
-    it('should handle missing frontmatter', () => {
-      const input = 'Just content without frontmatter'
-      const result = transformAgentFile(input)
+		it('should handle missing frontmatter', () => {
+			const input = 'Just content without frontmatter'
+			const result = transformAgentFile(input)
 
-      expect(result).toBe(input)
-    })
+			expect(result).toBe(input)
+		})
 
-    it('should use default description when missing', () => {
-      const input = `---
+		it('should use default description when missing', () => {
+			const input = `---
 name: test
 tools: Grep
 ---
 
 Content`
 
-      const result = transformAgentFile(input)
-      expect(result).toContain('description: Specialized agent')
-    })
+			const result = transformAgentFile(input)
+			expect(result).toContain('description: Specialized agent')
+		})
 
-    it('should handle Windows line endings', () => {
-      const input = `---\r\nname: test\r\ndescription: Test\r\ntools: Grep\r\n---\r\n\r\nContent`
-      const result = transformAgentFile(input)
+		it('should handle Windows line endings', () => {
+			const input = `---\r\nname: test\r\ndescription: Test\r\ntools: Grep\r\n---\r\n\r\nContent`
+			const result = transformAgentFile(input)
 
-      expect(result).toContain('description: Test')
-      expect(result).toContain('Content')
-    })
-  })
+			expect(result).toContain('description: Test')
+			expect(result).toContain('Content')
+		})
+	})
 
-  describe('transformSettings', () => {
-    it('should transform basic settings', () => {
-      const settings = {
-        model: 'opus',
-      }
+	describe('transformSettings', () => {
+		it('should transform basic settings', () => {
+			const settings = {}
 
-      const result = transformSettings(settings, {})
+			const result = transformSettings(settings)
 
-      expect(result.$schema).toBe('https://opencode.ai/config.json')
-      expect(result.model).toBe('anthropic/claude-opus-4')
-      expect(result.instructions).toEqual(['AGENTS.md'])
-    })
+			expect(result.$schema).toBe('https://opencode.ai/config.json')
+			expect(result.model).toBeUndefined()
+			expect(result.instructions).toEqual(['AGENTS.md'])
+		})
 
-    it('should use options.model over settings.model', () => {
-      const settings = {
-        model: 'sonnet',
-      }
+		it('should transform bash permissions', () => {
+			const settings = {
+				permissions: {
+					allow: ['Bash(./hack/spec_metadata.sh)', 'Bash(./hack/create_worktree.sh)'],
+				},
+			}
 
-      const result = transformSettings(settings, { model: 'haiku' })
-      expect(result.model).toBe('anthropic/claude-haiku-4-5')
-    })
+			const result = transformSettings(settings)
 
-    it('should transform bash permissions', () => {
-      const settings = {
-        model: 'opus',
-        permissions: {
-          allow: ['Bash(./hack/spec_metadata.sh)', 'Bash(./hack/create_worktree.sh)'],
-        },
-      }
+			expect(result.permission).toBeDefined()
+			expect(result.permission.bash).toEqual({
+				'./hack/spec_metadata.sh': 'allow',
+				'./hack/create_worktree.sh': 'allow',
+				'*': 'ask',
+			})
+		})
 
-      const result = transformSettings(settings, {})
+		it('should handle settings without permissions', () => {
+			const settings = {}
 
-      expect(result.permission).toBeDefined()
-      expect(result.permission.bash).toEqual({
-        './hack/spec_metadata.sh': 'allow',
-        './hack/create_worktree.sh': 'allow',
-        '*': 'ask',
-      })
-    })
+			const result = transformSettings(settings)
+			expect(result.permission).toBeUndefined()
+		})
+	})
 
-    it('should handle settings without permissions', () => {
-      const settings = {
-        model: 'sonnet',
-      }
+	describe('generateAgentsMd', () => {
+		it('should generate AGENTS.md content', () => {
+			const result = generateAgentsMd('/path/to/my-project')
 
-      const result = transformSettings(settings, {})
-      expect(result.permission).toBeUndefined()
-    })
+			expect(result).toContain('# my-project - OpenCode Configuration')
+			expect(result).toContain('Project Overview')
+			expect(result).toContain('Custom Commands')
+			expect(result).toContain('/create_plan')
+			expect(result).toContain('@codebase-locator')
+			expect(result).toContain('Code Conventions')
+		})
 
-    it('should default to opus when no model specified', () => {
-      const result = transformSettings({}, {})
-      expect(result.model).toBe('anthropic/claude-opus-4')
-    })
-  })
+		it('should use basename of project path', () => {
+			const result = generateAgentsMd('C:\\Users\\test\\projects\\awesome-app')
+			expect(result).toContain('# awesome-app - OpenCode Configuration')
+		})
 
-  describe('generateAgentsMd', () => {
-    it('should generate AGENTS.md content', () => {
-      const result = generateAgentsMd('/path/to/my-project')
+		it('should handle Unix paths', () => {
+			const result = generateAgentsMd('/home/user/projects/cool-project')
+			expect(result).toContain('# cool-project - OpenCode Configuration')
+		})
+	})
 
-      expect(result).toContain('# my-project - OpenCode Configuration')
-      expect(result).toContain('Project Overview')
-      expect(result).toContain('Custom Commands')
-      expect(result).toContain('/create_plan')
-      expect(result).toContain('@codebase-locator')
-      expect(result).toContain('Code Conventions')
-    })
-
-    it('should use basename of project path', () => {
-      const result = generateAgentsMd('C:\\Users\\test\\projects\\awesome-app')
-      expect(result).toContain('# awesome-app - OpenCode Configuration')
-    })
-
-    it('should handle Unix paths', () => {
-      const result = generateAgentsMd('/home/user/projects/cool-project')
-      expect(result).toContain('# cool-project - OpenCode Configuration')
-    })
-  })
-
-  describe('cross-platform line ending handling', () => {
-    it('should use platform EOL in transformCommandFile', () => {
-      const input = `---
+	describe('cross-platform line ending handling', () => {
+		it('should use platform EOL in transformCommandFile', () => {
+			const input = `---
 description: Test
 ---
 
 Content`
 
-      const result = transformCommandFile(input)
+			const result = transformCommandFile(input)
 
-      // Check that output uses system EOL
-      expect(result.split(EOL).length).toBeGreaterThan(1)
-    })
+			// Check that output uses system EOL
+			expect(result.split(EOL).length).toBeGreaterThan(1)
+		})
 
-    it('should use platform EOL in transformAgentFile', () => {
-      const input = `---
+		it('should use platform EOL in transformAgentFile', () => {
+			const input = `---
 name: test
 description: Test
 tools: Grep
@@ -457,10 +409,10 @@ tools: Grep
 
 Content`
 
-      const result = transformAgentFile(input)
+			const result = transformAgentFile(input)
 
-      // Check that output uses system EOL
-      expect(result.split(EOL).length).toBeGreaterThan(1)
-    })
-  })
+			// Check that output uses system EOL
+			expect(result.split(EOL).length).toBeGreaterThan(1)
+		})
+	})
 })

--- a/hlyr/src/commands/opencode/transform.test.ts
+++ b/hlyr/src/commands/opencode/transform.test.ts
@@ -65,48 +65,36 @@ describe('transform.ts', () => {
 	})
 
 	describe('needsPlatformGuidance', () => {
-		it('should return true for agents with grep tool', () => {
-			expect(needsPlatformGuidance({ grep: true }, 'some content')).toBe(true)
-		})
-
-		it('should return true for agents with glob tool', () => {
-			expect(needsPlatformGuidance({ glob: true }, 'some content')).toBe(true)
-		})
-
-		it('should return true for agents with list tool', () => {
-			expect(needsPlatformGuidance({ list: true }, 'some content')).toBe(true)
-		})
-
 		it('should return true when body contains thoughts/ reference', () => {
-			expect(needsPlatformGuidance(undefined, 'Check thoughts/shared/research')).toBe(true)
+			expect(needsPlatformGuidance('Check thoughts/shared/research')).toBe(true)
 		})
 
 		it('should return true when body contains codebase reference', () => {
-			expect(needsPlatformGuidance(undefined, 'Search the codebase for examples')).toBe(true)
+			expect(needsPlatformGuidance('Search the codebase for examples')).toBe(true)
 		})
 
 		it('should return true when body mentions directories', () => {
-			expect(needsPlatformGuidance(undefined, 'Check all directories in the project')).toBe(true)
-			expect(needsPlatformGuidance(undefined, 'List the directory contents')).toBe(true)
+			expect(needsPlatformGuidance('Check all directories in the project')).toBe(true)
+			expect(needsPlatformGuidance('List the directory contents')).toBe(true)
 		})
 
 		it('should return true when body mentions file paths', () => {
-			expect(needsPlatformGuidance(undefined, 'Provide the file path to the document')).toBe(true)
+			expect(needsPlatformGuidance('Provide the file path to the document')).toBe(true)
 		})
 
 		it('should return true when body references codebase agents', () => {
-			expect(needsPlatformGuidance(undefined, 'Use @codebase-locator to find files')).toBe(true)
-			expect(needsPlatformGuidance(undefined, 'Use @thoughts-locator agent')).toBe(true)
-			expect(needsPlatformGuidance(undefined, 'Invoke @codebase-analyzer')).toBe(true)
-			expect(needsPlatformGuidance(undefined, 'Use @codebase-pattern-finder')).toBe(true)
+			expect(needsPlatformGuidance('Use @codebase-locator to find files')).toBe(true)
+			expect(needsPlatformGuidance('Use @thoughts-locator agent')).toBe(true)
+			expect(needsPlatformGuidance('Invoke @codebase-analyzer')).toBe(true)
+			expect(needsPlatformGuidance('Use @codebase-pattern-finder')).toBe(true)
 		})
 
 		it('should return false when no platform guidance is needed', () => {
-			expect(needsPlatformGuidance({ read: true, write: true }, 'Simple content without paths')).toBe(false)
+			expect(needsPlatformGuidance('Simple content without paths')).toBe(false)
 		})
 
-		it('should return false for undefined tools and simple content', () => {
-			expect(needsPlatformGuidance(undefined, 'Simple task description')).toBe(false)
+		it('should return false for simple content', () => {
+			expect(needsPlatformGuidance('Simple task description')).toBe(false)
 		})
 	})
 

--- a/hlyr/src/commands/opencode/transform.ts
+++ b/hlyr/src/commands/opencode/transform.ts
@@ -1,0 +1,264 @@
+import path from 'path'
+
+export type ModelType = 'haiku' | 'sonnet' | 'opus'
+
+/**
+ * Transform short model names to full Anthropic model names
+ */
+export function transformModelName(model: string | undefined): string {
+  if (!model) return 'anthropic/claude-opus-4'
+
+  const modelMap: Record<string, string> = {
+    opus: 'anthropic/claude-opus-4',
+    sonnet: 'anthropic/claude-sonnet-4-5',
+    haiku: 'anthropic/claude-haiku-4-5',
+  }
+
+  // Return mapped value or pass through if already a full name
+  return modelMap[model] || model
+}
+
+/**
+ * Parse Claude tools string (comma-separated) to OpenCode tools object
+ */
+export function parseClaudeTools(toolsString: string): Record<string, boolean> {
+  const tools: Record<string, boolean> = {}
+
+  const toolMap: Record<string, string> = {
+    Grep: 'grep',
+    Glob: 'glob',
+    LS: 'list',
+    Read: 'read',
+    Write: 'write',
+    Edit: 'edit',
+    Bash: 'bash',
+    Task: 'task',
+    TodoWrite: 'todowrite',
+    TodoRead: 'todoread',
+  }
+
+  const parts = toolsString.split(',').map(s => s.trim())
+
+  for (const part of parts) {
+    const normalizedName = toolMap[part] || part.toLowerCase()
+    tools[normalizedName] = true
+  }
+
+  return tools
+}
+
+/**
+ * Transform command file from Claude format to OpenCode format
+ */
+export function transformCommandFile(content: string): string {
+  // Parse frontmatter and body
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/)
+
+  if (!frontmatterMatch) {
+    // No frontmatter - treat entire content as template
+    return `---\ndescription: Custom command\n---\n\n${content}`
+  }
+
+  const [, frontmatter, body] = frontmatterMatch
+  const lines = frontmatter.split('\n')
+  const fm: Record<string, any> = {}
+
+  // Parse YAML frontmatter
+  for (const line of lines) {
+    const match = line.match(/^(\w+):\s*(.*)$/)
+    if (match) {
+      fm[match[1]] = match[2]
+    }
+  }
+
+  // Transform body content
+  let transformedContent = body.trim()
+
+  // Transform: SlashCommand() calls -> just the command
+  // Example: "use SlashCommand() to call /ralph_research" -> "use /ralph_research"
+  transformedContent = transformedContent.replace(
+    /use SlashCommand\(\) to call (\/[\w_-]+)/g,
+    'use $1',
+  )
+
+  // Transform: npx humanlayer launch commands -> OpenCode equivalent
+  // These commands don't make sense in OpenCode (commands run in same session)
+  transformedContent = transformedContent.replace(
+    /launch a new session with `npx humanlayer launch[^`]+`/g,
+    '(Note: In OpenCode, commands run in the same session - no need to launch separate sessions)',
+  )
+
+  transformedContent = transformedContent.replace(/humanlayer launch[^\n]+/g, match => {
+    // Keep on separate line with note
+    return '(OpenCode note: This workflow is specific to Claude Code - adapt as needed for OpenCode)'
+  })
+
+  // Transform: Task() pseudo-code examples -> @agent syntax
+  transformedContent = transformedContent.replace(/Task\("([^"]+)",\s*([^)]+)\)/g, (match, desc) => {
+    return `@subagent with prompt: "${desc}"`
+  })
+
+  // Build new frontmatter
+  let newFrontmatter = '---\n'
+  newFrontmatter += `description: ${fm.description || 'Custom command'}\n`
+  if (fm.model) {
+    newFrontmatter += `model: ${transformModelName(fm.model)}\n`
+  }
+  if (fm.agent) {
+    newFrontmatter += `agent: ${fm.agent}\n`
+  }
+  if (fm.subtask !== undefined) {
+    newFrontmatter += `subtask: ${fm.subtask}\n`
+  }
+  newFrontmatter += '---\n\n'
+
+  return newFrontmatter + transformedContent
+}
+
+/**
+ * Transform agent file from Claude format to OpenCode format
+ */
+export function transformAgentFile(content: string): string {
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/)
+
+  if (!frontmatterMatch) {
+    return content // Return as-is if no frontmatter
+  }
+
+  const [, frontmatter, body] = frontmatterMatch
+  const lines = frontmatter.split('\n')
+  const fm: Record<string, any> = {}
+
+  // Parse YAML frontmatter
+  for (const line of lines) {
+    const match = line.match(/^(\w+):\s*(.*)$/)
+    if (match) {
+      fm[match[1]] = match[2]
+    }
+  }
+
+  // Build OpenCode frontmatter
+  let newFrontmatter = '---\n'
+
+  // description (required)
+  newFrontmatter += `description: ${fm.description || 'Specialized agent'}\n`
+
+  // mode (all agents in .claude are subagents)
+  newFrontmatter += `mode: subagent\n`
+
+  // model (transform short names)
+  if (fm.model) {
+    newFrontmatter += `model: ${transformModelName(fm.model)}\n`
+  }
+
+  // tools (transform from string to object)
+  if (fm.tools) {
+    const toolsObj = parseClaudeTools(fm.tools)
+    newFrontmatter += `tools:\n`
+    for (const [tool, enabled] of Object.entries(toolsObj)) {
+      newFrontmatter += `  ${tool}: ${enabled}\n`
+    }
+  }
+
+  // Note: We remove 'name' field - filename becomes the agent name in OpenCode
+
+  newFrontmatter += '---\n\n'
+
+  return newFrontmatter + body.trim()
+}
+
+/**
+ * Transform Claude settings.json to OpenCode opencode.json with helpful comments
+ */
+export function transformSettings(
+  settings: any,
+  options: { model?: ModelType },
+): Record<string, any> {
+  const config: Record<string, any> = {
+    $schema: 'https://opencode.ai/config.json',
+  }
+
+  // Transform model with comment
+  config['//model'] = 'Default model for OpenCode sessions. See: opencode models'
+  config.model = transformModelName(options.model || settings.model || 'opus')
+
+  // Transform permissions from Claude format to OpenCode format
+  if (settings.permissions?.allow) {
+    config['//permission'] =
+      'Controls what actions require approval. Options: "ask", "allow", "deny"'
+    config.permission = {}
+
+    // Parse Claude permissions
+    const bashPermissions: Record<string, string> = {}
+
+    for (const perm of settings.permissions.allow) {
+      // Example: "Bash(./hack/spec_metadata.sh)" -> bash permission
+      const bashMatch = perm.match(/^Bash\((.+)\)$/)
+      if (bashMatch) {
+        bashPermissions[bashMatch[1]] = 'allow'
+      }
+    }
+
+    if (Object.keys(bashPermissions).length > 0) {
+      config.permission.bash = {
+        ...bashPermissions,
+        '*': 'ask', // Default to asking for other commands
+      }
+    }
+  }
+
+  // Add instructions reference (for AGENTS.md if created)
+  config['//instructions'] = 'Additional instruction files to include in context'
+  config.instructions = ['AGENTS.md']
+
+  // Add tools section with helpful comment
+  config['//tools'] = 'Control which tools are available. Set to false to disable specific tools.'
+
+  // Drop Claude-specific settings that don't apply to OpenCode:
+  // - enableAllProjectMcpServers (OpenCode handles MCP differently)
+  // - env.MAX_THINKING_TOKENS (thinking mode is Claude-specific)
+  // - env.CLAUDE_BASH_MAINTAIN_WORKING_DIR (Claude-specific)
+  // - alwaysThinkingEnabled (Claude-specific)
+
+  return config
+}
+
+/**
+ * Generate AGENTS.md template for a project
+ */
+export function generateAgentsMd(projectPath: string): string {
+  const projectName = path.basename(projectPath)
+
+  return `# ${projectName} - OpenCode Configuration
+
+This file contains custom instructions for OpenCode when working in this project.
+
+## Project Overview
+
+[Add project description here]
+
+## Custom Commands
+
+This project includes HumanLayer workflow commands and agents initialized via \`humanlayer opencode init\`.
+
+Available in \`.opencode/command/\`:
+- Planning workflows (\`/create_plan\`, \`/implement_plan\`)
+- Code analysis (\`/research_codebase\`)
+- CI/CD helpers (\`/commit\`, \`/describe_pr\`)
+- And many more - see \`.opencode/command/\` for full list
+
+Available agents in \`.opencode/agent/\`:
+- \`@codebase-locator\` - Find files and components
+- \`@codebase-analyzer\` - Analyze code structure
+- \`@thoughts-analyzer\` - Process developer notes
+- And more - see \`.opencode/agent/\` for full list
+
+## Code Conventions
+
+[Add project-specific conventions here]
+
+## Important Notes
+
+[Add any critical information here]
+`
+}

--- a/hlyr/src/commands/opencode/transform.ts
+++ b/hlyr/src/commands/opencode/transform.ts
@@ -1,280 +1,248 @@
 import path from 'path'
 import os from 'os'
 
-export type ModelType = 'haiku' | 'sonnet' | 'opus'
-
 // Use platform-specific line ending
 const EOL = os.EOL
-
-/**
- * Transform short model names to full Anthropic model names
- */
-export function transformModelName(model: string | undefined): string {
-  if (!model) return 'anthropic/claude-opus-4'
-
-  const modelMap: Record<string, string> = {
-    opus: 'anthropic/claude-opus-4',
-    sonnet: 'anthropic/claude-sonnet-4-5',
-    haiku: 'anthropic/claude-haiku-4-5',
-  }
-
-  // Return mapped value or pass through if already a full name
-  return modelMap[model] || model
-}
 
 /**
  * Parse Claude tools string (comma-separated) to OpenCode tools object
  */
 export function parseClaudeTools(toolsString: string): Record<string, boolean> {
-  const tools: Record<string, boolean> = {}
+	const tools: Record<string, boolean> = {}
 
-  const toolMap: Record<string, string> = {
-    Grep: 'grep',
-    Glob: 'glob',
-    LS: 'list',
-    Read: 'read',
-    Write: 'write',
-    Edit: 'edit',
-    Bash: 'bash',
-    Task: 'task',
-    TodoWrite: 'todowrite',
-    TodoRead: 'todoread',
-  }
+	const toolMap: Record<string, string> = {
+		Grep: 'grep',
+		Glob: 'glob',
+		LS: 'list',
+		Read: 'read',
+		Write: 'write',
+		Edit: 'edit',
+		Bash: 'bash',
+		Task: 'task',
+		TodoWrite: 'todowrite',
+		TodoRead: 'todoread',
+	}
 
-  const parts = toolsString.split(',').map(s => s.trim())
+	const parts = toolsString.split(',').map((s) => s.trim())
 
-  for (const part of parts) {
-    const normalizedName = toolMap[part] || part.toLowerCase()
-    tools[normalizedName] = true
-  }
+	for (const part of parts) {
+		const normalizedName = toolMap[part] || part.toLowerCase()
+		tools[normalizedName] = true
+	}
 
-  return tools
+	return tools
 }
 
 /**
  * Check if content needs cross-platform guidance
  * Returns true if the content uses filesystem tools or references paths/directories
  */
-export function needsPlatformGuidance(
-  tools: Record<string, boolean> | undefined,
-  body: string,
-): boolean {
-  // Check if uses file-system tools
-  if (tools) {
-    const fsTools = ['grep', 'glob', 'list']
-    if (fsTools.some(tool => tools[tool])) {
-      return true
-    }
-  }
+export function needsPlatformGuidance(tools: Record<string, boolean> | undefined, body: string): boolean {
+	// Check if uses file-system tools
+	if (tools) {
+		const fsTools = ['grep', 'glob', 'list']
+		if (fsTools.some((tool) => tools[tool])) {
+			return true
+		}
+	}
 
-  // Check if body references paths/directories
-  const pathPatterns = [
-    /thoughts\//i,
-    /codebase/i,
-    /directory|directories/i,
-    /file path/i,
-    /@codebase-locator/i,
-    /@thoughts-locator/i,
-    /@codebase-analyzer/i,
-    /@codebase-pattern-finder/i,
-  ]
+	// Check if body references paths/directories
+	const pathPatterns = [
+		/thoughts\//i,
+		/codebase/i,
+		/directory|directories/i,
+		/file path/i,
+		/@codebase-locator/i,
+		/@thoughts-locator/i,
+		/@codebase-analyzer/i,
+		/@codebase-pattern-finder/i,
+	]
 
-  return pathPatterns.some(pattern => pattern.test(body))
+	return pathPatterns.some((pattern) => pattern.test(body))
 }
 
 /**
  * Generate concise cross-platform compatibility guidance
  */
 export function generatePlatformGuidance(): string {
-  return `## Platform Compatibility${EOL}${EOL}**IMPORTANT**: The \`grep\`, \`glob\`, and \`list\` tools automatically handle path separators for your platform (Windows, macOS, Linux).${EOL}${EOL}- Always use forward slashes (\`/\`) in search patterns and file paths - they work cross-platform${EOL}- Tools normalize paths to your platform's native format automatically${EOL}- Never manually construct platform-specific paths${EOL}- Let the tools handle cross-platform operation${EOL}${EOL}`
+	return `## Platform Compatibility${EOL}${EOL}**IMPORTANT**: The \`grep\`, \`glob\`, and \`list\` tools automatically handle path separators for your platform (Windows, macOS, Linux).${EOL}${EOL}- Always use forward slashes (\`/\`) in search patterns and file paths - they work cross-platform${EOL}- Tools normalize paths to your platform's native format automatically${EOL}- Never manually construct platform-specific paths${EOL}- Let the tools handle cross-platform operation${EOL}${EOL}`
 }
 
 /**
  * Transform command file from Claude format to OpenCode format
  */
 export function transformCommandFile(content: string): string {
-  // Parse frontmatter and body
-  // Handle both \n and \r\n line endings
-  const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/)
+	// Parse frontmatter and body
+	// Handle both \n and \r\n line endings
+	const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/)
 
-  if (!frontmatterMatch) {
-    // No frontmatter - treat entire content as template
-    return `---${EOL}description: Custom command${EOL}---${EOL}${EOL}${content}`
-  }
+	if (!frontmatterMatch) {
+		// No frontmatter - treat entire content as template
+		return `---${EOL}description: Custom command${EOL}---${EOL}${EOL}${content}`
+	}
 
-  const [, frontmatter, body] = frontmatterMatch
-  const lines = frontmatter.split(/\r?\n/)
-  const fm: Record<string, any> = {}
+	const [, frontmatter, body] = frontmatterMatch
+	const lines = frontmatter.split(/\r?\n/)
+	const fm: Record<string, any> = {}
 
-  // Parse YAML frontmatter
-  for (const line of lines) {
-    const match = line.match(/^(\w+):\s*(.*)$/)
-    if (match) {
-      fm[match[1]] = match[2]
-    }
-  }
+	// Parse YAML frontmatter
+	for (const line of lines) {
+		const match = line.match(/^(\w+):\s*(.*)$/)
+		if (match) {
+			fm[match[1]] = match[2]
+		}
+	}
 
-  // Transform body content
-  let transformedContent = body.trim()
+	// Transform body content
+	let transformedContent = body.trim()
 
-  // Transform: SlashCommand() calls -> just the command
-  // Example: "use SlashCommand() to call /ralph_research" -> "use /ralph_research"
-  transformedContent = transformedContent.replace(/use SlashCommand\(\) to call (\/[\w_-]+)/g, 'use $1')
+	// Transform: SlashCommand() calls -> just the command
+	// Example: "use SlashCommand() to call /ralph_research" -> "use /ralph_research"
+	transformedContent = transformedContent.replace(/use SlashCommand\(\) to call (\/[\w_-]+)/g, 'use $1')
 
-  // Transform: npx humanlayer launch commands -> OpenCode equivalent
-  // These commands don't make sense in OpenCode (commands run in same session)
-  transformedContent = transformedContent.replace(
-    /launch a new session with `npx humanlayer launch[^`]+`/g,
-    '(Note: In OpenCode, commands run in the same session - no need to launch separate sessions)',
-  )
+	// Transform: npx humanlayer launch commands -> OpenCode equivalent
+	// These commands don't make sense in OpenCode (commands run in same session)
+	transformedContent = transformedContent.replace(
+		/launch a new session with `npx humanlayer launch[^`]+`/g,
+		'(Note: In OpenCode, commands run in the same session - no need to launch separate sessions)',
+	)
 
-  transformedContent = transformedContent.replace(/humanlayer launch[^\n]+/g, match => {
-    // Keep on separate line with note
-    return '(OpenCode note: This workflow is specific to Claude Code - adapt as needed for OpenCode)'
-  })
+	transformedContent = transformedContent.replace(/humanlayer launch[^\n]+/g, (match) => {
+		// Keep on separate line with note
+		return '(OpenCode note: This workflow is specific to Claude Code - adapt as needed for OpenCode)'
+	})
 
-  // Transform: Task() pseudo-code examples -> @agent syntax
-  transformedContent = transformedContent.replace(/Task\("([^"]+)",\s*([^)]+)\)/g, (match, desc) => {
-    return `@subagent with prompt: "${desc}"`
-  })
+	// Transform: Task() pseudo-code examples -> @agent syntax
+	transformedContent = transformedContent.replace(/Task\("([^"]+)",\s*([^)]+)\)/g, (match, desc) => {
+		return `@subagent with prompt: "${desc}"`
+	})
 
-  // Build new frontmatter
-  let newFrontmatter = `---${EOL}`
-  newFrontmatter += `description: ${fm.description || 'Custom command'}${EOL}`
-  if (fm.model) {
-    newFrontmatter += `model: ${transformModelName(fm.model)}${EOL}`
-  }
-  if (fm.agent) {
-    newFrontmatter += `agent: ${fm.agent}${EOL}`
-  }
-  if (fm.subtask !== undefined) {
-    newFrontmatter += `subtask: ${fm.subtask}${EOL}`
-  }
-  newFrontmatter += `---${EOL}${EOL}`
+	// Build new frontmatter
+	let newFrontmatter = `---${EOL}`
+	newFrontmatter += `description: ${fm.description || 'Custom command'}${EOL}`
+	if (fm.agent) {
+		newFrontmatter += `agent: ${fm.agent}${EOL}`
+	}
+	if (fm.subtask !== undefined) {
+		newFrontmatter += `subtask: ${fm.subtask}${EOL}`
+	}
+	newFrontmatter += `---${EOL}${EOL}`
 
-  // Inject platform guidance if needed
-  if (needsPlatformGuidance(undefined, transformedContent)) {
-    return newFrontmatter + generatePlatformGuidance() + transformedContent
-  }
+	// Inject platform guidance if needed
+	if (needsPlatformGuidance(undefined, transformedContent)) {
+		return newFrontmatter + generatePlatformGuidance() + transformedContent
+	}
 
-  return newFrontmatter + transformedContent
+	return newFrontmatter + transformedContent
 }
 
 /**
  * Transform agent file from Claude format to OpenCode format
  */
 export function transformAgentFile(content: string): string {
-  // Handle both \n and \r\n line endings
-  const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/)
+	// Handle both \n and \r\n line endings
+	const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/)
 
-  if (!frontmatterMatch) {
-    return content // Return as-is if no frontmatter
-  }
+	if (!frontmatterMatch) {
+		return content // Return as-is if no frontmatter
+	}
 
-  const [, frontmatter, body] = frontmatterMatch
-  const lines = frontmatter.split(/\r?\n/)
-  const fm: Record<string, any> = {}
+	const [, frontmatter, body] = frontmatterMatch
+	const lines = frontmatter.split(/\r?\n/)
+	const fm: Record<string, any> = {}
 
-  // Parse YAML frontmatter
-  for (const line of lines) {
-    const match = line.match(/^(\w+):\s*(.*)$/)
-    if (match) {
-      fm[match[1]] = match[2]
-    }
-  }
+	// Parse YAML frontmatter
+	for (const line of lines) {
+		const match = line.match(/^(\w+):\s*(.*)$/)
+		if (match) {
+			fm[match[1]] = match[2]
+		}
+	}
 
-  // Build OpenCode frontmatter
-  let newFrontmatter = `---${EOL}`
+	// Build OpenCode frontmatter
+	let newFrontmatter = `---${EOL}`
 
-  // description (required)
-  newFrontmatter += `description: ${fm.description || 'Specialized agent'}${EOL}`
+	// description (required)
+	newFrontmatter += `description: ${fm.description || 'Specialized agent'}${EOL}`
 
-  // mode (all agents in .claude are subagents)
-  newFrontmatter += `mode: subagent${EOL}`
+	// mode (all agents in .claude are subagents)
+	newFrontmatter += `mode: subagent${EOL}`
 
-  // model (transform short names)
-  if (fm.model) {
-    newFrontmatter += `model: ${transformModelName(fm.model)}${EOL}`
-  }
+	// tools (transform from string to object)
+	if (fm.tools) {
+		const toolsObj = parseClaudeTools(fm.tools)
+		newFrontmatter += `tools:${EOL}`
+		for (const [tool, enabled] of Object.entries(toolsObj)) {
+			newFrontmatter += `  ${tool}: ${enabled}${EOL}`
+		}
+	}
 
-  // tools (transform from string to object)
-  if (fm.tools) {
-    const toolsObj = parseClaudeTools(fm.tools)
-    newFrontmatter += `tools:${EOL}`
-    for (const [tool, enabled] of Object.entries(toolsObj)) {
-      newFrontmatter += `  ${tool}: ${enabled}${EOL}`
-    }
-  }
+	// Note: We remove 'name' field - filename becomes the agent name in OpenCode
 
-  // Note: We remove 'name' field - filename becomes the agent name in OpenCode
+	newFrontmatter += `---${EOL}${EOL}`
 
-  newFrontmatter += `---${EOL}${EOL}`
+	// Parse tools for guidance detection
+	const toolsObj = fm.tools ? parseClaudeTools(fm.tools) : undefined
+	const bodyContent = body.trim()
 
-  // Parse tools for guidance detection
-  const toolsObj = fm.tools ? parseClaudeTools(fm.tools) : undefined
-  const bodyContent = body.trim()
+	// Inject platform guidance if needed
+	if (needsPlatformGuidance(toolsObj, bodyContent)) {
+		return newFrontmatter + generatePlatformGuidance() + bodyContent
+	}
 
-  // Inject platform guidance if needed
-  if (needsPlatformGuidance(toolsObj, bodyContent)) {
-    return newFrontmatter + generatePlatformGuidance() + bodyContent
-  }
-
-  return newFrontmatter + bodyContent
+	return newFrontmatter + bodyContent
 }
 
 /**
  * Transform Claude settings.json to OpenCode opencode.json
  */
-export function transformSettings(settings: any, options: { model?: ModelType }): Record<string, any> {
-  const config: Record<string, any> = {
-    $schema: 'https://opencode.ai/config.json',
-  }
+export function transformSettings(settings: any): Record<string, any> {
+	const config: Record<string, any> = {
+		$schema: 'https://opencode.ai/config.json',
+	}
 
-  // Transform model
-  config.model = transformModelName(options.model || settings.model || 'opus')
+	// Transform permissions from Claude format to OpenCode format
+	if (settings.permissions?.allow) {
+		config.permission = {}
 
-  // Transform permissions from Claude format to OpenCode format
-  if (settings.permissions?.allow) {
-    config.permission = {}
+		// Parse Claude permissions
+		const bashPermissions: Record<string, string> = {}
 
-    // Parse Claude permissions
-    const bashPermissions: Record<string, string> = {}
+		for (const perm of settings.permissions.allow) {
+			// Example: "Bash(./hack/spec_metadata.sh)" -> bash permission
+			const bashMatch = perm.match(/^Bash\((.+)\)$/)
+			if (bashMatch) {
+				bashPermissions[bashMatch[1]] = 'allow'
+			}
+		}
 
-    for (const perm of settings.permissions.allow) {
-      // Example: "Bash(./hack/spec_metadata.sh)" -> bash permission
-      const bashMatch = perm.match(/^Bash\((.+)\)$/)
-      if (bashMatch) {
-        bashPermissions[bashMatch[1]] = 'allow'
-      }
-    }
+		if (Object.keys(bashPermissions).length > 0) {
+			config.permission.bash = {
+				...bashPermissions,
+				'*': 'ask', // Default to asking for other commands
+			}
+		}
+	}
 
-    if (Object.keys(bashPermissions).length > 0) {
-      config.permission.bash = {
-        ...bashPermissions,
-        '*': 'ask', // Default to asking for other commands
-      }
-    }
-  }
+	// Add instructions reference (for AGENTS.md if created)
+	config.instructions = ['AGENTS.md']
 
-  // Add instructions reference (for AGENTS.md if created)
-  config.instructions = ['AGENTS.md']
+	// Drop Claude-specific settings that don't apply to OpenCode:
+	// - enableAllProjectMcpServers (OpenCode handles MCP differently)
+	// - env.MAX_THINKING_TOKENS (thinking mode is Claude-specific)
+	// - env.CLAUDE_BASH_MAINTAIN_WORKING_DIR (Claude-specific)
+	// - alwaysThinkingEnabled (Claude-specific)
 
-  // Drop Claude-specific settings that don't apply to OpenCode:
-  // - enableAllProjectMcpServers (OpenCode handles MCP differently)
-  // - env.MAX_THINKING_TOKENS (thinking mode is Claude-specific)
-  // - env.CLAUDE_BASH_MAINTAIN_WORKING_DIR (Claude-specific)
-  // - alwaysThinkingEnabled (Claude-specific)
-
-  return config
+	return config
 }
 
 /**
  * Generate AGENTS.md template for a project
  */
 export function generateAgentsMd(projectPath: string): string {
-  const projectName = path.basename(projectPath)
+	const projectName = path.basename(projectPath)
 
-  return `# ${projectName} - OpenCode Configuration
+	return `# ${projectName} - OpenCode Configuration
 
 This file contains custom instructions for OpenCode when working in this project.
 

--- a/hlyr/src/index.ts
+++ b/hlyr/src/index.ts
@@ -6,6 +6,7 @@ import { configShowCommand } from './commands/configShow.js'
 import { launchCommand } from './commands/launch.js'
 import { thoughtsCommand } from './commands/thoughts.js'
 import { claudeCommand } from './commands/claude.js'
+import { opencodeCommand } from './commands/opencode.js'
 import { joinWaitlistCommand } from './commands/joinWaitlist.js'
 import { startClaudeApprovalsMCPServer } from './mcp.js'
 import { getDefaultConfigPath } from './config.js'
@@ -87,6 +88,9 @@ thoughtsCommand(program)
 
 // Add claude command
 claudeCommand(program)
+
+// Add opencode command
+opencodeCommand(program)
 
 // Add join-waitlist command
 program

--- a/hlyr/tests/opencodeInit.e2e.test.ts
+++ b/hlyr/tests/opencodeInit.e2e.test.ts
@@ -1,0 +1,557 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawn } from 'child_process'
+import { promises as fs } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+describe('opencode init e2e tests', () => {
+  let tempDir: string
+  let testProjectDir: string
+
+  beforeEach(async () => {
+    // Create temp directory for test projects
+    tempDir = await fs.mkdtemp(join(tmpdir(), 'opencode-init-test-'))
+    testProjectDir = join(tempDir, 'test-project')
+    await fs.mkdir(testProjectDir, { recursive: true })
+  })
+
+  afterEach(async () => {
+    // Cleanup temp files
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true })
+    } catch {
+      // Ignore cleanup errors
+    }
+  })
+
+  describe('--all flag', () => {
+    it('should copy all files without prompting', async () => {
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('Successfully copied')
+
+      // Verify directories were created
+      const opencodeDir = join(testProjectDir, '.opencode')
+      expect(
+        await fs
+          .stat(opencodeDir)
+          .then(() => true)
+          .catch(() => false),
+      ).toBe(true)
+
+      const commandDir = join(opencodeDir, 'command') // SINGULAR
+      const agentDir = join(opencodeDir, 'agent') // SINGULAR
+      const configFile = join(opencodeDir, 'opencode.json')
+
+      expect(
+        await fs
+          .stat(commandDir)
+          .then(() => true)
+          .catch(() => false),
+      ).toBe(true)
+      expect(
+        await fs
+          .stat(agentDir)
+          .then(() => true)
+          .catch(() => false),
+      ).toBe(true)
+      expect(
+        await fs
+          .stat(configFile)
+          .then(() => true)
+          .catch(() => false),
+      ).toBe(true)
+
+      // Verify .gitignore was updated
+      const gitignorePath = join(testProjectDir, '.gitignore')
+      const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
+      expect(gitignoreContent).toContain('.opencode/opencode.local.json')
+    }, 15000)
+
+    it('should work in non-TTY environment with --all flag', async () => {
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir, {
+        isTTY: false,
+      })
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('Successfully copied')
+
+      // Verify files were created
+      const opencodeDir = join(testProjectDir, '.opencode')
+      expect(
+        await fs
+          .stat(opencodeDir)
+          .then(() => true)
+          .catch(() => false),
+      ).toBe(true)
+    }, 15000)
+  })
+
+  describe('--force flag', () => {
+    it('should overwrite existing .opencode directory without prompting', async () => {
+      // Create existing .opencode directory with a command file
+      const opencodeDir = join(testProjectDir, '.opencode')
+      const commandDir = join(opencodeDir, 'command')
+      await fs.mkdir(commandDir, { recursive: true })
+      const testFile = join(commandDir, 'existing_command.md')
+      await fs.writeFile(testFile, '# Existing Command\nOld content')
+
+      const result = await runCommand(['opencode', 'init', '--all', '--force'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('Successfully copied')
+
+      // Verify that new files were copied (directory was overwritten)
+      const commandFiles = await fs.readdir(commandDir)
+      expect(commandFiles.length).toBeGreaterThan(1)
+
+      // The old test file should not exist if it wasn't in the source
+      // Or should be overwritten if it was - either way, verify command directory exists
+      expect(
+        await fs
+          .stat(commandDir)
+          .then(() => true)
+          .catch(() => false),
+      ).toBe(true)
+    }, 15000)
+  })
+
+  describe('non-TTY environment', () => {
+    it('should fail without --all flag in non-TTY environment', async () => {
+      const result = await runCommand(['opencode', 'init'], testProjectDir, {
+        isTTY: false,
+      })
+
+      expect(result.exitCode).toBe(1)
+
+      // Check both stdout and stderr for error message
+      const output = result.stdout + result.stderr
+      expect(output).toContain('Not running in interactive terminal')
+      expect(output).toContain('Use --all flag')
+    }, 15000)
+  })
+
+  describe('source directory validation', () => {
+    it('should handle missing source directory gracefully', async () => {
+      // This test may pass or fail depending on where tests are run from
+      // The important thing is it should fail gracefully with a clear error message
+      // For now, we'll just verify the command runs
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+      // Either succeeds (source found) or fails with clear error (source not found)
+      if (result.exitCode !== 0) {
+        expect(result.stderr).toContain('Source .claude directory not found')
+      } else {
+        expect(result.stdout).toContain('Successfully copied')
+      }
+    }, 15000)
+  })
+
+  describe('file counting', () => {
+    it('should accurately count files copied', async () => {
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+
+      // Extract file count from output
+      const match = result.stdout.match(/Successfully copied (\d+) file/)
+      expect(match).toBeTruthy()
+
+      if (match) {
+        const fileCount = parseInt(match[1], 10)
+        expect(fileCount).toBeGreaterThan(0)
+      }
+    }, 15000)
+  })
+
+  describe('.gitignore management', () => {
+    it('should create .gitignore if it does not exist', async () => {
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+
+      const gitignorePath = join(testProjectDir, '.gitignore')
+      const gitignoreExists = await fs
+        .stat(gitignorePath)
+        .then(() => true)
+        .catch(() => false)
+      expect(gitignoreExists).toBe(true)
+
+      const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
+      expect(gitignoreContent).toContain('.opencode/opencode.local.json')
+      expect(gitignoreContent).toContain('# OpenCode local settings')
+    }, 15000)
+
+    it('should append to existing .gitignore', async () => {
+      const gitignorePath = join(testProjectDir, '.gitignore')
+      await fs.writeFile(gitignorePath, '# Existing content\nnode_modules/\n')
+
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+
+      const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
+      expect(gitignoreContent).toContain('# Existing content')
+      expect(gitignoreContent).toContain('node_modules/')
+      expect(gitignoreContent).toContain('.opencode/opencode.local.json')
+    }, 15000)
+
+    it('should not duplicate .gitignore entry', async () => {
+      const gitignorePath = join(testProjectDir, '.gitignore')
+      await fs.writeFile(
+        gitignorePath,
+        '# OpenCode local settings\n.opencode/opencode.local.json\n',
+      )
+
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+
+      const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
+      const matches = gitignoreContent.match(/\.opencode\/opencode\.local\.json/g)
+      expect(matches?.length).toBe(1)
+    }, 15000)
+  })
+
+  describe('output formatting', () => {
+    it('should use @clack/prompts styling', async () => {
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+
+      // Check for clack-style output (intro/outro)
+      expect(result.stdout).toContain('Initialize OpenCode Configuration')
+      expect(result.stdout).toContain('Successfully copied')
+      expect(result.stdout).toContain('You can now use these commands')
+    }, 15000)
+  })
+
+  describe('error handling', () => {
+    it('should handle errors gracefully', async () => {
+      // Try to run in a read-only directory (if possible)
+      // This test is platform-dependent and may be skipped
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+      // Command should either succeed or fail with a clear error message
+      if (result.exitCode !== 0) {
+        expect(result.stderr).toBeTruthy()
+        expect(result.stderr.length).toBeGreaterThan(0)
+      }
+    }, 15000)
+  })
+
+  describe('model configuration', () => {
+    it('should set model to opus by default', async () => {
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+
+      const configPath = join(testProjectDir, '.opencode', 'opencode.json')
+      const configContent = await fs.readFile(configPath, 'utf8')
+      const config = JSON.parse(configContent)
+
+      expect(config.model).toBe('anthropic/claude-opus-4')
+    }, 15000)
+
+    it('should set model when --model flag is used with opus', async () => {
+      const result = await runCommand(['opencode', 'init', '--all', '--model', 'opus'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+
+      const configPath = join(testProjectDir, '.opencode', 'opencode.json')
+      const configContent = await fs.readFile(configPath, 'utf8')
+      const config = JSON.parse(configContent)
+
+      expect(config.model).toBe('anthropic/claude-opus-4')
+    }, 15000)
+
+    it('should set model when --model flag is used with sonnet', async () => {
+      const result = await runCommand(
+        ['opencode', 'init', '--all', '--model', 'sonnet'],
+        testProjectDir,
+      )
+
+      expect(result.exitCode).toBe(0)
+
+      const configPath = join(testProjectDir, '.opencode', 'opencode.json')
+      const configContent = await fs.readFile(configPath, 'utf8')
+      const config = JSON.parse(configContent)
+
+      expect(config.model).toBe('anthropic/claude-sonnet-4-5')
+    }, 15000)
+
+    it('should set model when --model flag is used with haiku', async () => {
+      const result = await runCommand(['opencode', 'init', '--all', '--model', 'haiku'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+
+      const configPath = join(testProjectDir, '.opencode', 'opencode.json')
+      const configContent = await fs.readFile(configPath, 'utf8')
+      const config = JSON.parse(configContent)
+
+      expect(config.model).toBe('anthropic/claude-haiku-4-5')
+    }, 15000)
+
+    it('should reject invalid model values', async () => {
+      const result = await runCommand(
+        ['opencode', 'init', '--all', '--model', 'invalid'],
+        testProjectDir,
+      )
+
+      expect(result.exitCode).toBe(1)
+      const output = result.stdout + result.stderr
+      expect(output).toContain('Invalid model')
+      expect(output).toContain('haiku, sonnet, opus')
+    }, 15000)
+
+    it('should combine model with other settings flags', async () => {
+      const result = await runCommand(
+        [
+          'opencode',
+          'init',
+          '--all',
+          '--model',
+          'haiku',
+          '--no-always-thinking',
+          '--max-thinking-tokens',
+          '50000',
+        ],
+        testProjectDir,
+      )
+
+      expect(result.exitCode).toBe(0)
+
+      const configPath = join(testProjectDir, '.opencode', 'opencode.json')
+      const configContent = await fs.readFile(configPath, 'utf8')
+      const config = JSON.parse(configContent)
+
+      expect(config.model).toBe('anthropic/claude-haiku-4-5')
+      // Thinking flags are accepted but ignored for OpenCode
+    }, 15000)
+  })
+
+  describe('transformation tests', () => {
+    it('should transform command files correctly', async () => {
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+
+      // Read a transformed command file
+      const commandPath = join(testProjectDir, '.opencode', 'command', 'create_plan.md')
+      const content = await fs.readFile(commandPath, 'utf8')
+
+      // Verify frontmatter structure
+      expect(content).toContain('description:')
+
+      // Verify model name transformed (if present)
+      if (content.includes('model:')) {
+        expect(content).toContain('anthropic/claude-')
+        expect(content).not.toContain('model: opus')
+        expect(content).not.toContain('model: sonnet')
+        expect(content).not.toContain('model: haiku')
+      }
+    }, 15000)
+
+    it('should transform agent files correctly', async () => {
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+
+      // Read a transformed agent file
+      const agentPath = join(testProjectDir, '.opencode', 'agent', 'codebase-locator.md')
+      const content = await fs.readFile(agentPath, 'utf8')
+
+      // Verify frontmatter structure
+      expect(content).toContain('description:')
+      expect(content).toContain('mode: subagent')
+      expect(content).not.toContain('name:') // Name field removed
+
+      // Verify tools transformed from string to object
+      expect(content).toContain('tools:')
+      expect(content).toContain('  grep: true')
+      expect(content).not.toContain('tools: Grep, Glob')
+    }, 15000)
+
+    it('should generate opencode.json with comments', async () => {
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+
+      const configPath = join(testProjectDir, '.opencode', 'opencode.json')
+      const content = await fs.readFile(configPath, 'utf8')
+      const config = JSON.parse(content)
+
+      // Verify structure
+      expect(config.$schema).toBe('https://opencode.ai/config.json')
+      expect(config.model).toMatch(/^anthropic\/claude-/)
+
+      // Verify comments exist in raw content (they're stripped by JSON.parse)
+      expect(content).toContain('"//model"')
+      expect(content).toContain('"//instructions"')
+    }, 15000)
+
+    it('should transform SlashCommand() syntax', async () => {
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+
+      // Check oneshot.md which contains SlashCommand() calls
+      const commandPath = join(testProjectDir, '.opencode', 'command', 'oneshot.md')
+      if (
+        await fs
+          .stat(commandPath)
+          .then(() => true)
+          .catch(() => false)
+      ) {
+        const content = await fs.readFile(commandPath, 'utf8')
+
+        // Should not contain SlashCommand()
+        expect(content).not.toContain('SlashCommand()')
+
+        // Should contain transformed version
+        expect(content).toContain('use /')
+      }
+    }, 15000)
+
+    it('should comment out humanlayer launch commands', async () => {
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+
+      // Check files that contain launch commands
+      const commandPath = join(testProjectDir, '.opencode', 'command', 'oneshot.md')
+      if (
+        await fs
+          .stat(commandPath)
+          .then(() => true)
+          .catch(() => false)
+      ) {
+        const content = await fs.readFile(commandPath, 'utf8')
+
+        // Should contain OpenCode note
+        if (content.includes('launch')) {
+          expect(content).toContain('OpenCode')
+        }
+      }
+    }, 15000)
+  })
+
+  describe('AGENTS.md generation', () => {
+    it('should not generate AGENTS.md by default with --all flag', async () => {
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+
+      const agentsMdPath = join(testProjectDir, 'AGENTS.md')
+      const exists = await fs
+        .stat(agentsMdPath)
+        .then(() => true)
+        .catch(() => false)
+
+      expect(exists).toBe(false)
+    }, 15000)
+  })
+
+  describe('directory structure', () => {
+    it('should create singular directory names (command, agent)', async () => {
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+
+      const commandDir = join(testProjectDir, '.opencode', 'command')
+      const agentDir = join(testProjectDir, '.opencode', 'agent')
+      const commandsDir = join(testProjectDir, '.opencode', 'commands') // Should NOT exist
+      const agentsDir = join(testProjectDir, '.opencode', 'agents') // Should NOT exist
+
+      expect(
+        await fs
+          .stat(commandDir)
+          .then(() => true)
+          .catch(() => false),
+      ).toBe(true)
+      expect(
+        await fs
+          .stat(agentDir)
+          .then(() => true)
+          .catch(() => false),
+      ).toBe(true)
+      expect(
+        await fs
+          .stat(commandsDir)
+          .then(() => true)
+          .catch(() => false),
+      ).toBe(false)
+      expect(
+        await fs
+          .stat(agentsDir)
+          .then(() => true)
+          .catch(() => false),
+      ).toBe(false)
+    }, 15000)
+  })
+})
+
+async function runCommand(
+  args: string[],
+  cwd: string,
+  options?: {
+    isTTY?: boolean
+  },
+): Promise<{
+  stdout: string
+  stderr: string
+  exitCode: number
+}> {
+  return new Promise((resolve, reject) => {
+    // Build path to the CLI binary
+    const cliPath = join(__dirname, '..', 'dist', 'index.js')
+
+    // Prepare stdio based on TTY option
+    const stdio = options?.isTTY === false ? ['pipe', 'pipe', 'pipe'] : 'pipe'
+
+    const child = spawn('node', [cliPath, ...args], {
+      cwd,
+      stdio,
+      env: {
+        ...process.env,
+        // Force non-TTY mode if requested
+        ...(options?.isTTY === false && { TERM: 'dumb' }),
+      },
+    })
+
+    // Close stdin immediately for non-TTY tests
+    if (options?.isTTY === false && child.stdin) {
+      child.stdin.end()
+    }
+
+    let stdout = ''
+    let stderr = ''
+
+    child.stdout?.on('data', data => {
+      stdout += data.toString()
+    })
+
+    child.stderr?.on('data', data => {
+      stderr += data.toString()
+    })
+
+    child.on('close', code => {
+      resolve({
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        exitCode: code || 0,
+      })
+    })
+
+    child.on('error', error => {
+      reject(error)
+    })
+
+    // Set timeout
+    setTimeout(() => {
+      child.kill('SIGTERM')
+      reject(new Error('Command timeout'))
+    }, 12000)
+  })
+}

--- a/hlyr/tests/opencodeInit.e2e.test.ts
+++ b/hlyr/tests/opencodeInit.e2e.test.ts
@@ -66,7 +66,7 @@ describe('opencode init e2e tests', () => {
       // Verify .gitignore was updated
       const gitignorePath = join(testProjectDir, '.gitignore')
       const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
-      expect(gitignoreContent).toContain('.opencode/opencode.local.json')
+      expect(gitignoreContent).toContain('.opencode/')
     }, 15000)
 
     it('should work in non-TTY environment with --all flag', async () => {
@@ -179,7 +179,7 @@ describe('opencode init e2e tests', () => {
       expect(gitignoreExists).toBe(true)
 
       const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
-      expect(gitignoreContent).toContain('.opencode/opencode.local.json')
+      expect(gitignoreContent).toContain('.opencode/')
       expect(gitignoreContent).toContain('# OpenCode local settings')
     }, 15000)
 
@@ -192,9 +192,21 @@ describe('opencode init e2e tests', () => {
       expect(result.exitCode).toBe(0)
 
       const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
-      expect(gitignoreContent).toContain('# Existing content')
       expect(gitignoreContent).toContain('node_modules/')
-      expect(gitignoreContent).toContain('.opencode/opencode.local.json')
+      expect(gitignoreContent).toContain('.opencode/')
+    }, 15000)
+
+    it('should not duplicate .gitignore entry', async () => {
+      const gitignorePath = join(testProjectDir, '.gitignore')
+      await fs.writeFile(gitignorePath, '# OpenCode local settings\n.opencode/\n')
+
+      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+      expect(result.exitCode).toBe(0)
+
+      const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
+      const matches = gitignoreContent.match(/\.opencode\//g)
+      expect(matches?.length).toBe(1)
     }, 15000)
 
     it('should not duplicate .gitignore entry', async () => {

--- a/hlyr/tests/opencodeInit.e2e.test.ts
+++ b/hlyr/tests/opencodeInit.e2e.test.ts
@@ -5,738 +5,639 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 
 describe('opencode init e2e tests', () => {
-  let tempDir: string
-  let testProjectDir: string
-
-  beforeEach(async () => {
-    // Create temp directory for test projects
-    tempDir = await fs.mkdtemp(join(tmpdir(), 'opencode-init-test-'))
-    testProjectDir = join(tempDir, 'test-project')
-    await fs.mkdir(testProjectDir, { recursive: true })
-  })
-
-  afterEach(async () => {
-    // Cleanup temp files
-    try {
-      await fs.rm(tempDir, { recursive: true, force: true })
-    } catch {
-      // Ignore cleanup errors
-    }
-  })
-
-  describe('--all flag', () => {
-    it('should copy all files without prompting', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-      expect(result.stdout).toContain('Successfully copied')
-
-      // Verify directories were created
-      const opencodeDir = join(testProjectDir, '.opencode')
-      expect(
-        await fs
-          .stat(opencodeDir)
-          .then(() => true)
-          .catch(() => false),
-      ).toBe(true)
-
-      const commandDir = join(opencodeDir, 'command') // SINGULAR
-      const agentDir = join(opencodeDir, 'agent') // SINGULAR
-      const configFile = join(opencodeDir, 'opencode.json')
-
-      expect(
-        await fs
-          .stat(commandDir)
-          .then(() => true)
-          .catch(() => false),
-      ).toBe(true)
-      expect(
-        await fs
-          .stat(agentDir)
-          .then(() => true)
-          .catch(() => false),
-      ).toBe(true)
-      expect(
-        await fs
-          .stat(configFile)
-          .then(() => true)
-          .catch(() => false),
-      ).toBe(true)
-
-      // Verify .gitignore was updated
-      const gitignorePath = join(testProjectDir, '.gitignore')
-      const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
-      expect(gitignoreContent).toContain('.opencode/')
-    }, 15000)
-
-    it('should work in non-TTY environment with --all flag', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir, {
-        isTTY: false,
-      })
-
-      expect(result.exitCode).toBe(0)
-      expect(result.stdout).toContain('Successfully copied')
-
-      // Verify files were created
-      const opencodeDir = join(testProjectDir, '.opencode')
-      expect(
-        await fs
-          .stat(opencodeDir)
-          .then(() => true)
-          .catch(() => false),
-      ).toBe(true)
-    }, 15000)
-  })
-
-  describe('--force flag', () => {
-    it('should overwrite existing .opencode directory without prompting', async () => {
-      // Create existing .opencode directory with a command file
-      const opencodeDir = join(testProjectDir, '.opencode')
-      const commandDir = join(opencodeDir, 'command')
-      await fs.mkdir(commandDir, { recursive: true })
-      const testFile = join(commandDir, 'existing_command.md')
-      await fs.writeFile(testFile, '# Existing Command\nOld content')
-
-      const result = await runCommand(['opencode', 'init', '--all', '--force'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-      expect(result.stdout).toContain('Successfully copied')
-
-      // Verify that new files were copied (directory was overwritten)
-      const commandFiles = await fs.readdir(commandDir)
-      expect(commandFiles.length).toBeGreaterThan(1)
-
-      // The old test file should not exist if it wasn't in the source
-      // Or should be overwritten if it was - either way, verify command directory exists
-      expect(
-        await fs
-          .stat(commandDir)
-          .then(() => true)
-          .catch(() => false),
-      ).toBe(true)
-    }, 15000)
-  })
-
-  describe('non-TTY environment', () => {
-    it('should fail without --all flag in non-TTY environment', async () => {
-      const result = await runCommand(['opencode', 'init'], testProjectDir, {
-        isTTY: false,
-      })
-
-      expect(result.exitCode).toBe(1)
-
-      // Check both stdout and stderr for error message
-      const output = result.stdout + result.stderr
-      expect(output).toContain('Not running in interactive terminal')
-      expect(output).toContain('Use --all flag')
-    }, 15000)
-  })
-
-  describe('source directory validation', () => {
-    it('should handle missing source directory gracefully', async () => {
-      // This test may pass or fail depending on where tests are run from
-      // The important thing is it should fail gracefully with a clear error message
-      // For now, we'll just verify the command runs
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      // Either succeeds (source found) or fails with clear error (source not found)
-      if (result.exitCode !== 0) {
-        expect(result.stderr).toContain('Source .claude directory not found')
-      } else {
-        expect(result.stdout).toContain('Successfully copied')
-      }
-    }, 15000)
-  })
-
-  describe('file counting', () => {
-    it('should accurately count files copied', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      // Extract file count from output
-      const match = result.stdout.match(/Successfully copied (\d+) file/)
-      expect(match).toBeTruthy()
-
-      if (match) {
-        const fileCount = parseInt(match[1], 10)
-        expect(fileCount).toBeGreaterThan(0)
-      }
-    }, 15000)
-  })
-
-  describe('.gitignore management', () => {
-    it('should create .gitignore if it does not exist', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      const gitignorePath = join(testProjectDir, '.gitignore')
-      const gitignoreExists = await fs
-        .stat(gitignorePath)
-        .then(() => true)
-        .catch(() => false)
-      expect(gitignoreExists).toBe(true)
-
-      const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
-      expect(gitignoreContent).toContain('.opencode/')
-      expect(gitignoreContent).toContain('# OpenCode local settings')
-    }, 15000)
-
-    it('should append to existing .gitignore', async () => {
-      const gitignorePath = join(testProjectDir, '.gitignore')
-      await fs.writeFile(gitignorePath, '# Existing content\nnode_modules/\n')
-
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
-      expect(gitignoreContent).toContain('node_modules/')
-      expect(gitignoreContent).toContain('.opencode/')
-    }, 15000)
-
-    it('should not duplicate .gitignore entry', async () => {
-      const gitignorePath = join(testProjectDir, '.gitignore')
-      await fs.writeFile(gitignorePath, '# OpenCode local settings\n.opencode/\n')
-
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
-      const matches = gitignoreContent.match(/\.opencode\//g)
-      expect(matches?.length).toBe(1)
-    }, 15000)
-
-    it('should not duplicate .gitignore entry', async () => {
-      const gitignorePath = join(testProjectDir, '.gitignore')
-      await fs.writeFile(gitignorePath, '# OpenCode local settings\n.opencode/opencode.local.json\n')
-
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
-      const matches = gitignoreContent.match(/\.opencode\/opencode\.local\.json/g)
-      expect(matches?.length).toBe(1)
-    }, 15000)
-  })
-
-  describe('output formatting', () => {
-    it('should use @clack/prompts styling', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      // Check for clack-style output (intro/outro)
-      expect(result.stdout).toContain('Initialize OpenCode Configuration')
-      expect(result.stdout).toContain('Successfully copied')
-      expect(result.stdout).toContain('You can now use these commands')
-    }, 15000)
-  })
-
-  describe('error handling', () => {
-    it('should handle errors gracefully', async () => {
-      // Try to run in a read-only directory (if possible)
-      // This test is platform-dependent and may be skipped
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      // Command should either succeed or fail with a clear error message
-      if (result.exitCode !== 0) {
-        expect(result.stderr).toBeTruthy()
-        expect(result.stderr.length).toBeGreaterThan(0)
-      }
-    }, 15000)
-  })
-
-  describe('model configuration', () => {
-    it('should set model to opus by default', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      const configPath = join(testProjectDir, '.opencode', 'opencode.json')
-      const configContent = await fs.readFile(configPath, 'utf8')
-      const config = JSON.parse(configContent)
-
-      expect(config.model).toBe('anthropic/claude-opus-4')
-    }, 15000)
-
-    it('should set model when --model flag is used with opus', async () => {
-      const result = await runCommand(['opencode', 'init', '--all', '--model', 'opus'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      const configPath = join(testProjectDir, '.opencode', 'opencode.json')
-      const configContent = await fs.readFile(configPath, 'utf8')
-      const config = JSON.parse(configContent)
-
-      expect(config.model).toBe('anthropic/claude-opus-4')
-    }, 15000)
-
-    it('should set model when --model flag is used with sonnet', async () => {
-      const result = await runCommand(
-        ['opencode', 'init', '--all', '--model', 'sonnet'],
-        testProjectDir,
-      )
-
-      expect(result.exitCode).toBe(0)
-
-      const configPath = join(testProjectDir, '.opencode', 'opencode.json')
-      const configContent = await fs.readFile(configPath, 'utf8')
-      const config = JSON.parse(configContent)
-
-      expect(config.model).toBe('anthropic/claude-sonnet-4-5')
-    }, 15000)
-
-    it('should set model when --model flag is used with haiku', async () => {
-      const result = await runCommand(['opencode', 'init', '--all', '--model', 'haiku'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      const configPath = join(testProjectDir, '.opencode', 'opencode.json')
-      const configContent = await fs.readFile(configPath, 'utf8')
-      const config = JSON.parse(configContent)
-
-      expect(config.model).toBe('anthropic/claude-haiku-4-5')
-    }, 15000)
-
-    it('should reject invalid model values', async () => {
-      const result = await runCommand(
-        ['opencode', 'init', '--all', '--model', 'invalid'],
-        testProjectDir,
-      )
-
-      expect(result.exitCode).toBe(1)
-      const output = result.stdout + result.stderr
-      expect(output).toContain('Invalid model')
-      expect(output).toContain('haiku, sonnet, opus')
-    }, 15000)
-
-    it('should combine model with other settings flags', async () => {
-      const result = await runCommand(
-        [
-          'opencode',
-          'init',
-          '--all',
-          '--model',
-          'haiku',
-          '--no-always-thinking',
-          '--max-thinking-tokens',
-          '50000',
-        ],
-        testProjectDir,
-      )
-
-      expect(result.exitCode).toBe(0)
-
-      const configPath = join(testProjectDir, '.opencode', 'opencode.json')
-      const configContent = await fs.readFile(configPath, 'utf8')
-      const config = JSON.parse(configContent)
-
-      expect(config.model).toBe('anthropic/claude-haiku-4-5')
-      // Thinking flags are accepted but ignored for OpenCode
-    }, 15000)
-  })
-
-  describe('transformation tests', () => {
-    it('should transform command files correctly', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      // Read a transformed command file
-      const commandPath = join(testProjectDir, '.opencode', 'command', 'create_plan.md')
-      const content = await fs.readFile(commandPath, 'utf8')
-
-      // Verify frontmatter structure
-      expect(content).toContain('description:')
-
-      // Verify model name transformed (if present)
-      if (content.includes('model:')) {
-        expect(content).toContain('anthropic/claude-')
-        expect(content).not.toContain('model: opus')
-        expect(content).not.toContain('model: sonnet')
-        expect(content).not.toContain('model: haiku')
-      }
-    }, 15000)
-
-    it('should transform agent files correctly', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      // Read a transformed agent file
-      const agentPath = join(testProjectDir, '.opencode', 'agent', 'codebase-locator.md')
-      const content = await fs.readFile(agentPath, 'utf8')
-
-      // Verify frontmatter structure
-      expect(content).toContain('description:')
-      expect(content).toContain('mode: subagent')
-      expect(content).not.toContain('name:') // Name field removed
-
-      // Verify tools transformed from string to object
-      expect(content).toContain('tools:')
-      expect(content).toContain('  grep: true')
-      expect(content).not.toContain('tools: Grep, Glob')
-    }, 15000)
-
-    it('should generate opencode.json with valid structure', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      const configPath = join(testProjectDir, '.opencode', 'opencode.json')
-      const content = await fs.readFile(configPath, 'utf8')
-      const config = JSON.parse(content)
-
-      // Verify structure
-      expect(config.$schema).toBe('https://opencode.ai/config.json')
-      expect(config.model).toMatch(/^anthropic\/claude-/)
-      expect(config.instructions).toEqual(['AGENTS.md'])
-
-      // Verify it's valid JSON (no comment keys that would be rejected)
-      expect(config['//model']).toBeUndefined()
-      expect(config['//permission']).toBeUndefined()
-      expect(config['//instructions']).toBeUndefined()
-      expect(config['//tools']).toBeUndefined()
-    }, 15000)
-
-    it('should transform SlashCommand() syntax', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      // Check oneshot.md which contains SlashCommand() calls
-      const commandPath = join(testProjectDir, '.opencode', 'command', 'oneshot.md')
-      if (
-        await fs
-          .stat(commandPath)
-          .then(() => true)
-          .catch(() => false)
-      ) {
-        const content = await fs.readFile(commandPath, 'utf8')
-
-        // Should not contain SlashCommand()
-        expect(content).not.toContain('SlashCommand()')
-
-        // Should contain transformed version
-        expect(content).toContain('use /')
-      }
-    }, 15000)
-
-    it('should comment out humanlayer launch commands', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      // Check files that contain launch commands
-      const commandPath = join(testProjectDir, '.opencode', 'command', 'oneshot.md')
-      if (
-        await fs
-          .stat(commandPath)
-          .then(() => true)
-          .catch(() => false)
-      ) {
-        const content = await fs.readFile(commandPath, 'utf8')
-
-        // Should contain OpenCode note
-        if (content.includes('launch')) {
-          expect(content).toContain('OpenCode')
-        }
-      }
-    }, 15000)
-  })
-
-  describe('AGENTS.md generation', () => {
-    it('should not generate AGENTS.md by default with --all flag', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      const agentsMdPath = join(testProjectDir, 'AGENTS.md')
-      const exists = await fs
-        .stat(agentsMdPath)
-        .then(() => true)
-        .catch(() => false)
-
-      expect(exists).toBe(false)
-    }, 15000)
-  })
-
-  describe('directory structure', () => {
-    it('should create singular directory names (command, agent)', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      const commandDir = join(testProjectDir, '.opencode', 'command')
-      const agentDir = join(testProjectDir, '.opencode', 'agent')
-      const commandsDir = join(testProjectDir, '.opencode', 'commands') // Should NOT exist
-      const agentsDir = join(testProjectDir, '.opencode', 'agents') // Should NOT exist
-
-      expect(
-        await fs
-          .stat(commandDir)
-          .then(() => true)
-          .catch(() => false),
-      ).toBe(true)
-      expect(
-        await fs
-          .stat(agentDir)
-          .then(() => true)
-          .catch(() => false),
-      ).toBe(true)
-      expect(
-        await fs
-          .stat(commandsDir)
-          .then(() => true)
-          .catch(() => false),
-      ).toBe(false)
-      expect(
-        await fs
-          .stat(agentsDir)
-          .then(() => true)
-          .catch(() => false),
-      ).toBe(false)
-    }, 15000)
-  })
-
-  describe('platform compatibility guidance injection', () => {
-    it('should inject platform guidance into agents with filesystem tools', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      // Check codebase-locator agent (has Grep, Glob, LS tools)
-      const codebaseLocatorPath = join(testProjectDir, '.opencode', 'agent', 'codebase-locator.md')
-      if (
-        await fs
-          .stat(codebaseLocatorPath)
-          .then(() => true)
-          .catch(() => false)
-      ) {
-        const content = await fs.readFile(codebaseLocatorPath, 'utf8')
-
-        // Should contain platform compatibility section
-        expect(content).toContain('## Platform Compatibility')
-        expect(content).toContain('grep')
-        expect(content).toContain('glob')
-        expect(content).toContain('list')
-        expect(content).toContain('forward slashes')
-        expect(content).toContain('cross-platform')
-
-        // Should come after frontmatter and before main content
-        const lines = content.split('\n')
-        const platformHeaderIdx = lines.findIndex(l => l.includes('## Platform Compatibility'))
-        const frontmatterEnd = lines.findIndex((l, idx) => idx > 0 && l === '---')
-        expect(platformHeaderIdx).toBeGreaterThan(frontmatterEnd)
-      }
-    }, 15000)
-
-    it('should inject platform guidance into thoughts-locator agent', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      const thoughtsLocatorPath = join(testProjectDir, '.opencode', 'agent', 'thoughts-locator.md')
-      if (
-        await fs
-          .stat(thoughtsLocatorPath)
-          .then(() => true)
-          .catch(() => false)
-      ) {
-        const content = await fs.readFile(thoughtsLocatorPath, 'utf8')
-
-        // Should contain platform compatibility section
-        expect(content).toContain('## Platform Compatibility')
-        expect(content).toContain('grep')
-        expect(content).toContain('glob')
-        expect(content).toContain('list')
-        expect(content).toContain('cross-platform')
-      }
-    }, 15000)
-
-    it('should inject platform guidance into commands that reference paths', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      // Check research_codebase command (references thoughts/, codebase, directories)
-      const researchPath = join(testProjectDir, '.opencode', 'command', 'research_codebase.md')
-      if (
-        await fs
-          .stat(researchPath)
-          .then(() => true)
-          .catch(() => false)
-      ) {
-        const content = await fs.readFile(researchPath, 'utf8')
-
-        // Should contain platform compatibility section
-        expect(content).toContain('## Platform Compatibility')
-        expect(content).toContain('forward slashes')
-        expect(content).toContain('cross-platform')
-      }
-    }, 15000)
-
-    it('should inject platform guidance into create_plan command', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      const createPlanPath = join(testProjectDir, '.opencode', 'command', 'create_plan.md')
-      if (
-        await fs
-          .stat(createPlanPath)
-          .then(() => true)
-          .catch(() => false)
-      ) {
-        const content = await fs.readFile(createPlanPath, 'utf8')
-
-        // Should contain platform compatibility section (references thoughts/, @codebase-locator)
-        expect(content).toContain('## Platform Compatibility')
-      }
-    }, 15000)
-
-    it('should not inject platform guidance into agents without filesystem tools', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      // Check if there are any agents without grep/glob/list tools
-      // If thoughts-analyzer exists and doesn't use those tools, check it
-      const thoughtsAnalyzerPath = join(testProjectDir, '.opencode', 'agent', 'thoughts-analyzer.md')
-      if (
-        await fs
-          .stat(thoughtsAnalyzerPath)
-          .then(() => true)
-          .catch(() => false)
-      ) {
-        const content = await fs.readFile(thoughtsAnalyzerPath, 'utf8')
-
-        // Check the frontmatter to see if it has filesystem tools
-        const toolsMatch = content.match(/tools:\s*\n((?:\s+\w+:\s*\w+\s*\n)+)/)
-        if (toolsMatch) {
-          const toolsSection = toolsMatch[1]
-          const hasFilesystemTools =
-            toolsSection.includes('grep:') ||
-            toolsSection.includes('glob:') ||
-            toolsSection.includes('list:')
-
-          // Only verify absence if no filesystem tools
-          if (!hasFilesystemTools) {
-            expect(content).not.toContain('## Platform Compatibility')
-          }
-        }
-      }
-    }, 15000)
-
-    it('should place platform guidance immediately after frontmatter', async () => {
-      const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
-
-      expect(result.exitCode).toBe(0)
-
-      const codebaseLocatorPath = join(testProjectDir, '.opencode', 'agent', 'codebase-locator.md')
-      if (
-        await fs
-          .stat(codebaseLocatorPath)
-          .then(() => true)
-          .catch(() => false)
-      ) {
-        const content = await fs.readFile(codebaseLocatorPath, 'utf8')
-
-        // Platform Compatibility should appear right after frontmatter (after the second ---)
-        const lines = content.split('\n')
-        let foundFrontmatterEnd = false
-        let frontmatterEndIdx = -1
-
-        for (let i = 1; i < lines.length; i++) {
-          if (lines[i].trim() === '---') {
-            foundFrontmatterEnd = true
-            frontmatterEndIdx = i
-            break
-          }
-        }
-
-        expect(foundFrontmatterEnd).toBe(true)
-
-        // Find first ## heading after frontmatter
-        let firstHeadingIdx = -1
-        for (let i = frontmatterEndIdx + 1; i < lines.length; i++) {
-          if (lines[i].trim().startsWith('## ')) {
-            firstHeadingIdx = i
-            break
-          }
-        }
-
-        expect(firstHeadingIdx).toBeGreaterThan(-1)
-        expect(lines[firstHeadingIdx].trim()).toBe('## Platform Compatibility')
-      }
-    }, 15000)
-  })
+	let tempDir: string
+	let testProjectDir: string
+
+	beforeEach(async () => {
+		// Create temp directory for test projects
+		tempDir = await fs.mkdtemp(join(tmpdir(), 'opencode-init-test-'))
+		testProjectDir = join(tempDir, 'test-project')
+		await fs.mkdir(testProjectDir, { recursive: true })
+	})
+
+	afterEach(async () => {
+		// Cleanup temp files
+		try {
+			await fs.rm(tempDir, { recursive: true, force: true })
+		} catch {
+			// Ignore cleanup errors
+		}
+	})
+
+	describe('--all flag', () => {
+		it('should copy all files without prompting', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+			expect(result.stdout).toContain('Successfully copied')
+
+			// Verify directories were created
+			const opencodeDir = join(testProjectDir, '.opencode')
+			expect(
+				await fs
+					.stat(opencodeDir)
+					.then(() => true)
+					.catch(() => false),
+			).toBe(true)
+
+			const commandDir = join(opencodeDir, 'command') // SINGULAR
+			const agentDir = join(opencodeDir, 'agent') // SINGULAR
+			const configFile = join(opencodeDir, 'opencode.json')
+
+			expect(
+				await fs
+					.stat(commandDir)
+					.then(() => true)
+					.catch(() => false),
+			).toBe(true)
+			expect(
+				await fs
+					.stat(agentDir)
+					.then(() => true)
+					.catch(() => false),
+			).toBe(true)
+			expect(
+				await fs
+					.stat(configFile)
+					.then(() => true)
+					.catch(() => false),
+			).toBe(true)
+
+			// Verify .gitignore was updated
+			const gitignorePath = join(testProjectDir, '.gitignore')
+			const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
+			expect(gitignoreContent).toContain('.opencode/')
+		}, 15000)
+
+		it('should work in non-TTY environment with --all flag', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir, {
+				isTTY: false,
+			})
+
+			expect(result.exitCode).toBe(0)
+			expect(result.stdout).toContain('Successfully copied')
+
+			// Verify files were created
+			const opencodeDir = join(testProjectDir, '.opencode')
+			expect(
+				await fs
+					.stat(opencodeDir)
+					.then(() => true)
+					.catch(() => false),
+			).toBe(true)
+		}, 15000)
+	})
+
+	describe('--force flag', () => {
+		it('should overwrite existing .opencode directory without prompting', async () => {
+			// Create existing .opencode directory with a command file
+			const opencodeDir = join(testProjectDir, '.opencode')
+			const commandDir = join(opencodeDir, 'command')
+			await fs.mkdir(commandDir, { recursive: true })
+			const testFile = join(commandDir, 'existing_command.md')
+			await fs.writeFile(testFile, '# Existing Command\nOld content')
+
+			const result = await runCommand(['opencode', 'init', '--all', '--force'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+			expect(result.stdout).toContain('Successfully copied')
+
+			// Verify that new files were copied (directory was overwritten)
+			const commandFiles = await fs.readdir(commandDir)
+			expect(commandFiles.length).toBeGreaterThan(1)
+
+			// The old test file should not exist if it wasn't in the source
+			// Or should be overwritten if it was - either way, verify command directory exists
+			expect(
+				await fs
+					.stat(commandDir)
+					.then(() => true)
+					.catch(() => false),
+			).toBe(true)
+		}, 15000)
+	})
+
+	describe('non-TTY environment', () => {
+		it('should fail without --all flag in non-TTY environment', async () => {
+			const result = await runCommand(['opencode', 'init'], testProjectDir, {
+				isTTY: false,
+			})
+
+			expect(result.exitCode).toBe(1)
+
+			// Check both stdout and stderr for error message
+			const output = result.stdout + result.stderr
+			expect(output).toContain('Not running in interactive terminal')
+			expect(output).toContain('Use --all flag')
+		}, 15000)
+	})
+
+	describe('source directory validation', () => {
+		it('should handle missing source directory gracefully', async () => {
+			// This test may pass or fail depending on where tests are run from
+			// The important thing is it should fail gracefully with a clear error message
+			// For now, we'll just verify the command runs
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			// Either succeeds (source found) or fails with clear error (source not found)
+			if (result.exitCode !== 0) {
+				expect(result.stderr).toContain('Source .claude directory not found')
+			} else {
+				expect(result.stdout).toContain('Successfully copied')
+			}
+		}, 15000)
+	})
+
+	describe('file counting', () => {
+		it('should accurately count files copied', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			// Extract file count from output
+			const match = result.stdout.match(/Successfully copied (\d+) file/)
+			expect(match).toBeTruthy()
+
+			if (match) {
+				const fileCount = parseInt(match[1], 10)
+				expect(fileCount).toBeGreaterThan(0)
+			}
+		}, 15000)
+	})
+
+	describe('.gitignore management', () => {
+		it('should create .gitignore if it does not exist', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			const gitignorePath = join(testProjectDir, '.gitignore')
+			const gitignoreExists = await fs
+				.stat(gitignorePath)
+				.then(() => true)
+				.catch(() => false)
+			expect(gitignoreExists).toBe(true)
+
+			const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
+			expect(gitignoreContent).toContain('.opencode/')
+			expect(gitignoreContent).toContain('# OpenCode local settings')
+		}, 15000)
+
+		it('should append to existing .gitignore', async () => {
+			const gitignorePath = join(testProjectDir, '.gitignore')
+			await fs.writeFile(gitignorePath, '# Existing content\nnode_modules/\n')
+
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
+			expect(gitignoreContent).toContain('node_modules/')
+			expect(gitignoreContent).toContain('.opencode/')
+		}, 15000)
+
+		it('should not duplicate .gitignore entry', async () => {
+			const gitignorePath = join(testProjectDir, '.gitignore')
+			await fs.writeFile(gitignorePath, '# OpenCode local settings\n.opencode/\n')
+
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
+			const matches = gitignoreContent.match(/\.opencode\//g)
+			expect(matches?.length).toBe(1)
+		}, 15000)
+
+		it('should not duplicate .gitignore entry', async () => {
+			const gitignorePath = join(testProjectDir, '.gitignore')
+			await fs.writeFile(gitignorePath, '# OpenCode local settings\n.opencode/opencode.local.json\n')
+
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			const gitignoreContent = await fs.readFile(gitignorePath, 'utf8')
+			const matches = gitignoreContent.match(/\.opencode\/opencode\.local\.json/g)
+			expect(matches?.length).toBe(1)
+		}, 15000)
+	})
+
+	describe('output formatting', () => {
+		it('should use @clack/prompts styling', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			// Check for clack-style output (intro/outro)
+			expect(result.stdout).toContain('Initialize OpenCode Configuration')
+			expect(result.stdout).toContain('Successfully copied')
+			expect(result.stdout).toContain('You can now use these commands')
+		}, 15000)
+	})
+
+	describe('error handling', () => {
+		it('should handle errors gracefully', async () => {
+			// Try to run in a read-only directory (if possible)
+			// This test is platform-dependent and may be skipped
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			// Command should either succeed or fail with a clear error message
+			if (result.exitCode !== 0) {
+				expect(result.stderr).toBeTruthy()
+				expect(result.stderr.length).toBeGreaterThan(0)
+			}
+		}, 15000)
+	})
+
+	describe('transformation tests', () => {
+		it('should transform command files correctly', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			// Read a transformed command file
+			const commandPath = join(testProjectDir, '.opencode', 'command', 'create_plan.md')
+			const content = await fs.readFile(commandPath, 'utf8')
+
+			// Verify frontmatter structure
+			expect(content).toContain('description:')
+		}, 15000)
+
+		it('should transform agent files correctly', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			// Read a transformed agent file
+			const agentPath = join(testProjectDir, '.opencode', 'agent', 'codebase-locator.md')
+			const content = await fs.readFile(agentPath, 'utf8')
+
+			// Verify frontmatter structure
+			expect(content).toContain('description:')
+			expect(content).toContain('mode: subagent')
+			expect(content).not.toContain('name:') // Name field removed
+
+			// Verify tools transformed from string to object
+			expect(content).toContain('tools:')
+			expect(content).toContain('  grep: true')
+			expect(content).not.toContain('tools: Grep, Glob')
+		}, 15000)
+
+		it('should generate opencode.json with valid structure', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			const configPath = join(testProjectDir, '.opencode', 'opencode.json')
+			const content = await fs.readFile(configPath, 'utf8')
+			const config = JSON.parse(content)
+
+			// Verify structure
+			expect(config.$schema).toBe('https://opencode.ai/config.json')
+			expect(config.instructions).toEqual(['AGENTS.md'])
+
+			// Verify it's valid JSON (no comment keys that would be rejected)
+			expect(config['//model']).toBeUndefined()
+			expect(config['//permission']).toBeUndefined()
+			expect(config['//instructions']).toBeUndefined()
+			expect(config['//tools']).toBeUndefined()
+		}, 15000)
+
+		it('should transform SlashCommand() syntax', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			// Check oneshot.md which contains SlashCommand() calls
+			const commandPath = join(testProjectDir, '.opencode', 'command', 'oneshot.md')
+			if (
+				await fs
+					.stat(commandPath)
+					.then(() => true)
+					.catch(() => false)
+			) {
+				const content = await fs.readFile(commandPath, 'utf8')
+
+				// Should not contain SlashCommand()
+				expect(content).not.toContain('SlashCommand()')
+
+				// Should contain transformed version
+				expect(content).toContain('use /')
+			}
+		}, 15000)
+
+		it('should comment out humanlayer launch commands', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			// Check files that contain launch commands
+			const commandPath = join(testProjectDir, '.opencode', 'command', 'oneshot.md')
+			if (
+				await fs
+					.stat(commandPath)
+					.then(() => true)
+					.catch(() => false)
+			) {
+				const content = await fs.readFile(commandPath, 'utf8')
+
+				// Should contain OpenCode note
+				if (content.includes('launch')) {
+					expect(content).toContain('OpenCode')
+				}
+			}
+		}, 15000)
+	})
+
+	describe('AGENTS.md generation', () => {
+		it('should not generate AGENTS.md by default with --all flag', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			const agentsMdPath = join(testProjectDir, 'AGENTS.md')
+			const exists = await fs
+				.stat(agentsMdPath)
+				.then(() => true)
+				.catch(() => false)
+
+			expect(exists).toBe(false)
+		}, 15000)
+	})
+
+	describe('directory structure', () => {
+		it('should create singular directory names (command, agent)', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			const commandDir = join(testProjectDir, '.opencode', 'command')
+			const agentDir = join(testProjectDir, '.opencode', 'agent')
+			const commandsDir = join(testProjectDir, '.opencode', 'commands') // Should NOT exist
+			const agentsDir = join(testProjectDir, '.opencode', 'agents') // Should NOT exist
+
+			expect(
+				await fs
+					.stat(commandDir)
+					.then(() => true)
+					.catch(() => false),
+			).toBe(true)
+			expect(
+				await fs
+					.stat(agentDir)
+					.then(() => true)
+					.catch(() => false),
+			).toBe(true)
+			expect(
+				await fs
+					.stat(commandsDir)
+					.then(() => true)
+					.catch(() => false),
+			).toBe(false)
+			expect(
+				await fs
+					.stat(agentsDir)
+					.then(() => true)
+					.catch(() => false),
+			).toBe(false)
+		}, 15000)
+	})
+
+	describe('platform compatibility guidance injection', () => {
+		it('should inject platform guidance into agents with filesystem tools', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			// Check codebase-locator agent (has Grep, Glob, LS tools)
+			const codebaseLocatorPath = join(testProjectDir, '.opencode', 'agent', 'codebase-locator.md')
+			if (
+				await fs
+					.stat(codebaseLocatorPath)
+					.then(() => true)
+					.catch(() => false)
+			) {
+				const content = await fs.readFile(codebaseLocatorPath, 'utf8')
+
+				// Should contain platform compatibility section
+				expect(content).toContain('## Platform Compatibility')
+				expect(content).toContain('grep')
+				expect(content).toContain('glob')
+				expect(content).toContain('list')
+				expect(content).toContain('forward slashes')
+				expect(content).toContain('cross-platform')
+
+				// Should come after frontmatter and before main content
+				const lines = content.split('\n')
+				const platformHeaderIdx = lines.findIndex((l) => l.includes('## Platform Compatibility'))
+				const frontmatterEnd = lines.findIndex((l, idx) => idx > 0 && l === '---')
+				expect(platformHeaderIdx).toBeGreaterThan(frontmatterEnd)
+			}
+		}, 15000)
+
+		it('should inject platform guidance into thoughts-locator agent', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			const thoughtsLocatorPath = join(testProjectDir, '.opencode', 'agent', 'thoughts-locator.md')
+			if (
+				await fs
+					.stat(thoughtsLocatorPath)
+					.then(() => true)
+					.catch(() => false)
+			) {
+				const content = await fs.readFile(thoughtsLocatorPath, 'utf8')
+
+				// Should contain platform compatibility section
+				expect(content).toContain('## Platform Compatibility')
+				expect(content).toContain('grep')
+				expect(content).toContain('glob')
+				expect(content).toContain('list')
+				expect(content).toContain('cross-platform')
+			}
+		}, 15000)
+
+		it('should inject platform guidance into commands that reference paths', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			// Check research_codebase command (references thoughts/, codebase, directories)
+			const researchPath = join(testProjectDir, '.opencode', 'command', 'research_codebase.md')
+			if (
+				await fs
+					.stat(researchPath)
+					.then(() => true)
+					.catch(() => false)
+			) {
+				const content = await fs.readFile(researchPath, 'utf8')
+
+				// Should contain platform compatibility section
+				expect(content).toContain('## Platform Compatibility')
+				expect(content).toContain('forward slashes')
+				expect(content).toContain('cross-platform')
+			}
+		}, 15000)
+
+		it('should inject platform guidance into create_plan command', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			const createPlanPath = join(testProjectDir, '.opencode', 'command', 'create_plan.md')
+			if (
+				await fs
+					.stat(createPlanPath)
+					.then(() => true)
+					.catch(() => false)
+			) {
+				const content = await fs.readFile(createPlanPath, 'utf8')
+
+				// Should contain platform compatibility section (references thoughts/, @codebase-locator)
+				expect(content).toContain('## Platform Compatibility')
+			}
+		}, 15000)
+
+		it('should not inject platform guidance into agents without filesystem tools', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			// Check if there are any agents without grep/glob/list tools
+			// If thoughts-analyzer exists and doesn't use those tools, check it
+			const thoughtsAnalyzerPath = join(testProjectDir, '.opencode', 'agent', 'thoughts-analyzer.md')
+			if (
+				await fs
+					.stat(thoughtsAnalyzerPath)
+					.then(() => true)
+					.catch(() => false)
+			) {
+				const content = await fs.readFile(thoughtsAnalyzerPath, 'utf8')
+
+				// Check the frontmatter to see if it has filesystem tools
+				const toolsMatch = content.match(/tools:\s*\n((?:\s+\w+:\s*\w+\s*\n)+)/)
+				if (toolsMatch) {
+					const toolsSection = toolsMatch[1]
+					const hasFilesystemTools =
+						toolsSection.includes('grep:') ||
+						toolsSection.includes('glob:') ||
+						toolsSection.includes('list:')
+
+					// Only verify absence if no filesystem tools
+					if (!hasFilesystemTools) {
+						expect(content).not.toContain('## Platform Compatibility')
+					}
+				}
+			}
+		}, 15000)
+
+		it('should place platform guidance immediately after frontmatter', async () => {
+			const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
+
+			expect(result.exitCode).toBe(0)
+
+			const codebaseLocatorPath = join(testProjectDir, '.opencode', 'agent', 'codebase-locator.md')
+			if (
+				await fs
+					.stat(codebaseLocatorPath)
+					.then(() => true)
+					.catch(() => false)
+			) {
+				const content = await fs.readFile(codebaseLocatorPath, 'utf8')
+
+				// Platform Compatibility should appear right after frontmatter (after the second ---)
+				const lines = content.split('\n')
+				let foundFrontmatterEnd = false
+				let frontmatterEndIdx = -1
+
+				for (let i = 1; i < lines.length; i++) {
+					if (lines[i].trim() === '---') {
+						foundFrontmatterEnd = true
+						frontmatterEndIdx = i
+						break
+					}
+				}
+
+				expect(foundFrontmatterEnd).toBe(true)
+
+				// Find first ## heading after frontmatter
+				let firstHeadingIdx = -1
+				for (let i = frontmatterEndIdx + 1; i < lines.length; i++) {
+					if (lines[i].trim().startsWith('## ')) {
+						firstHeadingIdx = i
+						break
+					}
+				}
+
+				expect(firstHeadingIdx).toBeGreaterThan(-1)
+				expect(lines[firstHeadingIdx].trim()).toBe('## Platform Compatibility')
+			}
+		}, 15000)
+	})
 })
 
 async function runCommand(
-  args: string[],
-  cwd: string,
-  options?: {
-    isTTY?: boolean
-  },
+	args: string[],
+	cwd: string,
+	options?: {
+		isTTY?: boolean
+	},
 ): Promise<{
-  stdout: string
-  stderr: string
-  exitCode: number
+	stdout: string
+	stderr: string
+	exitCode: number
 }> {
-  return new Promise((resolve, reject) => {
-    // Build path to the CLI binary
-    const cliPath = join(__dirname, '..', 'dist', 'index.js')
+	return new Promise((resolve, reject) => {
+		// Build path to the CLI binary
+		const cliPath = join(__dirname, '..', 'dist', 'index.js')
 
-    // Prepare stdio based on TTY option
-    const stdio = options?.isTTY === false ? ['pipe', 'pipe', 'pipe'] : 'pipe'
+		// Prepare stdio based on TTY option
+		const stdio = options?.isTTY === false ? ['pipe', 'pipe', 'pipe'] : 'pipe'
 
-    const child = spawn('node', [cliPath, ...args], {
-      cwd,
-      stdio,
-      env: {
-        ...process.env,
-        // Force non-TTY mode if requested
-        ...(options?.isTTY === false && { TERM: 'dumb' }),
-      },
-    })
+		const child = spawn('node', [cliPath, ...args], {
+			cwd,
+			stdio,
+			env: {
+				...process.env,
+				// Force non-TTY mode if requested
+				...(options?.isTTY === false && { TERM: 'dumb' }),
+			},
+		})
 
-    // Close stdin immediately for non-TTY tests
-    if (options?.isTTY === false && child.stdin) {
-      child.stdin.end()
-    }
+		// Close stdin immediately for non-TTY tests
+		if (options?.isTTY === false && child.stdin) {
+			child.stdin.end()
+		}
 
-    let stdout = ''
-    let stderr = ''
+		let stdout = ''
+		let stderr = ''
 
-    child.stdout?.on('data', data => {
-      stdout += data.toString()
-    })
+		child.stdout?.on('data', (data) => {
+			stdout += data.toString()
+		})
 
-    child.stderr?.on('data', data => {
-      stderr += data.toString()
-    })
+		child.stderr?.on('data', (data) => {
+			stderr += data.toString()
+		})
 
-    child.on('close', code => {
-      resolve({
-        stdout: stdout.trim(),
-        stderr: stderr.trim(),
-        exitCode: code || 0,
-      })
-    })
+		child.on('close', (code) => {
+			resolve({
+				stdout: stdout.trim(),
+				stderr: stderr.trim(),
+				exitCode: code || 0,
+			})
+		})
 
-    child.on('error', error => {
-      reject(error)
-    })
+		child.on('error', (error) => {
+			reject(error)
+		})
 
-    // Set timeout
-    setTimeout(() => {
-      child.kill('SIGTERM')
-      reject(new Error('Command timeout'))
-    }, 12000)
-  })
+		// Set timeout
+		setTimeout(() => {
+			child.kill('SIGTERM')
+			reject(new Error('Command timeout'))
+		}, 12000)
+	})
 }

--- a/hlyr/tests/opencodeInit.e2e.test.ts
+++ b/hlyr/tests/opencodeInit.e2e.test.ts
@@ -373,7 +373,7 @@ describe('opencode init e2e tests', () => {
       expect(content).not.toContain('tools: Grep, Glob')
     }, 15000)
 
-    it('should generate opencode.json with comments', async () => {
+    it('should generate opencode.json with valid structure', async () => {
       const result = await runCommand(['opencode', 'init', '--all'], testProjectDir)
 
       expect(result.exitCode).toBe(0)
@@ -385,10 +385,13 @@ describe('opencode init e2e tests', () => {
       // Verify structure
       expect(config.$schema).toBe('https://opencode.ai/config.json')
       expect(config.model).toMatch(/^anthropic\/claude-/)
+      expect(config.instructions).toEqual(['AGENTS.md'])
 
-      // Verify comments exist in raw content (they're stripped by JSON.parse)
-      expect(content).toContain('"//model"')
-      expect(content).toContain('"//instructions"')
+      // Verify it's valid JSON (no comment keys that would be rejected)
+      expect(config['//model']).toBeUndefined()
+      expect(config['//permission']).toBeUndefined()
+      expect(config['//instructions']).toBeUndefined()
+      expect(config['//tools']).toBeUndefined()
     }, 15000)
 
     it('should transform SlashCommand() syntax', async () => {


### PR DESCRIPTION
## Summary

Implements `humanlayer opencode init` command to enable HumanLayer workflow integration with OpenCode.

Fixes #904

## Key Features

### 1. OpenCode Init Command

- ✅ Copies `.claude/` directory to `.opencode/` with automatic transformations
- ✅ Transforms Claude-specific syntax to OpenCode equivalents
- ✅ Generates `opencode.json` config file
- ✅ Updates `.gitignore` to exclude `.opencode/`
- ✅ Supports `--all` (non-interactive) and `--force` (overwrite) flags

### 2. Cross-Platform Compatibility

- ✅ Auto-injects platform guidance for Windows/macOS/Linux support
- ✅ Handles both LF and CRLF line endings
- ✅ Works seamlessly across all platforms

## Syntax Transformations

**Agent Files** (`.claude/agents/*.md` → `.opencode/agent/*.md`):

```yaml
# Before (Claude)
---
name: codebase-locator
description: Find files fast
tools: Grep, Glob, LS
---
# After (OpenCode)
---
description: Find files fast
mode: subagent
tools:
  grep: true
  glob: true
  list: true
---
```

**Command Files** (`.claude/commands/*.md` → `.opencode/command/*.md`):

- `SlashCommand()` → `/command`
- `humanlayer launch` → Commented with OpenCode notes
- `Task()` pseudo-code → `@agent` syntax

### Platform Guidance Injection

Automatically adds cross-platform guidance to files using filesystem operations:

```markdown
## Platform Compatibility

**IMPORTANT**: The `grep`, `glob`, and `list` tools automatically handle path separators for your platform.

- Always use forward slashes (`/`) in patterns - they work cross-platform
- Tools normalize paths to your platform's native format automatically
- Never manually construct platform-specific paths
- Let the tools handle cross-platform operation
```

## Example Usage

```bash
# Interactive mode (prompts for each action)
humanlayer opencode init

# Non-interactive mode (copy everything)
humanlayer opencode init --all

# Force overwrite existing .opencode directory
humanlayer opencode init --all --force
```

## Migration Notes

Users can now run:

```bash
# Install HumanLayer CLI
npm install -g humanlayer

# Initialize OpenCode support in their project
cd /path/to/project
humanlayer opencode init --all
```

This gives OpenCode users the same rich workflow experience that Claude Code users have enjoyed with HumanLayer's agents and commands.

## Design Decisions

1. **No Model Configuration**: Unlike `claude init`, `opencode init` doesn't prompt for model selection. OpenCode has a lot of models so I will leave that to the user to configure later on their own if they like to.

2. **Platform Guidance Auto-Injection**: Detects files that need cross-platform guidance and injects it automatically, ensuring Windows users have a great experience.

3. **Conservative Transformations**: Only transforms what's necessary for OpenCode compatibility, preserving as much original content as possible.

