### PR TITLE
fix(wui): move Google Fonts @import to top

### DIFF
--- a/humanlayer-wui/src/App.css
+++ b/humanlayer-wui/src/App.css
@@ -1,9 +1,10 @@
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap');
+
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @import './styles/markdown-terminal.css';
 @import './styles/react-syntax-highlighter-terminal.css';
 @import './styles/tiptap-editor.css';
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap');
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
Fixes PostCSS warning about @import order by moving the Google Fonts import to the very top of humanlayer-wui/src/App.css.

Repro:
- Build/run WUI with PostCSS/Tailwind pipeline and observe @import order warning.

After:
- Warning disappears because the external @import precedes the Tailwind import expansion.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Moves Google Fonts `@import` to the top of `App.css` to fix PostCSS import order warning.
> 
>   - **Behavior**:
>     - Moves Google Fonts `@import` to the top of `App.css` to fix PostCSS warning about import order.
>     - Ensures external `@import` precedes Tailwind import expansion, removing the warning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for ded523b25363cea6ef62f45079ea1969bb257223. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->