### PR TITLE
fix(dev): make ticket port selection wrap within ranges

### DIFF
--- a/hack/port-utils.sh
+++ b/hack/port-utils.sh
@@ -34,7 +34,7 @@ find_available_port() {
 
     # Try ports in 20000-29999 range to avoid Vite's 10000-19999 range
     for offset in 0 1000 2000 3000 4000 5000 6000 7000 8000 9000; do
-        local port=$((20000 + (ticket_num % 10000) + offset))
+        local port=$((20000 + ((ticket_num + offset) % 10000)))
 
         # Skip if port would exceed our range
         if [ "$port" -gt 29999 ]; then
@@ -49,7 +49,7 @@ find_available_port() {
 
     # Fallback to 40000-49999 range if needed
     for offset in 0 1000 2000 3000 4000 5000 6000 7000 8000 9000; do
-        local port=$((40000 + (ticket_num % 10000) + offset))
+        local port=$((40000 + ((ticket_num + offset) % 10000)))
 
         # Skip if port would exceed our range or maximum valid port
         if [ "$port" -gt 49999 ] || [ "$port" -gt 65535 ]; then
@@ -87,7 +87,7 @@ find_available_vite_port() {
 
     # Try ports in the 30000-39999 range
     for offset in 0 1000 2000 3000 4000 5000 6000 7000 8000 9000; do
-        local port=$((30000 + (ticket_num % 10000) + offset))
+        local port=$((30000 + ((ticket_num + offset) % 10000)))
 
         # Skip if port would exceed our range
         if [ "$port" -gt 39999 ]; then
@@ -102,7 +102,7 @@ find_available_vite_port() {
 
     # Fallback to 50000-59999 range if needed
     for offset in 0 1000 2000 3000 4000 5000 6000 7000 8000 9000; do
-        local port=$((50000 + (ticket_num % 10000) + offset))
+        local port=$((50000 + ((ticket_num + offset) % 10000)))
 
         # Skip if port would exceed our range or maximum valid port
         if [ "$port" -gt 59999 ] || [ "$port" -gt 65535 ]; then


### PR DESCRIPTION
Fixes edge case where tickets near 9999 only tried a single port per range and could fail with: 'Could not find available port for ticket 9999'.

Change:
- Generate candidate ports with wrap-around modulo so each offset produces a different port within the intended ranges.

Repro:
- Run: make codelayer-dev TICKET=ENG-9999
- Before: could fail depending on whether 9999/29999/49999 were in use.
- After: finds a free port as long as at least one candidate port is available.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes port selection edge case for tickets near 9999 by using wrap-around modulo in `port-utils.sh`.
> 
>   - **Behavior**:
>     - Fixes edge case in `find_available_port()` and `find_available_vite_port()` in `port-utils.sh` where tickets near 9999 only tried a single port per range.
>     - Uses wrap-around modulo for port calculation to ensure multiple candidate ports are tried within 20000-29999, 30000-39999, 40000-49999, and 50000-59999 ranges.
>   - **Repro**:
>     - Before: Could fail if 9999/29999/49999 were in use.
>     - After: Finds a free port if at least one candidate is available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 437d483df6841b03c3925fb5ae26cc8e3838ed80. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->