### PR TITLE
Fix: Cancelling fork dialog with ESC no longer clears input

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/components/ActiveSession.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/ActiveSession.tsx
@@ -237,7 +237,6 @@ export function ActiveSession({ session, onClose }: ActiveSessionProps) {
   // Fork cancel handler
   const handleForkCancel = useCallback(() => {
     setForkPreviewData(null)
-    responseEditor?.commands.setContent('')
   }, [responseEditor])
 
   // Reset scroll flag when session changes


### PR DESCRIPTION
## What problem(s) was I solving?

## What user-facing changes did I ship?

## How I implemented it

## How to verify it

- [x] I have ensured `make check test` passes

## Description for the changelog

Closes: #893

Cancelling the fork dialog using the ESC key was unintentionally clearing the input field, causing users to lose any text they had already typed. This PR fixes that behavior by ensuring the input state is preserved unless the user explicitly submits or clears it.

## A picture of a cute animal (not mandatory but encouraged)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue in `ActiveSession.tsx` where pressing ESC in fork dialog cleared input field, preserving input state unless explicitly cleared.
> 
>   - **Behavior**:
>     - Fixes issue where pressing ESC in fork dialog cleared input field in `ActiveSession.tsx`.
>     - Input state is now preserved unless explicitly submitted or cleared.
>   - **Functions**:
>     - Removes `responseEditor?.commands.setContent('')` from `handleForkCancel` in `ActiveSession.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for 58a0182f61e802c68ceb7faa2f001df99c737957. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->