### PR TITLE
Fix numbering typos for research prompts; fix example for plan.

### DIFF
--- a/.claude/commands/create_plan_generic.md
+++ b/.claude/commands/create_plan_generic.md
@@ -428,7 +428,7 @@ tasks = [
 ## Example Interaction Flow
 
 ```
-User: /implementation_plan
+User: /create_plan
 Assistant: I'll help you create a detailed implementation plan...
 
 User: We need to add parent-child tracking for Claude sub-tasks. See thoughts/allison/tickets/eng_1478.md

--- a/.claude/commands/research_codebase.md
+++ b/.claude/commands/research_codebase.md
@@ -94,7 +94,7 @@ Then wait for the user's research query.
        - Without ticket: `2025-01-08-authentication-flow.md`
 
 6. **Generate research document:**
-   - Use the metadata gathered in step 4
+   - Use the metadata gathered in step 5
    - Structure the document with YAML frontmatter followed by content:
      ```markdown
      ---
@@ -112,10 +112,10 @@ Then wait for the user's research query.
 
      # Research: [User's Question/Topic]
 
-     **Date**: [Current date and time with timezone from step 4]
+     **Date**: [Current date and time with timezone from step 5]
      **Researcher**: [Researcher name from thoughts status]
-     **Git Commit**: [Current commit hash from step 4]
-     **Branch**: [Current branch name from step 4]
+     **Git Commit**: [Current commit hash from step 5]
+     **Branch**: [Current branch name from step 5]
      **Repository**: [Repository name]
 
      ## Research Question

--- a/.claude/commands/research_codebase_generic.md
+++ b/.claude/commands/research_codebase_generic.md
@@ -64,7 +64,7 @@ Then wait for the user's research query.
        - Without ticket: `2025-01-08-authentication-flow.md`
 
 6. **Generate research document:**
-   - Use the metadata gathered in step 4
+   - Use the metadata gathered in step 5
    - Structure the document with YAML frontmatter followed by content:
      ```markdown
      ---
@@ -82,10 +82,10 @@ Then wait for the user's research query.
 
      # Research: [User's Question/Topic]
 
-     **Date**: [Current date and time with timezone from step 4]
+     **Date**: [Current date and time with timezone from step 5]
      **Researcher**: [Researcher name]
-     **Git Commit**: [Current commit hash from step 4]
-     **Branch**: [Current branch name from step 4]
+     **Git Commit**: [Current commit hash from step 5]
+     **Branch**: [Current branch name from step 5]
      **Repository**: [Repository name]
 
      ## Research Question

--- a/.claude/commands/research_codebase_nt.md
+++ b/.claude/commands/research_codebase_nt.md
@@ -88,7 +88,7 @@ Then wait for the user's research query.
        - Without ticket: `2025-01-08-authentication-flow.md`
 
 6. **Generate research document:**
-   - Use the metadata gathered in step 4
+   - Use the metadata gathered in step 5
    - Structure the document with YAML frontmatter followed by content:
      ```markdown
      ---
@@ -106,10 +106,10 @@ Then wait for the user's research query.
 
      # Research: [User's Question/Topic]
 
-     **Date**: [Current date and time with timezone from step 4]
+     **Date**: [Current date and time with timezone from step 5]
      **Researcher**: [Researcher name from metadata]
-     **Git Commit**: [Current commit hash from step 4]
-     **Branch**: [Current branch name from step 4]
+     **Git Commit**: [Current commit hash from step 5]
+     **Branch**: [Current branch name from step 5]
      **Repository**: [Repository name]
 
      ## Research Question


### PR DESCRIPTION
## What problem(s) was I solving?
Typos in research / plan markdown files

Fixes #856 

## What user-facing changes did I ship?
None

## How I implemented it
Manually, in Zed.

## How to verify it

- [X] I have ensured `make check test` passes

## Description for the changelog
Fixed minor typos in prompts

## A picture of a cute animal (not mandatory but encouraged)
<img width="800" height="800" alt="image" src="https://github.com/user-attachments/assets/f17ceef5-8059-4f59-af5f-e253b240975b" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes numbering typos and example command in markdown files for research and planning commands.
> 
>   - **Fixes in `create_plan_generic.md`**:
>     - Corrects example command from `/implementation_plan` to `/create_plan`.
>   - **Fixes in `research_codebase.md`, `research_codebase_generic.md`, and `research_codebase_nt.md`**:
>     - Corrects step references from 4 to 5 in multiple places to ensure accurate metadata usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fhumanlayer&utm_source=github&utm_medium=referral)<sup> for cd1a559904714e05aeb55085c06a07bf1d034c11. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->