### PR TITLE
fix(thoughts): prevent path TypeError when repo mapping is object

### DIFF
--- a/hlyr/src/commands/thoughts/init.ts
+++ b/hlyr/src/commands/thoughts/init.ts
@@ -19,6 +19,7 @@ import {
   updateSymlinksForNewUsers,
   validateProfile,
   resolveProfileForRepo,
+  getRepoNameFromMapping,
 } from '../../thoughtsConfig.js'
 
 interface InitOptions {
@@ -614,11 +615,18 @@ export async function thoughtsInitCommand(options: InitOptions): Promise<void> {
       saveThoughtsConfig(config, options)
     }
 
+    // After ensuring mapping exists, resolve the final repo name (handles string or object mapping)
+    const finalMapping = config.repoMappings[currentRepo]
+    const repoName = getRepoNameFromMapping(finalMapping)
+    if (!repoName) {
+      throw new Error('Could not determine repo name from thoughts mapping')
+    }
+
     // Resolve profile config for directory creation
     const profileConfig = resolveProfileForRepo(config, currentRepo)
 
     // Create directory structure using profile config
-    createThoughtsDirectoryStructure(profileConfig, mappedName, config.user)
+    createThoughtsDirectoryStructure(profileConfig, repoName, config.user)
 
     // Create thoughts directory in current repo
     const thoughtsDir = path.join(currentRepo, 'thoughts')
@@ -642,7 +650,7 @@ export async function thoughtsInitCommand(options: InitOptions): Promise<void> {
     fs.mkdirSync(thoughtsDir)
 
     // Create symlinks - flipped structure for easier access
-    const repoTarget = getRepoThoughtsPath(profileConfig, mappedName)
+    const repoTarget = getRepoThoughtsPath(profileConfig, repoName)
     const globalTarget = getGlobalThoughtsPath(profileConfig)
 
     // Direct symlinks to user and shared directories for repo-specific thoughts
@@ -653,7 +661,7 @@ export async function thoughtsInitCommand(options: InitOptions): Promise<void> {
     fs.symlinkSync(globalTarget, path.join(thoughtsDir, 'global'), 'dir')
 
     // Check for other users and create symlinks
-    const otherUsers = updateSymlinksForNewUsers(currentRepo, profileConfig, mappedName, config.user)
+    const otherUsers = updateSymlinksForNewUsers(currentRepo, profileConfig, repoName, config.user)
 
     if (otherUsers.length > 0) {
       console.log(chalk.green(`✓ Added symlinks for other users: ${otherUsers.join(', ')}`))
@@ -680,7 +688,7 @@ export async function thoughtsInitCommand(options: InitOptions): Promise<void> {
     const claudeMd = generateClaudeMd(
       profileConfig.thoughtsRepo,
       profileConfig.reposDir,
-      mappedName,
+      repoName,
       config.user,
     )
     fs.writeFileSync(path.join(thoughtsDir, 'CLAUDE.md'), claudeMd)
@@ -699,10 +707,10 @@ export async function thoughtsInitCommand(options: InitOptions): Promise<void> {
     console.log(`  ${chalk.cyan(currentRepo)}/`)
     console.log(`    └── thoughts/`)
     console.log(
-      `         ├── ${config.user}/     ${chalk.gray(`→ ${profileConfig.thoughtsRepo}/${profileConfig.reposDir}/${mappedName}/${config.user}/`)}`,
+      `         ├── ${config.user}/     ${chalk.gray(`→ ${profileConfig.thoughtsRepo}/${profileConfig.reposDir}/${repoName}/${config.user}/`)}`,
     )
     console.log(
-      `         ├── shared/      ${chalk.gray(`→ ${profileConfig.thoughtsRepo}/${profileConfig.reposDir}/${mappedName}/shared/`)}`,
+      `         ├── shared/      ${chalk.gray(`→ ${profileConfig.thoughtsRepo}/${profileConfig.reposDir}/${repoName}/shared/`)}`,
     )
     console.log(
       `         └── global/      ${chalk.gray(`→ ${profileConfig.thoughtsRepo}/${profileConfig.globalDir}/`)}`,


### PR DESCRIPTION
## Summary
Fixes a crash in `humanlayer thoughts init --profile <name>` when reconfiguring a repo that already has a profile-aware mapping.

## Repro
1. Configure thoughts for a repo with a profile (mapping stored as object `{ repo, profile }`).
2. Run: `humanlayer thoughts init --profile <profile-name>`
3. Choose reconfigure (`y`).
4. Observe: `TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received an instance of Object`

## Root cause
`thoughts init` uses `mappedName = config.repoMappings[currentRepo]`, which can be either:
- `string` (legacy)
- `{ repo: string, profile?: string }` (profile-aware)

Later, `mappedName` was passed directly into path helper calls expecting a string repo name.

## Fix
Resolve the repo name via `getRepoNameFromMapping(...)` after mapping is ensured, then use the resolved string (`repoName`) for all path operations:
- `createThoughtsDirectoryStructure(...)`
- `getRepoThoughtsPath(...)`
- `updateSymlinksForNewUsers(...)`
- `generateClaudeMd(...)`
- summary output paths

## Verification
- Confirmed bug exists on latest `origin/main` in a clean worktree.
- Applied fix on top of latest main.
- Rebuilt and re-linked CLI.
- Re-ran `humanlayer thoughts init --profile <profile-name>` with reconfigure prompt; command completed successfully.

Co-Authored-By: Warp <agent@warp.dev>
