### PR TITLE
fix: strip CLAUDECODE env var when spawning claude subprocesses

### DIFF
--- a/claudecode-go/client.go
+++ b/claudecode-go/client.go
@@ -16,6 +16,25 @@ import (
 	"time"
 )
 
+// antiNestingEnvVar is the environment variable that Claude Code sets as an
+// anti-nesting guard to prevent running Claude inside another Claude session.
+// We strip this when spawning claude subprocesses so that tools like Riptide
+// work correctly when launched from a Claude Code terminal.
+const antiNestingEnvVar = "CLAUDECODE"
+
+// filteredEnviron returns os.Environ() with the anti-nesting guard variable removed.
+func filteredEnviron() []string {
+	env := os.Environ()
+	filtered := make([]string, 0, len(env))
+	prefix := antiNestingEnvVar + "="
+	for _, e := range env {
+		if !strings.HasPrefix(e, prefix) {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
+}
+
 // isClosedPipeError checks if an error is due to a closed pipe (expected when process exits)
 func isClosedPipeError(err error) bool {
 	if err == nil {
@@ -124,6 +143,7 @@ func (c *Client) GetVersion() (string, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, c.claudePath, "--version")
+	cmd.Env = filteredEnviron()
 	output, err := cmd.Output()
 	if err != nil {
 		// Check if it was a timeout
@@ -320,12 +340,10 @@ func (c *Client) Launch(config SessionConfig) (*Session, error) {
 	log.Printf("Executing Claude command: %s %v", c.claudePath, args)
 	cmd := exec.Command(c.claudePath, args...)
 
-	// Set environment variables if specified
-	if len(config.Env) > 0 {
-		cmd.Env = os.Environ() // Start with current environment
-		for key, value := range config.Env {
-			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
-		}
+	// Set environment variables, always starting from a filtered base environment
+	cmd.Env = filteredEnviron()
+	for key, value := range config.Env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
 	}
 
 	// Set working directory if specified

--- a/claudecode-go/env_internal_test.go
+++ b/claudecode-go/env_internal_test.go
@@ -1,0 +1,50 @@
+package claudecode
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFilteredEnviron(t *testing.T) {
+	t.Run("strips CLAUDECODE variable", func(t *testing.T) {
+		t.Setenv("CLAUDECODE", "1")
+
+		env := filteredEnviron()
+
+		for _, e := range env {
+			if strings.HasPrefix(e, "CLAUDECODE=") {
+				t.Errorf("filteredEnviron() should strip CLAUDECODE, but found: %s", e)
+			}
+		}
+	})
+
+	t.Run("preserves other variables", func(t *testing.T) {
+		t.Setenv("CLAUDECODE", "1")
+		t.Setenv("TEST_PRESERVE_VAR", "keep_me")
+
+		env := filteredEnviron()
+
+		found := false
+		for _, e := range env {
+			if strings.HasPrefix(e, "TEST_PRESERVE_VAR=") {
+				found = true
+				if e != "TEST_PRESERVE_VAR=keep_me" {
+					t.Errorf("expected TEST_PRESERVE_VAR=keep_me, got %s", e)
+				}
+				break
+			}
+		}
+		if !found {
+			t.Error("filteredEnviron() should preserve other variables, but TEST_PRESERVE_VAR was missing")
+		}
+	})
+
+	t.Run("works when CLAUDECODE is not set", func(t *testing.T) {
+		// Don't set CLAUDECODE — filteredEnviron should return all env vars
+		env := filteredEnviron()
+
+		if len(env) == 0 {
+			t.Error("filteredEnviron() should return non-empty environment")
+		}
+	})
+}


### PR DESCRIPTION
Closes https://github.com/humanlayer/humanlayer/issues/961

## What problems was I solving

When Riptide is launched from a terminal running inside Claude Code, the `CLAUDECODE` anti-nesting environment variable propagates through the entire subprocess chain (Tauri WUI → hld daemon → claude CLI). This causes `claude` to refuse execution, making Riptide's setup health check fail with "Verifying Claude Code works" errors. Users who happen to launch Riptide from a Claude Code terminal hit this wall with no workaround.

## What user-facing changes did I ship

- Riptide setup health check now passes regardless of whether the app was launched from a Claude Code terminal or a regular terminal
- No visible UI changes — this is a behind-the-scenes environment fix

## How I implemented it

Added a `filteredEnviron()` helper in `claudecode-go/client.go` that returns `os.Environ()` with the `CLAUDECODE` anti-nesting variable stripped out. Applied it to both subprocess spawn points:

- **`claudecode-go/client.go`** — Added `antiNestingEnvVar` constant and `filteredEnviron()` function after the import block. Modified `GetVersion()` to explicitly set `cmd.Env = filteredEnviron()` instead of inheriting the full parent environment. Modified `Launch()` to unconditionally use `filteredEnviron()` as the base environment (previously it only set `cmd.Env` when `config.Env` was non-empty).

- **`claudecode-go/env_internal_test.go`** (new) — Internal test file with three test cases: verifies `CLAUDECODE` is stripped, other variables are preserved, and the function works when `CLAUDECODE` is not set.

## Deviations from the plan

### Implemented as planned
- `antiNestingEnvVar` constant and `filteredEnviron()` helper — exactly as specified
- `GetVersion()` modification — exactly as specified
- `Launch()` modification — exactly as specified
- `env_internal_test.go` — all three subtests match the plan

### Deviations/surprises
- Minor comment change on the `Launch()` env block: changed from "Set environment variables if specified" to "Set environment variables, always starting from a filtered base environment" to reflect the new unconditional behavior

### Additions not in plan
None.

### Items planned but not implemented
None (manual verification is a process step, not a code artifact).

## How to verify it

### Setup
```bash
git fetch
git checkout fix/strip-claudecode-env-var
```

### Automated Tests
```bash
cd claudecode-go && go test ./...
cd claudecode-go && go vet ./...
```

### Manual Testing
- [ ] Launch Riptide from a Claude Code terminal (`open /Applications/Riptide-Beta.app`), verify setup health check passes ("Verifying Claude Code works" succeeds)
- [ ] Launch Riptide from a regular terminal, verify setup still works as before

## Description for the changelog

Fix: Strip `CLAUDECODE` anti-nesting env var when spawning claude subprocesses so Riptide works when launched from a Claude Code terminal.
