### PR TITLE
fix: clear archived session selection

### DIFF
--- a/humanlayer-wui/src/AppStore.archive.test.ts
+++ b/humanlayer-wui/src/AppStore.archive.test.ts
@@ -77,6 +77,31 @@ describe('AppStore - Archive Session Focus Clearing', () => {
     })
   })
 
+  test('should remove archived session from selectedSessions', async () => {
+    const session = createMockSession({
+      id: 'session-1',
+      archived: false,
+    })
+    const otherSession = createMockSession({
+      id: 'session-2',
+      archived: false,
+    })
+
+    useStore.getState().initSessions([session, otherSession])
+    useStore.getState().toggleSessionSelection(session.id)
+    useStore.getState().toggleSessionSelection(otherSession.id)
+
+    expect(useStore.getState().selectedSessions).toEqual(new Set(['session-1', 'session-2']))
+
+    await useStore.getState().archiveSession(session.id, true)
+
+    expect(useStore.getState().selectedSessions).toEqual(new Set(['session-2']))
+    expect(mockArchiveSession).toHaveBeenCalledWith({
+      session_id: 'session-1',
+      archived: true,
+    })
+  })
+
   test('should NOT clear focusedSession when unarchiving', async () => {
     const session = createMockSession({
       id: 'session-1',

--- a/humanlayer-wui/src/AppStore.ts
+++ b/humanlayer-wui/src/AppStore.ts
@@ -459,6 +459,14 @@ export const useStore = create<StoreState>((set, get) => {
         // Update local state immediately for better UX
         get().updateSession(sessionId, { archived })
 
+        if (archived) {
+          set(state => ({
+            selectedSessions: new Set(
+              Array.from(state.selectedSessions).filter(id => id !== sessionId),
+            ),
+          }))
+        }
+
         // Clear focus if archiving and in Normal view
         const state = get()
         if (


### PR DESCRIPTION
## Summary
- remove a session from `selectedSessions` when it is archived via the single-session archive flow
- keep the existing focused-session clearing behavior unchanged
- add a regression test covering the stale background selection described in #525

## Testing
- `PATH=/home/torch/.bun/bin:$PATH /home/torch/.bun/bin/bun test src/AppStore.archive.test.ts`
- `timeout 120s ./node_modules/.bin/tsc --noEmit`

Closes #525