### PR TITLE
fix: focus the prompt when starting a new draft

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/components/DraftLauncherForm.test.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/DraftLauncherForm.test.tsx
@@ -1,0 +1,158 @@
+/// <reference lib="dom" />
+import React, { forwardRef, useImperativeHandle } from 'react'
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { render, screen, waitFor } from '@testing-library/react'
+
+const draftInputFocus = mock(() => {})
+const mockTrackEvent = mock(() => {})
+const mockRefreshSessions = mock(() => Promise.resolve())
+
+mock.module('lucide-react', () => ({
+  FolderOpen: () => null,
+  TextSearch: () => null,
+}))
+
+mock.module('react-router-dom', () => ({
+  useNavigate: () => mock(() => {}),
+  useSearchParams: () => [new URLSearchParams()],
+}))
+
+mock.module('react-hotkeys-hook', () => ({
+  useHotkeys: mock(() => {}),
+}))
+
+mock.module('sonner', () => ({
+  toast: {
+    error: mock(() => {}),
+    success: mock(() => {}),
+  },
+}))
+
+mock.module('@/AppStore', () => {
+  const useStore = (selector: (state: any) => unknown) =>
+    selector({
+      responseEditor: null,
+      refreshSessions: mockRefreshSessions,
+    })
+
+  useStore.getState = () => ({
+    responseEditor: {
+      getText: () => '',
+    },
+  })
+
+  return { useStore }
+})
+
+mock.module('@/hooks/usePostHogTracking', () => ({
+  usePostHogTracking: () => ({
+    trackEvent: mockTrackEvent,
+  }),
+}))
+
+mock.module('@/hooks/useLocalStorage', () => ({
+  useLocalStorage: (_key: string, initialValue: unknown) => [initialValue, mock(() => {}), true],
+}))
+
+mock.module('@/hooks/useRecentPaths', () => ({
+  useRecentPaths: () => ({
+    paths: [],
+  }),
+}))
+
+mock.module('@/lib/daemon', () => ({
+  daemonClient: {
+    launchSession: mock(() => Promise.resolve({ sessionId: 'draft-1' })),
+    updateSession: mock(() => Promise.resolve()),
+    deleteSession: mock(() => Promise.resolve()),
+    getDirectoryInfo: mock(() => Promise.resolve({})),
+  },
+}))
+
+mock.module('@/lib/logging', () => ({
+  logger: {
+    log: mock(() => {}),
+    error: mock(() => {}),
+    warn: mock(() => {}),
+    debug: mock(() => {}),
+  },
+}))
+
+mock.module('@/utils/errors', () => ({
+  formatError: (error: unknown) => String(error),
+}))
+
+mock.module('@/components/FuzzySearchInput', () => ({
+  SearchInput: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}))
+
+mock.module('@/components/HotkeyScopeBoundary', () => ({
+  HotkeyScopeBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+mock.module('@/components/ui/input', () => ({
+  Input: forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>((props, ref) => (
+    <input ref={ref} {...props} />
+  )),
+}))
+
+mock.module('@/components/ui/label', () => ({
+  Label: ({ children }: { children: React.ReactNode }) => <label>{children}</label>,
+}))
+
+mock.module('../DangerouslySkipPermissionsDialog', () => ({
+  DangerouslySkipPermissionsDialog: () => null,
+}))
+
+mock.module('./CreateDirectoryDialog', () => ({
+  CreateDirectoryDialog: () => null,
+}))
+
+mock.module('./DiscardDraftDialog', () => ({
+  DiscardDraftDialog: () => null,
+}))
+
+mock.module('./DraftLauncherInput', () => ({
+  DraftLauncherInput: forwardRef((_props: unknown, ref: React.ForwardedRef<{ focus: () => void }>) => {
+    useImperativeHandle(ref, () => ({
+      focus: draftInputFocus,
+    }))
+
+    return <div data-testid="draft-launcher-input" />
+  }),
+}))
+
+import { SessionStatus } from '@/lib/daemon/types'
+import { createMockSession } from '@/test-utils'
+import { DraftLauncherForm } from './DraftLauncherForm'
+
+describe('DraftLauncherForm autofocus', () => {
+  beforeEach(() => {
+    draftInputFocus.mockReset()
+    mockTrackEvent.mockReset()
+    mockRefreshSessions.mockReset()
+  })
+
+  test('focuses the draft input for a new draft', async () => {
+    render(<DraftLauncherForm session={null} />)
+
+    await waitFor(() => {
+      expect(draftInputFocus).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  test('falls back to the title field for an existing titled draft', async () => {
+    const session = createMockSession({
+      status: SessionStatus.Draft,
+      title: 'Existing draft',
+      summary: 'Existing draft',
+    })
+
+    render(<DraftLauncherForm session={session} />)
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Describe this session...')).toHaveFocus()
+    })
+    expect(draftInputFocus).not.toHaveBeenCalled()
+  })
+})

--- a/humanlayer-wui/src/components/internal/SessionDetail/components/DraftLauncherForm.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/DraftLauncherForm.tsx
@@ -15,7 +15,7 @@ import { HOTKEY_SCOPES } from '@/hooks/hotkeys/scopes'
 import { useLocalStorage } from '@/hooks/useLocalStorage'
 import { useRecentPaths } from '@/hooks/useRecentPaths'
 import { daemonClient } from '@/lib/daemon'
-import { type Session, ViewMode } from '@/lib/daemon/types'
+import { type Session, SessionStatus, ViewMode } from '@/lib/daemon/types'
 import { logger } from '@/lib/logging'
 import { formatError } from '@/utils/errors'
 import { DangerouslySkipPermissionsDialog } from '../DangerouslySkipPermissionsDialog'
@@ -33,6 +33,7 @@ export const DraftLauncherForm: React.FC<DraftLauncherFormProps> = ({ session, o
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const titleInputRef = useRef<HTMLInputElement>(null)
+  const draftInputRef = useRef<{ focus: () => void; blur?: () => void }>(null)
   const { trackEvent } = usePostHogTracking()
 
   // Core Form State
@@ -139,11 +140,21 @@ export const DraftLauncherForm: React.FC<DraftLauncherFormProps> = ({ session, o
       setSessionId(draftId)
     }
 
-    // Always focus title input on mount
+    const shouldFocusDraftInput =
+      !session ||
+      (session.status === SessionStatus.Draft &&
+        !(session.title ?? session.summary ?? '').trim() &&
+        !session.editorState)
+
+    if (shouldFocusDraftInput && draftInputRef.current) {
+      draftInputRef.current.focus()
+      return
+    }
+
     if (titleInputRef.current) {
       titleInputRef.current.focus()
     }
-  }, []) // Run only once on mount
+  }, [searchParams, session]) // Run on mount for the current draft
 
   // Load localStorage values once they're ready
   useEffect(() => {
@@ -822,6 +833,7 @@ export const DraftLauncherForm: React.FC<DraftLauncherFormProps> = ({ session, o
 
           {/* Draft Launcher Input */}
           <DraftLauncherInput
+            ref={draftInputRef}
             session={displaySession}
             workingDirectoryRef={workingDirectoryRef}
             onLaunchDraft={handleLaunchDraft}


### PR DESCRIPTION
## Summary
- prefer the prompt editor when opening a new or empty draft session
- keep the title field as the fallback when reopening an existing draft with content
- add a regression test around the autofocus decision in `DraftLauncherForm`

## Testing
- `PATH=/home/torch/.bun/bin:$PATH /home/torch/.bun/bin/bun test src/components/internal/SessionDetail/components/DraftLauncherForm.test.tsx`
- `timeout 120s ./node_modules/.bin/tsc --noEmit`

Closes #919