### PR TITLE
feat: add modifier-enter navigation for task sessions

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionTable.tsx
+++ b/humanlayer-wui/src/components/internal/SessionTable.tsx
@@ -38,6 +38,7 @@ interface SessionTableProps {
   handleFocusNextSession?: () => void
   handleFocusPreviousSession?: () => void
   handleActivateSession?: (session: Session) => void
+  handleOpenLatestChildSession?: (session: Session) => void
   focusedSession: Session | null
   searchText?: string
   matchedSessions?: Map<string, any>
@@ -54,6 +55,7 @@ function SessionTableInner({
   handleFocusNextSession,
   handleFocusPreviousSession,
   handleActivateSession,
+  handleOpenLatestChildSession,
   focusedSession,
   searchText,
   matchedSessions,
@@ -371,6 +373,27 @@ function SessionTableInner({
       }
     },
     { scopes: [tableScope], enabled: !isSessionLauncherOpen },
+  )
+
+  useHotkeys(
+    'meta+enter, ctrl+enter',
+    () => {
+      if (!focusedSession) {
+        return
+      }
+
+      if (handleOpenLatestChildSession) {
+        handleOpenLatestChildSession(focusedSession)
+        return
+      }
+
+      handleActivateSession?.(focusedSession)
+    },
+    {
+      scopes: [tableScope],
+      enabled: !isSessionLauncherOpen,
+      preventDefault: true,
+    },
   )
 
   // Track if g>e was recently pressed to prevent 'e' from firing

--- a/humanlayer-wui/src/pages/SessionTablePage.test.ts
+++ b/humanlayer-wui/src/pages/SessionTablePage.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test'
+import { SessionStatus } from '@/lib/daemon/types'
+import { createMockSession } from '@/test-utils'
+import { getLatestChildSession } from './SessionTablePage'
+
+describe('getLatestChildSession', () => {
+  test('prefers an active child session over newer completed children', () => {
+    const parent = createMockSession({ id: 'parent-1' })
+    const runningChild = createMockSession({
+      id: 'child-running',
+      parentSessionId: parent.id,
+      status: SessionStatus.Running,
+      lastActivityAt: new Date('2026-03-12T20:00:00Z'),
+    })
+    const completedChild = createMockSession({
+      id: 'child-completed',
+      parentSessionId: parent.id,
+      status: SessionStatus.Completed,
+      lastActivityAt: new Date('2026-03-12T21:00:00Z'),
+    })
+
+    expect(getLatestChildSession([parent, completedChild, runningChild], parent.id)?.id).toBe(
+      'child-running',
+    )
+  })
+
+  test('falls back to the most recent child when none are active', () => {
+    const parent = createMockSession({ id: 'parent-2' })
+    const olderChild = createMockSession({
+      id: 'child-older',
+      parentSessionId: parent.id,
+      status: SessionStatus.Completed,
+      lastActivityAt: new Date('2026-03-12T18:00:00Z'),
+    })
+    const newestChild = createMockSession({
+      id: 'child-newest',
+      parentSessionId: parent.id,
+      status: SessionStatus.Completed,
+      lastActivityAt: new Date('2026-03-12T22:00:00Z'),
+    })
+
+    expect(getLatestChildSession([parent, olderChild, newestChild], parent.id)?.id).toBe(
+      'child-newest',
+    )
+  })
+
+  test('returns null when a session has no child sessions', () => {
+    const parent = createMockSession({ id: 'parent-3' })
+
+    expect(getLatestChildSession([parent], parent.id)).toBeNull()
+  })
+})

--- a/humanlayer-wui/src/pages/SessionTablePage.tsx
+++ b/humanlayer-wui/src/pages/SessionTablePage.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useStore } from '@/AppStore'
-import { ViewMode } from '@/lib/daemon/types'
+import { SessionStatus, type Session, ViewMode } from '@/lib/daemon/types'
 import SessionTable from '@/components/internal/SessionTable'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useKeyboardNavigationProtection } from '@/hooks'
@@ -127,6 +127,20 @@ export function SessionTablePage() {
       navigate(`/sessions/${session.id}`)
     }
   }
+
+  const handleOpenLatestChildSession = useCallback(
+    (session: Session) => {
+      const latestChildSession = getLatestChildSession(sessions, session.id)
+
+      if (latestChildSession) {
+        handleActivateSession(latestChildSession)
+        return
+      }
+
+      handleActivateSession(session)
+    },
+    [sessions],
+  )
 
   // Custom navigation functions that work with sessions
   const focusNextSession = () => {
@@ -385,6 +399,7 @@ export function SessionTablePage() {
             }
           }}
           handleActivateSession={handleActivateSession}
+          handleOpenLatestChildSession={handleOpenLatestChildSession}
           focusedSession={focusedSession}
           handleFocusNextSession={focusNextSession}
           handleFocusPreviousSession={focusPreviousSession}
@@ -411,4 +426,32 @@ export function SessionTablePage() {
       </HotkeyScopeBoundary>
     </div>
   )
+}
+
+function getSessionTimestamp(session: Session) {
+  return new Date(session.lastActivityAt ?? session.createdAt).getTime()
+}
+
+export function getLatestChildSession(sessions: Session[], parentSessionId: string) {
+  const childSessions = sessions.filter(session => session.parentSessionId === parentSessionId)
+
+  if (childSessions.length === 0) {
+    return null
+  }
+
+  const activeStatuses = new Set<SessionStatus>([
+    SessionStatus.Running,
+    SessionStatus.WaitingInput,
+    SessionStatus.Starting,
+  ])
+
+  const activeChild = childSessions
+    .filter(session => activeStatuses.has(session.status))
+    .sort((left, right) => getSessionTimestamp(right) - getSessionTimestamp(left))[0]
+
+  if (activeChild) {
+    return activeChild
+  }
+
+  return childSessions.sort((left, right) => getSessionTimestamp(right) - getSessionTimestamp(left))[0]
 }


### PR DESCRIPTION
## Summary
- add `cmd+enter` / `ctrl+enter` handling in the sessions table
- open the running child session for a task when one exists, otherwise fall back to the latest child session
- keep plain `enter` behavior unchanged and add regression tests for the child-session selection helper

## Testing
- `PATH=/home/torch/.bun/bin:$PATH /home/torch/.bun/bin/bun test src/pages/SessionTablePage.test.ts`
- `timeout 120s ./node_modules/.bin/tsc --noEmit`

Closes #938