### PR TITLE
feat: add block-no-verify PreToolUse hook to prevent AI agents from skipping git hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,5 +9,18 @@
   "enableAllProjectMcpServers": false,
   "env": {
     "MAX_THINKING_TOKENS": "32000"
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## What problem(s) was I solving?

AI agents using Claude Code can silently bypass pre-commit, commit-msg, and pre-push hooks using the git hook-skip flag. This is the last enforcement gap in a codebase that otherwise has human oversight via HumanLayer — automated quality gates can be skipped without any approval.

## What user-facing changes did I ship?

Added `block-no-verify@1.1.2` as a PreToolUse Bash hook in `.claude/settings.json`. When Claude Code attempts to run a git command with the hook-bypass flag, the hook intercepts it and exits with code 2, blocking the command before execution.

The diff is a single settings file change — no custom scripts, no new dependencies installed in the project.

## How I implemented it

Added a `hooks` section to `.claude/settings.json`:

```json
"hooks": {
  "PreToolUse": [
    {
      "matcher": "Bash",
      "hooks": [
        { "type": "command", "command": "npx block-no-verify@1.1.2" }
      ]
    }
  ]
}
```

`block-no-verify` reads Claude Code's hook stdin payload, checks for the hook-bypass flag pattern across all git subcommands, and exits 2 to block if found.

## How to verify it

- [x] Open Claude Code in this repo, attempt `git commit` with the hook-bypass flag — it should be blocked
- [x] Normal `git commit` (without the flag) should pass through unaffected

## Description for the changelog

Add `block-no-verify@1.1.2` PreToolUse hook to prevent Claude Code from bypassing git hooks.

## A picture of a cute animal (not mandatory but encouraged)

🦊

---

Closes #968

_Disclosure: I am the author and maintainer of `block-no-verify`._
