### PR TITLE
Fix stale working directory when launching drafts

### DIFF
--- a/humanlayer-wui/src/components/internal/SessionDetail/components/DraftLauncherForm.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/components/DraftLauncherForm.tsx
@@ -452,7 +452,7 @@ export const DraftLauncherForm: React.FC<DraftLauncherFormProps> = ({ session, o
         return
       }
 
-      const workingDir = workingDirectory
+      const workingDir = workingDirectoryRef.current
       if (!workingDir) {
         toast.error('Please select a working directory', {
           description: 'You must choose a directory before launching the session',


### PR DESCRIPTION
## Summary
- Use the working directory ref when launching a draft session so a just-selected directory is not read from stale React state.
- This avoids validating/submitting the partial path that can remain in state immediately after clicking a directory suggestion.

## Notes
This is aimed at the path-selection race behind #949, where suggested directories with spaces can still launch with a stale/partial value and fail validation.

## Testing
- Not run: local clone does not have bun installed.
- Not run: npm run typecheck fails because node_modules/tsc is not installed in this checkout.