### PR TITLE
feat: add Focus button to substantial agent responses for distraction-free view

### DIFF
--- a/humanlayer-wui/src/components/QuickLauncherDirectoryInput.test.tsx
+++ b/humanlayer-wui/src/components/QuickLauncherDirectoryInput.test.tsx
@@ -1,0 +1,72 @@
+import { describe, test, expect } from 'bun:test'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { RecentPath } from '@/lib/daemon'
+
+import { QuickLauncherDirectoryInput } from './QuickLauncherDirectoryInput'
+
+const recentDirectories: RecentPath[] = [
+  { path: '/Users/test/project-alpha', lastUsed: new Date('2026-01-01'), usageCount: 3 },
+  { path: '/Users/test/project-beta', lastUsed: new Date('2026-01-02'), usageCount: 2 },
+  { path: '/Users/test/zebra-work', lastUsed: new Date('2026-01-03'), usageCount: 1 },
+]
+
+const renderInput = (value: string, directories: RecentPath[] = recentDirectories) =>
+  render(<QuickLauncherDirectoryInput value={value} onChange={() => {}} recentDirectories={directories} />)
+
+const focusInput = () => {
+  const input = screen.getByRole('textbox')
+  fireEvent.focus(input)
+  return input
+}
+
+const queryOption = (path: string) => document.querySelector(`[data-value="${path}"]`)
+
+describe('QuickLauncherDirectoryInput', () => {
+  test('focus with empty input shows recent directories dropdown', async () => {
+    renderInput('')
+
+    focusInput()
+
+    await waitFor(() => {
+      expect(screen.getByText('/Users/test/project-alpha')).toBeDefined()
+    })
+  })
+
+  test('focus with default ~/ input shows recent directories dropdown', async () => {
+    renderInput('~/')
+
+    focusInput()
+
+    await waitFor(() => {
+      expect(screen.getByText('/Users/test/project-alpha')).toBeDefined()
+    })
+  })
+
+  test('focus with explicit path does not auto-open dropdown', () => {
+    renderInput('/some/explicit/path')
+
+    focusInput()
+
+    expect(screen.queryByText('/Users/test/project-alpha')).toBeNull()
+  })
+
+  test('typing after focus uses fuzzy search against recent directories', async () => {
+    renderInput('')
+
+    const input = focusInput()
+    fireEvent.change(input, { target: { value: 'zebra' } })
+
+    await waitFor(() => {
+      expect(queryOption('/Users/test/zebra-work')).toBeDefined()
+    })
+    expect(queryOption('/Users/test/project-alpha')).toBeNull()
+  })
+
+  test('focus does not open dropdown when there are no recent directories', () => {
+    renderInput('~/', [])
+
+    focusInput()
+
+    expect(screen.queryByText('No recent directories')).toBeNull()
+  })
+})

--- a/humanlayer-wui/src/components/internal/ConversationStream/EventContent/AssistantMessageContent.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/EventContent/AssistantMessageContent.tsx
@@ -1,4 +1,10 @@
+import { useState } from 'react'
+import { Expand } from 'lucide-react'
 import { MarkdownRenderer } from '@/components/internal/SessionDetail/MarkdownRenderer'
+import { FocusViewModal } from '@/components/internal/SessionDetail/FocusViewModal'
+import { Button } from '@/components/ui/button'
+
+export const FOCUS_VIEW_CHARACTER_THRESHOLD = 1500
 
 export function AssistantMessageContent({
   eventContent,
@@ -7,6 +13,9 @@ export function AssistantMessageContent({
   eventContent: string
   isThinking: boolean
 }) {
+  const [isFocusViewOpen, setIsFocusViewOpen] = useState(false)
+  const showFocusButton = !isThinking && eventContent.length >= FOCUS_VIEW_CHARACTER_THRESHOLD
+
   if (isThinking && !eventContent) {
     return (
       <div>
@@ -16,9 +25,31 @@ export function AssistantMessageContent({
   }
 
   return (
-    <div>
+    <div className="relative min-w-0 flex-1">
+      {showFocusButton && (
+        <>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="absolute top-0 right-0 h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity duration-200"
+            onClick={e => {
+              e.stopPropagation()
+              setIsFocusViewOpen(true)
+            }}
+            aria-label="Open focus view"
+            title="Open focus view"
+          >
+            <Expand className="h-3 w-3" />
+          </Button>
+          <FocusViewModal
+            open={isFocusViewOpen}
+            onOpenChange={setIsFocusViewOpen}
+            content={eventContent}
+          />
+        </>
+      )}
       <div
-        className={`whitespace-pre-wrap text-foreground break-words hyphens-auto ${isThinking ? 'text-muted-foreground italic' : ''}`}
+        className={`whitespace-pre-wrap text-foreground break-words hyphens-auto ${showFocusButton ? 'pr-8' : ''} ${isThinking ? 'text-muted-foreground italic' : ''}`}
       >
         <MarkdownRenderer content={eventContent} />
       </div>

--- a/humanlayer-wui/src/components/internal/ConversationStream/EventContent/AssistantMessageContent.tsx
+++ b/humanlayer-wui/src/components/internal/ConversationStream/EventContent/AssistantMessageContent.tsx
@@ -25,7 +25,7 @@ export function AssistantMessageContent({
   }
 
   return (
-    <div className="relative min-w-0 flex-1">
+    <div className="group relative min-w-0 flex-1">
       {showFocusButton && (
         <>
           <Button

--- a/humanlayer-wui/src/components/internal/SessionDetail/FocusViewModal.test.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/FocusViewModal.test.tsx
@@ -1,0 +1,98 @@
+import { describe, test, expect } from 'bun:test'
+import type { ReactElement } from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { HotkeysProvider } from 'react-hotkeys-hook'
+import {
+  AssistantMessageContent,
+  FOCUS_VIEW_CHARACTER_THRESHOLD,
+} from '../ConversationStream/EventContent/AssistantMessageContent'
+import { UserMessageContent } from '../ConversationStream/EventContent/UserMessageContent'
+
+const longMessage = `${'This is a substantial assistant response. '.repeat(60)}
+
+## Details
+
+The focus view should render the same markdown content.
+
+\`\`\`ts
+const focused = true
+\`\`\`
+`
+
+function renderWithHotkeys(ui: ReactElement) {
+  return render(<HotkeysProvider initiallyActiveScopes={['*', '.']}>{ui}</HotkeysProvider>)
+}
+
+describe('Focus view modal', () => {
+  test('does not render a focus button for short assistant messages', () => {
+    renderWithHotkeys(<AssistantMessageContent eventContent="Short response." isThinking={false} />)
+
+    expect(screen.queryByRole('button', { name: /open focus view/i })).not.toBeInTheDocument()
+  })
+
+  test('renders a focus button for long assistant messages', () => {
+    renderWithHotkeys(
+      <AssistantMessageContent
+        eventContent={'x'.repeat(FOCUS_VIEW_CHARACTER_THRESHOLD)}
+        isThinking={false}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: /open focus view/i })).toBeInTheDocument()
+  })
+
+  test('opens the modal with rendered markdown when focus is clicked', async () => {
+    renderWithHotkeys(<AssistantMessageContent eventContent={longMessage} isThinking={false} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /open focus view/i }))
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /focus view/i })).toBeInTheDocument()
+    expect(screen.getAllByText(/the focus view should render the same markdown content/i)).toHaveLength(
+      2,
+    )
+    expect(screen.getAllByLabelText(/copy code/i).length).toBeGreaterThanOrEqual(2)
+  })
+
+  test('closes the modal when Escape is pressed', async () => {
+    renderWithHotkeys(<AssistantMessageContent eventContent={longMessage} isThinking={false} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /open focus view/i }))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' })
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  })
+
+  test('restores the conversation scroll position when closed', async () => {
+    const conversationContainer = document.createElement('div')
+    conversationContainer.setAttribute('data-conversation-container', '')
+    conversationContainer.scrollTop = 240
+    document.body.appendChild(conversationContainer)
+
+    try {
+      renderWithHotkeys(<AssistantMessageContent eventContent={longMessage} isThinking={false} />)
+
+      fireEvent.click(screen.getByRole('button', { name: /open focus view/i }))
+      expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+      conversationContainer.scrollTop = 0
+      fireEvent.click(screen.getByRole('button', { name: /close/i }))
+
+      await waitFor(() => {
+        expect(conversationContainer.scrollTop).toBe(240)
+      })
+    } finally {
+      conversationContainer.remove()
+    }
+  })
+
+  test('does not render a focus button for user messages', () => {
+    renderWithHotkeys(<UserMessageContent eventContent={longMessage} />)
+
+    expect(screen.queryByRole('button', { name: /open focus view/i })).not.toBeInTheDocument()
+  })
+})

--- a/humanlayer-wui/src/components/internal/SessionDetail/FocusViewModal.test.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/FocusViewModal.test.tsx
@@ -41,6 +41,17 @@ describe('Focus view modal', () => {
     expect(screen.getByRole('button', { name: /open focus view/i })).toBeInTheDocument()
   })
 
+  test('does not render a focus button one character below the threshold', () => {
+    renderWithHotkeys(
+      <AssistantMessageContent
+        eventContent={'x'.repeat(FOCUS_VIEW_CHARACTER_THRESHOLD - 1)}
+        isThinking={false}
+      />,
+    )
+
+    expect(screen.queryByRole('button', { name: /open focus view/i })).not.toBeInTheDocument()
+  })
+
   test('opens the modal with rendered markdown when focus is clicked', async () => {
     renderWithHotkeys(<AssistantMessageContent eventContent={longMessage} isThinking={false} />)
 

--- a/humanlayer-wui/src/components/internal/SessionDetail/FocusViewModal.tsx
+++ b/humanlayer-wui/src/components/internal/SessionDetail/FocusViewModal.tsx
@@ -1,0 +1,114 @@
+import React from 'react'
+import { useHotkeys } from 'react-hotkeys-hook'
+import { Expand } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { HotkeyScopeBoundary } from '@/components/HotkeyScopeBoundary'
+import { HOTKEY_SCOPES } from '@/hooks/hotkeys/scopes'
+import { MarkdownRenderer } from './MarkdownRenderer'
+
+interface FocusViewModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  content: string
+}
+
+export function FocusViewModal({ open, onOpenChange, content }: FocusViewModalProps) {
+  const previousFocusRef = React.useRef<HTMLElement | null>(null)
+  const previousScrollTopRef = React.useRef<number | null>(null)
+
+  React.useEffect(() => {
+    if (!open) return
+
+    previousFocusRef.current = document.activeElement as HTMLElement
+    const conversationContainer = document.querySelector('[data-conversation-container]')
+    previousScrollTopRef.current =
+      conversationContainer instanceof HTMLElement ? conversationContainer.scrollTop : null
+  }, [open])
+
+  const handleClose = React.useCallback(() => {
+    onOpenChange(false)
+
+    setTimeout(() => {
+      const conversationContainer = document.querySelector('[data-conversation-container]')
+      if (conversationContainer instanceof HTMLElement && previousScrollTopRef.current !== null) {
+        conversationContainer.scrollTop = previousScrollTopRef.current
+      }
+
+      previousFocusRef.current?.focus?.()
+    }, 0)
+  }, [onOpenChange])
+
+  useHotkeys(
+    'escape',
+    ev => {
+      ev.preventDefault()
+      ev.stopPropagation()
+      ev.stopImmediatePropagation()
+      handleClose()
+    },
+    {
+      enabled: open,
+      scopes: [HOTKEY_SCOPES.FOCUS_VIEW_MODAL],
+      preventDefault: true,
+      enableOnFormTags: true,
+    },
+  )
+
+  if (!open) return null
+
+  return (
+    <HotkeyScopeBoundary
+      scope={HOTKEY_SCOPES.FOCUS_VIEW_MODAL}
+      isActive={open}
+      rootScopeDisabled={true}
+      componentName="FocusViewModal"
+    >
+      <Dialog
+        open={open}
+        onOpenChange={isOpen => {
+          if (!isOpen) {
+            handleClose()
+          } else {
+            onOpenChange(true)
+          }
+        }}
+      >
+        <DialogContent
+          className="w-screen max-w-none h-screen p-0 sm:max-w-none rounded-none border-0 flex flex-col overflow-hidden"
+          onEscapeKeyDown={e => {
+            e.preventDefault()
+          }}
+        >
+          <DialogHeader className="px-4 py-3 border-b bg-background flex-none">
+            <DialogTitle className="text-sm font-mono flex items-center gap-2">
+              <Expand className="h-3.5 w-3.5 text-accent" />
+              Focus View
+            </DialogTitle>
+            <DialogDescription className="sr-only">
+              Distraction-free view of the assistant response.
+            </DialogDescription>
+          </DialogHeader>
+
+          <ScrollArea className="flex-1 min-h-0">
+            <div className="mx-auto max-w-4xl px-6 py-6">
+              <MarkdownRenderer content={content} />
+            </div>
+          </ScrollArea>
+
+          <div className="px-4 py-2 border-t bg-muted/30 flex justify-end items-center flex-none">
+            <span className="text-xs text-muted-foreground">
+              <kbd>ESC</kbd> to close
+            </span>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </HotkeyScopeBoundary>
+  )
+}

--- a/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionNavigation.test.ts
+++ b/humanlayer-wui/src/components/internal/SessionDetail/hooks/useSessionNavigation.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, mock } from 'bun:test'
+import { act, renderHook } from '@testing-library/react'
+import { HOTKEY_SCOPES } from '@/hooks/hotkeys/scopes'
+import type { ConversationEvent } from '@/lib/daemon/types'
+
+const hotkeyHandlers = new Map<string, () => void>()
+
+mock.module('@humanlayer/hld-sdk', () => ({
+  SessionStatus: {},
+  ApprovalStatus: {},
+}))
+
+mock.module('react-hotkeys-hook', () => ({
+  useHotkeys: (keys: string, callback: () => void) => {
+    hotkeyHandlers.set(keys, callback)
+  },
+}))
+
+const { useSessionNavigation } = await import('./useSessionNavigation')
+
+const events = [1, 2, 3].map(
+  id =>
+    ({
+      id,
+      eventType: 'message',
+    }) as ConversationEvent,
+)
+
+const rect = (top: number, bottom: number) =>
+  ({
+    top,
+    bottom,
+    left: 0,
+    right: 100,
+    width: 100,
+    height: bottom - top,
+    x: 0,
+    y: top,
+    toJSON: () => {},
+  }) as DOMRect
+
+const renderNavigation = () =>
+  renderHook(() =>
+    useSessionNavigation({
+      events,
+      hasSubTasks: false,
+      expandedTasks: new Set(),
+      toggleTaskGroup: () => {},
+      scope: HOTKEY_SCOPES.SESSION_DETAIL,
+    }),
+  )
+
+const pressHotkey = (key: string) => {
+  const handler = hotkeyHandlers.get(key)
+  if (!handler) throw new Error(`No handler registered for ${key}`)
+
+  act(() => {
+    handler()
+  })
+}
+
+const setupEventBounds = ({
+  eventId,
+  top,
+  height,
+  containerHeight = 100,
+}: {
+  eventId: number
+  top: number
+  height: number
+  containerHeight?: number
+}) => {
+  const scrollCalls: number[] = []
+  const container = document.createElement('div')
+  container.setAttribute('data-conversation-container', '')
+  container.getBoundingClientRect = () => rect(0, containerHeight)
+  Object.defineProperty(container, 'clientHeight', { configurable: true, value: containerHeight })
+  container.scrollBy = ((options: ScrollToOptions) => {
+    const delta = options.top ?? 0
+    scrollCalls.push(delta)
+    container.scrollTop += delta
+  }) as typeof container.scrollBy
+
+  events.forEach(event => {
+    const element = document.createElement('div')
+    element.setAttribute('data-event-id', String(event.id))
+    element.getBoundingClientRect = () => {
+      if (event.id !== eventId) return rect(0, 20)
+
+      const currentTop = top - container.scrollTop
+      return rect(currentTop, currentTop + height)
+    }
+    container.appendChild(element)
+  })
+
+  document.body.appendChild(container)
+
+  return scrollCalls
+}
+
+beforeEach(() => {
+  hotkeyHandlers.clear()
+  document.body.innerHTML = ''
+  Element.prototype.scrollIntoView = () => {}
+})
+
+describe('useSessionNavigation', () => {
+  it('j on a short visible message jumps to the next event', () => {
+    const { result } = renderNavigation()
+    setupEventBounds({ eventId: 1, top: 0, height: 80 })
+
+    act(() => result.current.setFocusedEventId(1))
+    pressHotkey('j')
+
+    expect(result.current.focusedEventId).toBe(2)
+  })
+
+  it('j on a long message scrolls down without changing focus', () => {
+    const { result } = renderNavigation()
+    const scrollCalls = setupEventBounds({ eventId: 1, top: 0, height: 260 })
+
+    act(() => result.current.setFocusedEventId(1))
+    pressHotkey('j')
+
+    expect(result.current.focusedEventId).toBe(1)
+    expect(scrollCalls).toEqual([80])
+  })
+
+  it('repeated j reveals a long message before jumping to the next event', () => {
+    const { result } = renderNavigation()
+    const scrollCalls = setupEventBounds({ eventId: 1, top: 0, height: 260 })
+
+    act(() => result.current.setFocusedEventId(1))
+    pressHotkey('j')
+    pressHotkey('j')
+    pressHotkey('j')
+
+    expect(scrollCalls).toEqual([80, 80])
+    expect(result.current.focusedEventId).toBe(2)
+  })
+
+  it('k scrolls up within a long message before jumping to the previous event', () => {
+    const { result } = renderNavigation()
+    const scrollCalls = setupEventBounds({ eventId: 2, top: 0, height: 260 })
+
+    act(() => {
+      result.current.setFocusedEventId(2)
+    })
+
+    const container = document.querySelector('[data-conversation-container]') as HTMLElement
+    container.scrollTop = 160
+
+    pressHotkey('k')
+    pressHotkey('k')
+    pressHotkey('k')
+
+    expect(scrollCalls).toEqual([-80, -80])
+    expect(result.current.focusedEventId).toBe(1)
+  })
+
+  it('ArrowDown and ArrowUp jump events without scroll-aware pre-checks', () => {
+    const { result } = renderNavigation()
+    const scrollCalls = setupEventBounds({ eventId: 2, top: -160, height: 260 })
+
+    act(() => result.current.setFocusedEventId(2))
+
+    pressHotkey('ArrowDown')
+    expect(result.current.focusedEventId).toBe(3)
+
+    pressHotkey('ArrowUp')
+    expect(result.current.focusedEventId).toBe(2)
+    expect(scrollCalls).toEqual([])
+  })
+})

--- a/humanlayer-wui/src/hooks/hotkeys/scopes.ts
+++ b/humanlayer-wui/src/hooks/hotkeys/scopes.ts
@@ -10,6 +10,7 @@ export const HOTKEY_SCOPES = {
   SESSION_DETAIL_FORK_IN_PROGRESS: 'sessions.details.forkInProgress',
   FORK_MODAL: 'sessions.details.forkModal',
   TOOL_RESULT_MODAL: 'sessions.details.toolResultModal',
+  FOCUS_VIEW_MODAL: 'sessions.details.focusViewModal',
   BYPASS_PERMISSIONS_MODAL: 'sessions.details.bypassPermissionsModal',
   SELECT_MODEL_MODAL: 'sessions.details.selectModelModal',
   DISCARD_DRAFT_DIALOG: 'sessions.details.discardDraftDialog',


### PR DESCRIPTION
## Summary

feat: add Focus button to substantial agent responses for distraction-free view

Closes #979

---
AI was used for assistance.