### PR TITLE
fix(wui): run a trailing refresh so discard/undo cannot desync session state

### DIFF
--- a/humanlayer-wui/src/AppStore.sync.test.ts
+++ b/humanlayer-wui/src/AppStore.sync.test.ts
@@ -34,6 +34,7 @@ describe('AppStore - State Synchronization', () => {
       selectedSessions: new Set(),
       pendingUpdates: new Map(),
       isRefreshing: false,
+      refreshQueued: false,
       activeSessionDetail: null,
     })
     // Set view mode separately using the method
@@ -222,19 +223,26 @@ describe('AppStore - State Synchronization', () => {
       expect(state.pendingUpdates.has('test-1')).toBe(false)
     })
 
-    test('should prevent concurrent refreshes', async () => {
+    test('should coalesce a concurrent refresh into a single trailing refresh', async () => {
       let resolvePromise: (value: { sessions: any[] }) => void
       const promise = new Promise<{ sessions: any[] }>(resolve => {
         resolvePromise = resolve
       })
 
-      mockGetSessionLeaves.mockImplementation(() => promise)
+      mockGetSessionLeaves
+        .mockImplementationOnce(() => promise) // first refresh, kept in flight
+        .mockImplementationOnce(() => Promise.resolve({ sessions: [] })) // trailing refresh
 
       // Start first refresh
       const refresh1Promise = useStore.getState().refreshSessions()
 
-      // Try to start second refresh immediately (should be skipped)
+      // Request a second refresh while the first is in flight. It must NOT run
+      // concurrently, but it must NOT be silently dropped either — it is queued.
       const refresh2Promise = useStore.getState().refreshSessions()
+
+      // Only one in-flight call so far; the second is queued.
+      expect(mockGetSessionLeaves).toHaveBeenCalledTimes(1)
+      expect(useStore.getState().refreshQueued).toBe(true)
 
       // Resolve the promise to complete the first refresh
       resolvePromise!({ sessions: [] })
@@ -243,11 +251,44 @@ describe('AppStore - State Synchronization', () => {
       await refresh1Promise
       await refresh2Promise
 
-      // Should only call API once
-      expect(mockGetSessionLeaves).toHaveBeenCalledTimes(1)
+      // Exactly one trailing refresh runs after the first settles (2 calls total).
+      expect(mockGetSessionLeaves).toHaveBeenCalledTimes(2)
 
-      // Ensure isRefreshing is false after completion
+      // Ensure flags are clear after completion
       expect(useStore.getState().isRefreshing).toBe(false)
+      expect(useStore.getState().refreshQueued).toBe(false)
+    })
+
+    test('should run a trailing refresh so a mid-flight request is not lost (discard/undo desync)', async () => {
+      // Models the SessionTable discard→undo race: a refresh (the discard flow)
+      // is in flight and returns STALE data; meanwhile the undo flow restores the
+      // draft server-side and requests another refresh. Before the fix that second
+      // refresh hit the `isRefreshing` guard and was dropped forever, leaving the
+      // UI desynced. With the trailing-refresh fix, the latest server state wins.
+      let resolveFirst: (value: { sessions: any[] }) => void
+      const first = new Promise<{ sessions: any[] }>(resolve => {
+        resolveFirst = resolve
+      })
+      const staleSessions = [createMockSession({ id: 'stale-discarded' })]
+      const restoredSessions = [createMockSession({ id: 'restored-draft' })]
+
+      mockGetSessionLeaves
+        .mockImplementationOnce(() => first) // discard-flow refresh (stale)
+        .mockImplementationOnce(() => Promise.resolve({ sessions: restoredSessions as any }))
+
+      const discardRefresh = useStore.getState().refreshSessions()
+      const undoRefresh = useStore.getState().refreshSessions() // queued, not dropped
+
+      expect(useStore.getState().refreshQueued).toBe(true)
+
+      resolveFirst!({ sessions: staleSessions as any })
+      await discardRefresh
+      await undoRefresh
+
+      // The trailing refresh ran and the restored (latest) state is reflected.
+      expect(mockGetSessionLeaves).toHaveBeenCalledTimes(2)
+      expect(useStore.getState().sessions.map(s => s.id)).toEqual(['restored-draft'])
+      expect(useStore.getState().refreshQueued).toBe(false)
     })
 
     test('should set isRefreshing flag correctly', async () => {

--- a/humanlayer-wui/src/AppStore.ts
+++ b/humanlayer-wui/src/AppStore.ts
@@ -31,6 +31,13 @@ interface StoreState {
   selectedSessions: Set<string> // For bulk selection
   pendingUpdates: Map<string, PendingUpdate> // Track in-flight updates
   isRefreshing: boolean // Prevent concurrent refresh/updates
+  /**
+   * Set when a refresh is requested while one is already in flight. Causes
+   * exactly one trailing {@link AppState.refreshSessions} to run after the
+   * current refresh settles, so a mid-flight request is coalesced rather than
+   * silently dropped. Reset to `false` once that trailing refresh starts.
+   */
+  refreshQueued: boolean
   activeSessionDetail: {
     session: Session
     conversation: any[] // ConversationEvent[] from useConversation
@@ -176,6 +183,7 @@ export const useStore = create<StoreState>((set, get) => {
     selectedSessions: new Set<string>(),
     pendingUpdates: new Map<string, PendingUpdate>(),
     isRefreshing: false,
+    refreshQueued: false,
     activeSessionDetail: null,
     claudeConfig: null,
     responseEditor: null,
@@ -316,15 +324,34 @@ export const useStore = create<StoreState>((set, get) => {
               }
             : state.activeSessionDetail,
       })),
+    /**
+     * Refresh the session list from the daemon, reconciling server state with
+     * any in-flight optimistic updates.
+     *
+     * Refreshes are serialized — at most one runs at a time. Critically, a
+     * refresh requested while another is in flight is **not** dropped: it sets
+     * {@link AppState.refreshQueued}, and exactly one trailing refresh runs once
+     * the current one settles (in `finally`). This prevents a discard→refresh
+     * from racing an undo→refresh and stranding the UI on stale `discarded`
+     * session state — the undo's refresh would otherwise hit the `isRefreshing`
+     * guard and be lost until a full reload. A burst of mid-flight requests
+     * coalesces to a single trailing refresh (the flag is a boolean, not a
+     * counter), preserving the original anti-thundering-herd behavior.
+     */
     refreshSessions: async () => {
       // Prevent concurrent refreshes
       const state = get()
       if (state.isRefreshing) {
-        logger.debug('Refresh already in progress, skipping')
+        // Don't silently drop the request: a refresh issued while one is in
+        // flight (e.g. an undo→refresh racing a discard→refresh) would otherwise
+        // be lost forever, leaving the UI desynced from the server. Remember it
+        // and run exactly one more refresh once the current one settles.
+        logger.debug('Refresh already in progress, queueing a trailing refresh')
+        set({ refreshQueued: true })
         return
       }
 
-      set({ isRefreshing: true })
+      set({ isRefreshing: true, refreshQueued: false })
 
       try {
         const { pendingUpdates, getViewMode } = get()
@@ -382,6 +409,13 @@ export const useStore = create<StoreState>((set, get) => {
       } catch (error) {
         logger.error('Failed to refresh sessions:', error)
         set({ isRefreshing: false })
+      } finally {
+        // If a refresh was requested while this one was running, honor it now so
+        // the latest server state is always reflected (fixes the discard/undo race).
+        if (get().refreshQueued) {
+          set({ refreshQueued: false })
+          await get().refreshSessions()
+        }
       }
     },
     refreshActiveSessionConversation: async (sessionId: string) => {


### PR DESCRIPTION
## What problem(s) was I solving?

A state-desync race in the WUI session store. `AppStore.refreshSessions()` returns early when `isRefreshing` is set, **silently dropping** the request. When a draft is discarded and then undone, the undo's restore→refresh races the discard's refresh, hits the guard, and is lost — leaving the UI on a stale `discarded` row until a full reload.

## What user-facing changes did I ship?

Discard-then-undo no longer leaves the session list stuck on a stale `discarded` row; the latest server state always wins. No visible API or layout change.

## How I implemented it

Replaced the silent early-return with a single **trailing refresh**: a mid-flight request sets a `refreshQueued` flag instead of being dropped, and a `finally` block runs exactly one refresh after the in-flight one settles. Bursts coalesce to a single trailing refresh (the flag is a boolean, not a counter), so the anti-thundering-herd intent is preserved.

## How to verify it

`cd humanlayer-wui && bun install && bun run check && bun test` — the store tests in `src/AppStore.sync.test.ts` include a new discard/undo desync test that fails before this change (the dropped refresh) and passes after.

- [x] I have ensured `make check test` passes — ran the WUI-scoped equivalent (`bun run check` + `bun test` in `humanlayer-wui/`); the root target additionally builds the Go daemon + Rust/Tauri, out of scope for this WUI-only change.

## Description for the changelog

Fix a discard/undo race in the WUI session store that could leave the session list desynced until a reload.

## A picture of a cute animal (not mandatory but encouraged)

🦦

<sub>Full forensic verification evidence (AIV-L3) is in the comment below.</sub>
