### PR TITLE
fix: preserve piped input for thoughts init prompts

### DIFF
--- a/hlyr/src/commands/thoughts/init.test.ts
+++ b/hlyr/src/commands/thoughts/init.test.ts
@@ -1,0 +1,26 @@
+import { Readable, Writable } from 'stream'
+import { describe, expect, it } from 'vitest'
+import { createPromptSession } from './init.js'
+
+class NullWritable extends Writable {
+  _write(_chunk: Buffer, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+    callback()
+  }
+}
+
+describe('createPromptSession', () => {
+  it('consumes multiple answers from one piped input stream', async () => {
+    const input = Readable.from(['\nrepos-dir\nglobal-dir\nalice\n'])
+    const output = new NullWritable()
+    const session = createPromptSession({ input, output })
+
+    try {
+      await expect(session.prompt('Thoughts repository location: ')).resolves.toBe('')
+      await expect(session.prompt('Directory name for repos: ')).resolves.toBe('repos-dir')
+      await expect(session.prompt('Directory name for global thoughts: ')).resolves.toBe('global-dir')
+      await expect(session.prompt('Your username: ')).resolves.toBe('alice')
+    } finally {
+      session.close()
+    }
+  })
+})

--- a/hlyr/src/commands/thoughts/init.ts
+++ b/hlyr/src/commands/thoughts/init.ts
@@ -32,18 +32,57 @@ function sanitizeDirectoryName(name: string): string {
   return name.replace(/[^a-zA-Z0-9_-]/g, '_')
 }
 
-function prompt(question: string): Promise<string> {
+interface PromptSessionOptions {
+  input?: NodeJS.ReadableStream
+  output?: NodeJS.WritableStream
+}
+
+export function createPromptSession(options: PromptSessionOptions = {}) {
+  const output = options.output ?? process.stdout
+  const queuedAnswers: string[] = []
+  const pendingPrompts: Array<(answer: string) => void> = []
+  let inputClosed = false
+
   const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
+    input: options.input ?? process.stdin,
+    output,
   })
 
-  return new Promise(resolve => {
-    rl.question(question, answer => {
-      rl.close()
+  const resolvePrompt = (answer: string): void => {
+    const resolve = pendingPrompts.shift()
+    if (resolve) {
       resolve(answer.trim())
-    })
+    } else {
+      queuedAnswers.push(answer.trim())
+    }
+  }
+
+  rl.on('line', resolvePrompt)
+  rl.on('close', () => {
+    inputClosed = true
+    while (pendingPrompts.length > 0) {
+      pendingPrompts.shift()?.('')
+    }
   })
+
+  return {
+    prompt(question: string): Promise<string> {
+      output.write(question)
+      const queuedAnswer = queuedAnswers.shift()
+      if (queuedAnswer !== undefined) {
+        return Promise.resolve(queuedAnswer)
+      }
+      if (inputClosed) {
+        return Promise.resolve('')
+      }
+      return new Promise(resolve => {
+        pendingPrompts.push(resolve)
+      })
+    },
+    close(): void {
+      rl.close()
+    },
+  }
 }
 
 function checkExistingSetup(config?: ThoughtsConfig | null): {
@@ -105,7 +144,11 @@ function checkExistingSetup(config?: ThoughtsConfig | null): {
   return { exists: true, isValid: true }
 }
 
-async function selectFromList(message: string, options: string[]): Promise<number> {
+async function selectFromList(
+  message: string,
+  options: string[],
+  prompt: (question: string) => Promise<string>,
+): Promise<number> {
   if (message) {
     console.log(chalk.cyan(message))
   }
@@ -317,6 +360,9 @@ fi
 }
 
 export async function thoughtsInitCommand(options: InitOptions): Promise<void> {
+  const promptSession = createPromptSession()
+  const { prompt } = promptSession
+
   try {
     const currentRepo = getCurrentRepoPath()
 
@@ -545,7 +591,7 @@ export async function thoughtsInitCommand(options: InitOptions): Promise<void> {
             ...existingRepos.map(repo => `Use existing: ${repo}`),
             '→ Create new directory',
           ]
-          const selection = await selectFromList('', options)
+          const selection = await selectFromList('', options, prompt)
 
           if (selection === options.length - 1) {
             // Create new
@@ -724,5 +770,7 @@ export async function thoughtsInitCommand(options: InitOptions): Promise<void> {
   } catch (error) {
     console.error(chalk.red(`Error during thoughts init: ${error}`))
     process.exit(1)
+  } finally {
+    promptSession.close()
   }
 }


### PR DESCRIPTION
Fixes #994

## Summary
- keep a single prompt session for `thoughts init` instead of recreating readline for each question
- buffer prompt answers from piped stdin so multiple newline-separated answers are not dropped after the first prompt
- add regression coverage for sequential prompts consuming one piped input stream

## Tests
- `npm test -- init.test.ts`
- `npm test`
- `npm run build`
- `npx eslint src/commands/thoughts/init.ts src/commands/thoughts/init.test.ts --ext .ts`
- `npx prettier --check src/commands/thoughts/init.ts src/commands/thoughts/init.test.ts`
- `git diff --check`

Note: the local test/build commands print a warning that the repo-level `../tsconfig.json` extends `@codelayer/typescript-config/base.json`, but all listed hlyr checks pass.